### PR TITLE
UX: Automatically Close Dropdowns on Outside Click

### DIFF
--- a/src/controls/components/MultiChoiceOptions.tsx
+++ b/src/controls/components/MultiChoiceOptions.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 
 import HoverableButton from '../../generic/HoverableButton';
+import { useClickOutside } from '../../generic/useClickOutside';
 
 type Props<T extends React.Key> = {
   getOptionDescription?: (value: T | T[]) => React.ReactNode;
@@ -30,6 +31,11 @@ function MultiChoiceOptions<T extends React.Key>({
     </HoverableButton>
   ));
   const [expanded, setExpanded] = useState(false);
+  const popupRef = useRef<HTMLDivElement>(null);
+  const closeDropdown = useCallback(() => setExpanded(false), []);
+  useClickOutside(popupRef, () => {
+    if (expanded) closeDropdown();
+  });
 
   return mode == 'flat' ? (
     contents
@@ -45,7 +51,7 @@ function MultiChoiceOptions<T extends React.Key>({
         {selected.length > 1 && 'Multiple selected'} {expanded ? `▼` : `▶`}
       </HoverableButton>
       {expanded && (
-        <div className="SelectorPopupAnchor">
+        <div className="SelectorPopupAnchor" ref={popupRef}>
           <div className="SelectorPopup">{contents}</div>
         </div>
       )}

--- a/src/controls/components/MultiChoiceOptions.tsx
+++ b/src/controls/components/MultiChoiceOptions.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState } from 'react';
 
 import HoverableButton from '../../generic/HoverableButton';
 import { useClickOutside } from '../../generic/useClickOutside';
@@ -31,11 +31,7 @@ function MultiChoiceOptions<T extends React.Key>({
     </HoverableButton>
   ));
   const [expanded, setExpanded] = useState(false);
-  const popupRef = useRef<HTMLDivElement>(null);
-  const closeDropdown = useCallback(() => setExpanded(false), []);
-  useClickOutside(popupRef, () => {
-    if (expanded) closeDropdown();
-  });
+  const popupRef = useClickOutside(() => setExpanded(false));
 
   return mode == 'flat' ? (
     contents

--- a/src/controls/components/SingleChoiceOptions.tsx
+++ b/src/controls/components/SingleChoiceOptions.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState } from 'react';
 
 import HoverableButton from '../../generic/HoverableButton';
 import { useClickOutside } from '../../generic/useClickOutside';
@@ -21,11 +21,7 @@ function SingleChoiceOptions<T extends React.Key>({
   selected,
 }: Props<T>) {
   const [expanded, setExpanded] = useState(false);
-  const popupRef = useRef<HTMLDivElement>(null);
-  const closeDropdown = useCallback(() => setExpanded(false), []);
-  useClickOutside(popupRef, () => {
-    if (expanded) closeDropdown();
-  });
+  const popupRef = useClickOutside(() => setExpanded(false));
   const contents = options.map((option) => (
     <HoverableButton
       key={option}

--- a/src/controls/components/SingleChoiceOptions.tsx
+++ b/src/controls/components/SingleChoiceOptions.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 
 import HoverableButton from '../../generic/HoverableButton';
+import { useClickOutside } from '../../generic/useClickOutside';
 
 type Props<T extends React.Key> = {
   getOptionDescription?: (value: T) => React.ReactNode;
@@ -20,6 +21,11 @@ function SingleChoiceOptions<T extends React.Key>({
   selected,
 }: Props<T>) {
   const [expanded, setExpanded] = useState(false);
+  const popupRef = useRef<HTMLDivElement>(null);
+  const closeDropdown = useCallback(() => setExpanded(false), []);
+  useClickOutside(popupRef, () => {
+    if (expanded) closeDropdown();
+  });
   const contents = options.map((option) => (
     <HoverableButton
       key={option}
@@ -48,7 +54,7 @@ function SingleChoiceOptions<T extends React.Key>({
         {getOptionLabel(selected)} {expanded ? `▼` : `▶`}
       </HoverableButton>
       {expanded && (
-        <div className="SelectorPopupAnchor">
+        <div className="SelectorPopupAnchor" ref={popupRef}>
           <div className="SelectorPopup">{contents}</div>
         </div>
       )}

--- a/src/generic/useClickOutside.tsx
+++ b/src/generic/useClickOutside.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+
+/**
+ * Calls the callback when a mousedown occurs outside the referenced element.
+ * @param ref React ref to the element
+ * @param callback Function to call on outside click
+ */
+export function useClickOutside(
+  ref: React.RefObject<HTMLDivElement | null>,
+  callback: () => void
+) {
+  useEffect(() => {
+    function handleEvent(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        callback();
+      }
+    }
+    document.addEventListener('mousedown', handleEvent);
+    return () => {
+      document.removeEventListener('mousedown', handleEvent);
+    };
+  }, [ref, callback]);
+} 

--- a/src/generic/useClickOutside.tsx
+++ b/src/generic/useClickOutside.tsx
@@ -1,10 +1,9 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
+// Custom hook that returns a ref and calls the callback when a mousedown occurs outside the referenced element.
 
-export function useClickOutside(
-  ref: React.RefObject<HTMLDivElement | null>,
-  callback: () => void
-) {
+export function useClickOutside(callback: () => void) {
+  const ref = useRef<HTMLDivElement>(null);
   useEffect(() => {
     function handleEvent(event: MouseEvent) {
       if (ref.current && !ref.current.contains(event.target as Node)) {
@@ -15,5 +14,6 @@ export function useClickOutside(
     return () => {
       document.removeEventListener('mousedown', handleEvent);
     };
-  }, [ref, callback]);
+  }, [callback]);
+  return ref;
 } 

--- a/src/generic/useClickOutside.tsx
+++ b/src/generic/useClickOutside.tsx
@@ -1,10 +1,6 @@
 import { useEffect } from 'react';
 
-/**
- * Calls the callback when a mousedown occurs outside the referenced element.
- * @param ref React ref to the element
- * @param callback Function to call on outside click
- */
+
 export function useClickOutside(
   ref: React.RefObject<HTMLDivElement | null>,
   callback: () => void


### PR DESCRIPTION
1. In useClickOutside.tsx Added a reusable React hook to detect and handle clicks outside a specified element.
2. In SingleChoiceOptions.tsx and MultiChoiceOptions.tsx Integrated the new hook to automatically close the dropdown when clicking outside.

Before the changes:
<img width="1470" alt="Screenshot 2025-05-21 at 1 02 01 AM" src="https://github.com/user-attachments/assets/08f34a6d-3720-449b-976c-189791fa03cf" />

After the changes:
<img width="1470" alt="Screenshot 2025-05-21 at 1 01 13 AM" src="https://github.com/user-attachments/assets/a1ed8d3d-6df0-4bc5-bdc5-3f1141be18d2" />

