### PR TITLE
Search: Improve how search works with detailsSearch in details

### DIFF
--- a/src/controls/components/Selector.tsx
+++ b/src/controls/components/Selector.tsx
@@ -5,7 +5,6 @@ import Hoverable from '../../generic/Hoverable';
 type Props = {
   appearance?: 'rounded' | 'tabs';
   children: React.ReactNode;
-  className?: string;
   selectorLabel?: string;
   selectorDescription?: React.ReactNode;
   size?: 'regular' | 'compact';
@@ -14,13 +13,12 @@ type Props = {
 const Selector: React.FC<Props> = ({
   appearance = 'rounded',
   children,
-  className = '',
   selectorLabel,
   selectorDescription,
   size = 'regular',
 }) => {
   return (
-    <div className={className + ' selector ' + size + ' ' + appearance}>
+    <div className={'selector ' + size + ' ' + appearance}>
       {selectorLabel != null && (
         <label>
           <Hoverable hoverContent={selectorDescription} style={{ textDecoration: 'none' }}>

--- a/src/controls/components/Selector.tsx
+++ b/src/controls/components/Selector.tsx
@@ -5,6 +5,7 @@ import Hoverable from '../../generic/Hoverable';
 type Props = {
   appearance?: 'rounded' | 'tabs';
   children: React.ReactNode;
+  className?: string;
   selectorLabel?: string;
   selectorDescription?: React.ReactNode;
   size?: 'regular' | 'compact';
@@ -13,12 +14,13 @@ type Props = {
 const Selector: React.FC<Props> = ({
   appearance = 'rounded',
   children,
+  className = '',
   selectorLabel,
   selectorDescription,
   size = 'regular',
 }) => {
   return (
-    <div className={'selector ' + size + ' ' + appearance}>
+    <div className={className + ' selector ' + size + ' ' + appearance}>
       {selectorLabel != null && (
         <label>
           <Hoverable hoverContent={selectorDescription} style={{ textDecoration: 'none' }}>

--- a/src/controls/components/TextInput.tsx
+++ b/src/controls/components/TextInput.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 
+import HoverableButton from '../../generic/HoverableButton';
+import { View } from '../../types/PageParamTypes';
+import { usePageParams } from '../PageParamsContext';
+
 export type Suggestion = {
   id: string;
+  searchString: string;
   label: React.ReactNode;
 };
 
@@ -9,6 +14,8 @@ type Props = {
   inputStyle?: React.CSSProperties;
   getSuggestions?: (query: string) => Promise<Suggestion[]>;
   onChange: (value: string) => void;
+  showFilterButton?: boolean;
+  showGoToDetailsButton?: boolean;
   placeholder?: string;
   value: string;
 };
@@ -17,6 +24,8 @@ const TextInput: React.FC<Props> = ({
   inputStyle,
   getSuggestions = () => [],
   onChange,
+  showFilterButton = true,
+  showGoToDetailsButton = false,
   placeholder,
   value,
 }) => {
@@ -89,15 +98,14 @@ const TextInput: React.FC<Props> = ({
         <div className="SelectorPopupAnchor">
           <div className="SelectorPopup">
             {suggestions.map((s) => (
-              <button
+              <SuggestionRow
                 key={s.id}
-                onClick={() => {
-                  setImmediateValue(s.id);
-                  setShowSuggestions(false);
-                }}
-              >
-                {s.label}
-              </button>
+                setImmediateValue={setImmediateValue}
+                setShowSuggestions={setShowSuggestions}
+                showFilterButton={showFilterButton}
+                showGoToDetailsButton={showGoToDetailsButton}
+                suggestion={s}
+              />
             ))}
           </div>
         </div>
@@ -113,6 +121,64 @@ const TextInput: React.FC<Props> = ({
         &#x2716;
       </button>
     </>
+  );
+};
+
+type SuggestionRowProps = {
+  setImmediateValue: (value: string) => void;
+  setShowSuggestions: (show: boolean) => void;
+  showFilterButton?: boolean;
+  showGoToDetailsButton?: boolean;
+  suggestion: Suggestion;
+};
+
+const SuggestionRow: React.FC<SuggestionRowProps> = ({
+  setImmediateValue,
+  showFilterButton,
+  showGoToDetailsButton,
+  suggestion,
+}) => {
+  const { id, searchString, label } = suggestion;
+  const { updatePageParams } = usePageParams();
+
+  const setFilter = () => {
+    setImmediateValue(searchString);
+  };
+  const goToDetails = () => {
+    updatePageParams({ objectID: id, view: View.Details, searchString });
+  };
+
+  if (!showFilterButton) {
+    return (
+      <HoverableButton
+        hoverContent={<>Go to the details page for {searchString}</>}
+        onClick={goToDetails}
+      >
+        {label}
+      </HoverableButton>
+    );
+  }
+  if (!showGoToDetailsButton) {
+    return (
+      <button key={id} onClick={setFilter}>
+        {label}
+      </button>
+    );
+  }
+
+  return (
+    <div key={id} className="SuggestionRowWithMultipleInteractions">
+      <div>{label}</div>
+      <HoverableButton hoverContent={<>Filter by &quot;{searchString}&quot;</>} onClick={setFilter}>
+        &#x1F50E;
+      </HoverableButton>
+      <HoverableButton
+        hoverContent={<>Go to the details page for {searchString}</>}
+        onClick={goToDetails}
+      >
+        &#x2197;
+      </HoverableButton>
+    </div>
   );
 };
 

--- a/src/controls/components/TextInput.tsx
+++ b/src/controls/components/TextInput.tsx
@@ -14,8 +14,8 @@ type Props = {
   inputStyle?: React.CSSProperties;
   getSuggestions?: (query: string) => Promise<Suggestion[]>;
   onChange: (value: string) => void;
-  showFilterButton?: boolean;
   showGoToDetailsButton?: boolean;
+  showTextInputButton?: boolean;
   placeholder?: string;
   value: string;
 };
@@ -24,8 +24,8 @@ const TextInput: React.FC<Props> = ({
   inputStyle,
   getSuggestions = () => [],
   onChange,
-  showFilterButton = true,
   showGoToDetailsButton = false,
+  showTextInputButton = true,
   placeholder,
   value,
 }) => {
@@ -102,7 +102,7 @@ const TextInput: React.FC<Props> = ({
                 key={s.searchString}
                 setImmediateValue={setImmediateValue}
                 setShowSuggestions={setShowSuggestions}
-                showFilterButton={showFilterButton}
+                showTextInputButton={showTextInputButton}
                 showGoToDetailsButton={showGoToDetailsButton}
                 suggestion={s}
               />
@@ -127,15 +127,15 @@ const TextInput: React.FC<Props> = ({
 type SuggestionRowProps = {
   setImmediateValue: (value: string) => void;
   setShowSuggestions: (show: boolean) => void;
-  showFilterButton?: boolean;
   showGoToDetailsButton?: boolean;
+  showTextInputButton?: boolean;
   suggestion: Suggestion;
 };
 
 const SuggestionRow: React.FC<SuggestionRowProps> = ({
   setImmediateValue,
-  showFilterButton,
   showGoToDetailsButton,
+  showTextInputButton,
   suggestion,
 }) => {
   const { objectID, searchString, label } = suggestion;
@@ -148,7 +148,14 @@ const SuggestionRow: React.FC<SuggestionRowProps> = ({
     updatePageParams({ objectID, view: View.Details, searchString });
   };
 
-  if (!showFilterButton) {
+  // Some simplier states if we have 1 button
+  if (!showGoToDetailsButton) {
+    if (!showTextInputButton) {
+      return label;
+    }
+    return <button onClick={setFilter}>{label}</button>;
+  }
+  if (!showTextInputButton) {
     return (
       <HoverableButton
         hoverContent={<>Go to the details page for {searchString}</>}
@@ -158,10 +165,8 @@ const SuggestionRow: React.FC<SuggestionRowProps> = ({
       </HoverableButton>
     );
   }
-  if (!showGoToDetailsButton) {
-    return <button onClick={setFilter}>{label}</button>;
-  }
 
+  // The more complex case, where we have 2 buttons
   return (
     <div className="SuggestionRowWithMultipleInteractions">
       <div>{label}</div>

--- a/src/controls/components/TextInput.tsx
+++ b/src/controls/components/TextInput.tsx
@@ -5,7 +5,7 @@ import { View } from '../../types/PageParamTypes';
 import { usePageParams } from '../PageParamsContext';
 
 export type Suggestion = {
-  id: string;
+  objectID?: string;
   searchString: string;
   label: React.ReactNode;
 };
@@ -99,7 +99,7 @@ const TextInput: React.FC<Props> = ({
           <div className="SelectorPopup">
             {suggestions.map((s) => (
               <SuggestionRow
-                key={s.id}
+                key={s.searchString}
                 setImmediateValue={setImmediateValue}
                 setShowSuggestions={setShowSuggestions}
                 showFilterButton={showFilterButton}
@@ -138,14 +138,14 @@ const SuggestionRow: React.FC<SuggestionRowProps> = ({
   showGoToDetailsButton,
   suggestion,
 }) => {
-  const { id, searchString, label } = suggestion;
+  const { objectID, searchString, label } = suggestion;
   const { updatePageParams } = usePageParams();
 
   const setFilter = () => {
     setImmediateValue(searchString);
   };
   const goToDetails = () => {
-    updatePageParams({ objectID: id, view: View.Details, searchString });
+    updatePageParams({ objectID, view: View.Details, searchString });
   };
 
   if (!showFilterButton) {
@@ -159,15 +159,11 @@ const SuggestionRow: React.FC<SuggestionRowProps> = ({
     );
   }
   if (!showGoToDetailsButton) {
-    return (
-      <button key={id} onClick={setFilter}>
-        {label}
-      </button>
-    );
+    return <button onClick={setFilter}>{label}</button>;
   }
 
   return (
-    <div key={id} className="SuggestionRowWithMultipleInteractions">
+    <div className="SuggestionRowWithMultipleInteractions">
       <div>{label}</div>
       <HoverableButton hoverContent={<>Filter by &quot;{searchString}&quot;</>} onClick={setFilter}>
         &#x1F50E;

--- a/src/controls/components/TextInput.tsx
+++ b/src/controls/components/TextInput.tsx
@@ -97,9 +97,9 @@ const TextInput: React.FC<Props> = ({
       {showSuggestions && suggestions.length > 0 && (
         <div className="SelectorPopupAnchor">
           <div className="SelectorPopup">
-            {suggestions.map((s) => (
+            {suggestions.map((s, i) => (
               <SuggestionRow
-                key={s.searchString}
+                key={i}
                 setImmediateValue={setImmediateValue}
                 setShowSuggestions={setShowSuggestions}
                 showTextInputButton={showTextInputButton}

--- a/src/controls/controls.css
+++ b/src/controls/controls.css
@@ -213,18 +213,18 @@
     border-radius: 0px;
 }
 
-.selector .SelectorPopup .SuggestionRowWithMultipleInteractions:first-child :first-child {
+.selector .SelectorPopup .SuggestionRowWithMultipleInteractions:first-child > :first-child {
     border-top-left-radius: 1em;
 }
 
-.selector .SelectorPopup .SuggestionRowWithMultipleInteractions:last-child :first-child {
+.selector .SelectorPopup .SuggestionRowWithMultipleInteractions:last-child > :first-child {
     border-bottom-left-radius: 1em;
 }
 
-.selector .SelectorPopup .SuggestionRowWithMultipleInteractions:first-child :last-child {
+.selector .SelectorPopup .SuggestionRowWithMultipleInteractions:first-child > :last-child {
     border-top-right-radius: 1em;
 }
 
-.selector .SelectorPopup .SuggestionRowWithMultipleInteractions:last-child :last-child {
+.selector .SelectorPopup .SuggestionRowWithMultipleInteractions:last-child > :last-child {
     border-bottom-right-radius: 1em;
 }

--- a/src/controls/controls.css
+++ b/src/controls/controls.css
@@ -193,3 +193,38 @@
 .tabs .SelectorPopup button.notselected {
     color: var(--color-button-primary)
 }
+
+.SuggestionRowWithMultipleInteractions {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.selector .SelectorPopup .SuggestionRowWithMultipleInteractions div:first-child {
+    white-space: nowrap;
+    max-width: 12em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding-left: 1em;
+}
+
+.selector .SelectorPopup .SuggestionRowWithMultipleInteractions button {
+    width: fit-content;
+    border-radius: 0px;
+}
+
+.selector .SelectorPopup .SuggestionRowWithMultipleInteractions:first-child :first-child {
+    border-top-left-radius: 1em;
+}
+
+.selector .SelectorPopup .SuggestionRowWithMultipleInteractions:last-child :first-child {
+    border-bottom-left-radius: 1em;
+}
+
+.selector .SelectorPopup .SuggestionRowWithMultipleInteractions:first-child :last-child {
+    border-top-right-radius: 1em;
+}
+
+.selector .SelectorPopup .SuggestionRowWithMultipleInteractions:last-child :last-child {
+    border-bottom-right-radius: 1em;
+}

--- a/src/controls/selectors/LimitInput.tsx
+++ b/src/controls/selectors/LimitInput.tsx
@@ -20,10 +20,10 @@ const LimitInput: React.FC = () => {
       <TextInput
         inputStyle={{ width: '3em' }}
         getSuggestions={async () => [
-          { id: '8', label: '8' },
-          { id: '20', label: '20' },
-          { id: '100', label: '100' },
-          { id: '200', label: '200' },
+          { searchString: '8', label: '8' },
+          { searchString: '20', label: '20' },
+          { searchString: '100', label: '100' },
+          { searchString: '200', label: '200' },
         ]}
         onChange={(limit: string) => updatePageParams({ limit: parseInt(limit) })}
         placeholder="∞"

--- a/src/controls/selectors/SearchBar.tsx
+++ b/src/controls/selectors/SearchBar.tsx
@@ -13,14 +13,14 @@ const SearchBar: React.FC = () => {
   const getSearchSuggestions = useSearchSuggestions();
 
   return (
-    <Selector className="SearchBar" selectorLabel="🔎">
+    <Selector selectorLabel="🔎">
       <TextInput
         inputStyle={{ minWidth: '20em' }}
         getSuggestions={getSearchSuggestions}
         onChange={(searchString: string) => updatePageParams({ searchString })}
         placeholder="search"
-        showFilterButton={view !== View.Details}
         showGoToDetailsButton={true}
+        showTextInputButton={view !== View.Details}
         value={searchString}
       />
       <label className="NoLeftBorder">on</label>

--- a/src/controls/selectors/SearchBar.tsx
+++ b/src/controls/selectors/SearchBar.tsx
@@ -12,18 +12,15 @@ const SearchBar: React.FC = () => {
   const { searchBy, searchString, updatePageParams, view } = usePageParams();
   const getSearchSuggestions = useSearchSuggestions();
 
-  if (view === View.Details) {
-    // Not supported for this view
-    return <></>;
-  }
-
   return (
-    <Selector selectorLabel="🔎">
+    <Selector className="SearchBar" selectorLabel="🔎">
       <TextInput
         inputStyle={{ minWidth: '20em' }}
         getSuggestions={getSearchSuggestions}
         onChange={(searchString: string) => updatePageParams({ searchString })}
         placeholder="search"
+        showFilterButton={view !== View.Details}
+        showGoToDetailsButton={true}
         value={searchString}
       />
       <label className="NoLeftBorder">on</label>

--- a/src/controls/selectors/useSearchSuggestions.tsx
+++ b/src/controls/selectors/useSearchSuggestions.tsx
@@ -45,7 +45,7 @@ export function useSearchSuggestions(): (query: string) => Promise<Suggestion[]>
           .slice(0, SEARCH_RESULTS_LIMIT)
           .map((object) => {
             let label = <HighlightedObjectField object={object} field={searchBy} query={query} />;
-            let id = getSearchableField(object, searchBy);
+            let searchString = getSearchableField(object, searchBy);
             if (searchBy === SearchableField.Code) {
               label = (
                 <>
@@ -53,9 +53,9 @@ export function useSearchSuggestions(): (query: string) => Promise<Suggestion[]>
                 </>
               );
             } else if (searchBy === SearchableField.Territory) {
-              id = object.nameDisplay;
+              searchString = object.nameDisplay;
             }
-            return { id, label };
+            return { id: object.ID, searchString, label };
           }),
         (item) => item.id,
       );

--- a/src/controls/selectors/useSearchSuggestions.tsx
+++ b/src/controls/selectors/useSearchSuggestions.tsx
@@ -55,9 +55,9 @@ export function useSearchSuggestions(): (query: string) => Promise<Suggestion[]>
             } else if (searchBy === SearchableField.Territory) {
               searchString = object.nameDisplay;
             }
-            return { id: object.ID, searchString, label };
+            return { objectID: object.ID, searchString, label };
           }),
-        (item) => item.id,
+        (item) => item.objectID,
       );
     };
   }, [objects, scopeFilter, searchBy]);

--- a/src/views/common/ObjectTitle.tsx
+++ b/src/views/common/ObjectTitle.tsx
@@ -52,7 +52,10 @@ const ObjectTitle: React.FC<Props> = ({ object, highlightSearchMatches = false }
         <ObjectFieldHighlightedByPageSearch object={object} field={SearchableField.EngName} />
       </strong>{' '}
       {nameDisplay != nameEndonym && (
-        <ObjectFieldHighlightedByPageSearch object={object} field={SearchableField.Endonym} />
+        <div style={{ display: 'inline-block' }}>
+          {/* placed in its own div to prevent right-to-left names from breaking */}
+          <ObjectFieldHighlightedByPageSearch object={object} field={SearchableField.Endonym} />
+        </div>
       )}{' '}
       [
       <ObjectFieldHighlightedByPageSearch object={object} field={SearchableField.Code} />]


### PR DESCRIPTION
This change improves the search suggestions interactions, in particular to support details view too. The user-journey we are focusing on here is that is someone starts a search, they may want to filter, but they may just want to jump straight to the details about what they are searching for.

So this refactors the suggestions box a bit and gives it the option to go to the Details view.

If you open the suggestions (here I entered Chinese to filter them) in most views, you'll see new button icons

| Before this PR | After this PR |
|--|--|
|<img width="352" alt="Screenshot 2025-05-20 at 12 21 14" src="https://github.com/user-attachments/assets/3bb863b4-8ec8-4c2b-85bb-aebc73bc504f" />|<img width="354" alt="Screenshot 2025-05-20 at 12 21 25" src="https://github.com/user-attachments/assets/f66da1cc-75fb-4ecc-a78d-a8a87a63384b" />

Here you can see the tooltips for the 2 icons
<img width="420" alt="Screenshot 2025-05-20 at 12 21 38" src="https://github.com/user-attachments/assets/9b045dcd-19e3-46be-9b22-3642212328c0" />
<img width="327" alt="Screenshot 2025-05-20 at 12 21 35" src="https://github.com/user-attachments/assets/b1ca51cb-a1ea-46cf-aeab-bde877c71352" />

Clicking on the filter option does as it did before, putting it as the search string and filtering whatever view you are in (hierarchy, table, cardlist). Clicking on the goto details button now takes you to that page.

<img width="675" alt="Screenshot 2025-05-20 at 12 30 44" src="https://github.com/user-attachments/assets/c33fdfe5-a86a-4971-8031-05c74c6d5f13" />


Btw I did some RTL testing with endonyms and realized there were a few bugs rendering RTL content in LTR views so I also fixed a few places.

<img width="601" alt="Screenshot 2025-05-20 at 12 31 47" src="https://github.com/user-attachments/assets/53a014ce-0f13-4e22-9cf9-a0e38c028cd0" />

