### PR TITLE
Censuses: Show census records for locales

### DIFF
--- a/src/dataloading/CensusData.tsx
+++ b/src/dataloading/CensusData.tsx
@@ -173,9 +173,29 @@ export function addCensusData(coreData: CoreData, censusData: CensusImport): voi
         census.territory = territory;
         territory.censuses.push(census);
       }
+
+      // Create references to census from the locale data
+      addCensusRecordsToLocales(coreData, census);
     } else {
       // It's reloaded twice on dev mode
       // console.warn(`Census data for ${census.ID} already exists, skipping.`);
     }
   }
+}
+
+export function addCensusRecordsToLocales(codeData: CoreData, census: CensusData): void {
+  Object.entries(census.languageEstimates).forEach(([languageCode, populationEstimate]) => {
+    // Assuming languageCode is using the canonical ID (eg. eng not en or stan1293)
+    const locale = codeData.locales[languageCode + '_' + census.isoRegionCode];
+    if (locale != null) {
+      // Add the census to the locale
+      locale.censusRecords.push({
+        census,
+        populationEstimate,
+        populationPercent: (populationEstimate * 100.0) / census.eligiblePopulation,
+      });
+    } else {
+      // TODO: show warning in the "Notices" tool
+    }
+  });
 }

--- a/src/dataloading/DataParsing.tsx
+++ b/src/dataloading/DataParsing.tsx
@@ -92,6 +92,8 @@ export function parseLocaleLine(line: string): LocaleData {
     populationSource: parts[7] as PopulationSourceCategory,
     populationEstimate: Number.parseInt(parts[8]?.replace(/,/g, '')),
     officialStatus: parts[9] != '' ? (parts[9] as OfficialStatus) : undefined,
+
+    censusRecords: [], // Populated later
   };
 }
 

--- a/src/generic/numUtils.tsx
+++ b/src/generic/numUtils.tsx
@@ -1,0 +1,12 @@
+/**
+ * When showing numbers there may be both very small and large numbers in the same context.
+ * While generally we'd want them to be compared with the same number of decimals (eg. 13.1% and 6.8%),
+ * when there are very small numbers (eg. 0.0023%) that will easily be rounded to oblivion (0.00%), so
+ * this function will still show small numbers.
+ */
+export function numberToFixedUnlessSmall(value: number, precision: number = 2): string {
+  if (value > 1) {
+    return value.toFixed(precision);
+  }
+  return value.toPrecision(precision);
+}

--- a/src/types/DataTypes.tsx
+++ b/src/types/DataTypes.tsx
@@ -121,6 +121,12 @@ export enum OfficialStatus {
   RecognizedRegionally = 'recognized_regional',
 }
 
+export type LocaleInCensus = {
+  census: CensusData;
+  populationEstimate: number;
+  populationPercent: number;
+};
+
 export interface LocaleData extends ObjectBase {
   type: ObjectType.Locale;
 
@@ -134,8 +140,10 @@ export interface LocaleData extends ObjectBase {
   territoryCode: TerritoryCode;
   explicitScriptCode?: ScriptCode;
   variantTag?: VariantIANATag;
+
+  populationEstimate: number; // The canonical population
   populationSource: PopulationSourceCategory;
-  populationEstimate: number;
+
   officialStatus?: OfficialStatus;
 
   // References to other objects, filled in after loading the TSV
@@ -145,4 +153,5 @@ export interface LocaleData extends ObjectBase {
 
   // Data added up some references
   populationPercentOfTerritory?: number;
+  censusRecords: LocaleInCensus[]; // Maps census ID to population estimate
 }

--- a/src/views/census/TableOfLanguagesInCensus.tsx
+++ b/src/views/census/TableOfLanguagesInCensus.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
+import { usePageParams } from '../../controls/PageParamsContext';
 import { useDataContext } from '../../dataloading/DataContext';
+import Hoverable from '../../generic/Hoverable';
+import { numberToFixedUnlessSmall } from '../../generic/numUtils';
 import { CensusData } from '../../types/CensusTypes';
 import { LocaleData } from '../../types/DataTypes';
 import { ObjectType, SortBy } from '../../types/PageParamTypes';
 import { getLanguageScopeLevel, ScopeLevel } from '../../types/ScopeLevel';
+import HoverableObject from '../common/HoverableObject';
 import { CodeColumn, NameColumn } from '../common/table/CommonColumns';
 import ObjectTable from '../common/table/ObjectTable';
 
@@ -15,7 +19,9 @@ type Props = {
 const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
   const {
     languagesBySchema: { Inclusive: langObjects },
+    locales,
   } = useDataContext();
+  const { localeSeparator } = usePageParams();
 
   const langsNotFound: string[] = [];
 
@@ -29,8 +35,8 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
       }
       return {
         type: ObjectType.Locale,
-        ID: langID + census.ID,
-        codeDisplay: lang.codeDisplay,
+        ID: langID + '_' + census.isoRegionCode,
+        codeDisplay: lang.codeDisplay + localeSeparator + census.isoRegionCode,
         languageCode: langID,
         language: lang,
         nameDisplay: lang.nameDisplay,
@@ -46,6 +52,13 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
       } as LocaleData;
     })
     .filter((loc) => loc != null);
+
+  const getActualLocaleInfoButton = useCallback(
+    (mockedLocale: LocaleData): React.ReactNode => (
+      <ActualLocaleInfoButton actualLocale={locales[mockedLocale.ID]} />
+    ),
+    [locales],
+  );
 
   return (
     <div>
@@ -70,7 +83,7 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
             label: 'Percent within Territory',
             render: (loc) =>
               loc.populationPercentOfTerritory != null
-                ? loc.populationPercentOfTerritory.toFixed(2) + '%'
+                ? numberToFixedUnlessSmall(loc.populationPercentOfTerritory) + '%'
                 : 'N/A',
             isNumeric: true,
           },
@@ -79,9 +92,32 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
             render: (loc) => loc.language?.scope,
             isNumeric: false,
           },
+          {
+            label: (
+              <Hoverable hoverContent="The locale dataset has a canonical population estimate and may refer to estimates from multiple censuses. Hover for the canonical locale entry or click to see more details. The locale dataset does not contain every combination of language + territory so some may not be found.">
+                Locale Entry
+              </Hoverable>
+            ),
+            render: getActualLocaleInfoButton,
+          },
         ]}
       />
     </div>
+  );
+};
+
+const ActualLocaleInfoButton: React.FC<{ actualLocale?: LocaleData }> = ({ actualLocale }) => {
+  if (actualLocale == null) {
+    return (
+      <span className="unsupported" style={{ fontSize: '0.8em' }}>
+        not found
+      </span>
+    );
+  }
+  return (
+    <HoverableObject object={actualLocale}>
+      <button className="InfoButton">&#x24D8;</button>
+    </HoverableObject>
   );
 };
 

--- a/src/views/common/table/ObjectTable.tsx
+++ b/src/views/common/table/ObjectTable.tsx
@@ -11,7 +11,7 @@ import VisibleItemsMeter from '../../VisibleItemsMeter';
 import './tableStyles.css';
 
 export interface TableColumn<T> {
-  label: string;
+  label: React.ReactNode;
   render: (object: T) => React.ReactNode;
   key?: string;
   isNumeric?: boolean;

--- a/src/views/locale/LocaleDetails.tsx
+++ b/src/views/locale/LocaleDetails.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { numberToFixedUnlessSmall } from '../../generic/numUtils';
 import { LocaleData } from '../../types/DataTypes';
 import HoverableObjectName from '../common/HoverableObjectName';
 
@@ -10,13 +11,29 @@ type Props = {
 };
 
 const LocaleDetails: React.FC<Props> = ({ locale }) => {
+  const { officialStatus } = locale;
+  return (
+    <div className="Details">
+      <LocaleDefinitionSection locale={locale} />
+      <LocalePopulationSection locale={locale} />
+      {officialStatus && (
+        <div className="section">
+          <h3>Other</h3>
+          <div>
+            <label>Government status:</label>
+            {getOfficialLabel(officialStatus)}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const LocaleDefinitionSection: React.FC<{ locale: LocaleData }> = ({ locale }) => {
   const {
     explicitScriptCode,
     language,
     languageCode,
-    officialStatus,
-    populationEstimate,
-    populationPercentOfTerritory,
     territory,
     territoryCode,
     variantTag,
@@ -24,73 +41,102 @@ const LocaleDetails: React.FC<Props> = ({ locale }) => {
   } = locale;
 
   return (
-    <div className="Details">
+    <div className="section">
+      <h3>Definition</h3>
       <div>
-        <h3>Definition</h3>
-        <div>
-          <label>Language:</label>
-          {language ? (
-            <HoverableObjectName object={language} />
-          ) : (
-            <span>
-              {languageCode} <em>[language not in database]</em>
-            </span>
-          )}
-        </div>
-        <div>
-          <label>Territory:</label>
-          {territory ? (
-            <HoverableObjectName object={territory} />
-          ) : (
-            <span>
-              {territoryCode} <em>[territory not in database]</em>
-            </span>
-          )}
-        </div>
-
-        {explicitScriptCode && (
-          <div>
-            <label>Writing System:</label>
-            {writingSystem ? (
-              <HoverableObjectName object={writingSystem} />
-            ) : (
-              <span>
-                {explicitScriptCode} <em>[writing system not in database]</em>
-              </span>
-            )}
-          </div>
-        )}
-
-        {variantTag && (
-          <div>
-            <label>Variant:</label>
-            {variantTag} <em>[variant not in database]</em>
-          </div>
+        <label>Language:</label>
+        {language ? (
+          <HoverableObjectName object={language} />
+        ) : (
+          <span>
+            {languageCode} <em>[language not in database]</em>
+          </span>
         )}
       </div>
       <div>
-        <h3>Attributes</h3>
-        <div>
-          <label>Speakers:</label>
-          {populationEstimate.toLocaleString()}
-          {' ['}
-          {getPopulationCitation(locale)}
-          {']'}
-        </div>
-
-        {populationPercentOfTerritory != null && (
-          <div>
-            <label>Percent of {territory?.territoryType ?? 'territory'}:</label>
-            {populationPercentOfTerritory.toFixed(1)}%
-          </div>
-        )}
-        {officialStatus && (
-          <div>
-            <label>Government status:</label>
-            {getOfficialLabel(officialStatus)}
-          </div>
+        <label>Territory:</label>
+        {territory ? (
+          <HoverableObjectName object={territory} />
+        ) : (
+          <span>
+            {territoryCode} <em>[territory not in database]</em>
+          </span>
         )}
       </div>
+      {explicitScriptCode && (
+        <div>
+          <label>Writing System:</label>
+          {writingSystem ? (
+            <HoverableObjectName object={writingSystem} />
+          ) : (
+            <span>
+              {explicitScriptCode} <em>[writing system not in database]</em>
+            </span>
+          )}
+        </div>
+      )}
+      {variantTag && (
+        <div>
+          <label>Variant:</label>
+          {variantTag} <em>[variant not in database]</em>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const LocalePopulationSection: React.FC<{ locale: LocaleData }> = ({ locale }) => {
+  const { populationEstimate, populationPercentOfTerritory, territory, censusRecords } = locale;
+
+  return (
+    <div className="section">
+      <h3>Population</h3>
+      <div>
+        <label>Speakers:</label>
+        {populationEstimate.toLocaleString()}
+        {' ['}
+        {getPopulationCitation(locale)}
+        {']'}
+      </div>
+
+      {populationPercentOfTerritory != null && (
+        <div>
+          <label>Percent of {territory?.territoryType ?? 'territory'}:</label>
+          {numberToFixedUnlessSmall(populationPercentOfTerritory)}%
+        </div>
+      )}
+
+      {censusRecords.length > 0 && (
+        <div>
+          <label>Other Censuses:</label>
+          <table style={{ marginLeft: '2em', borderSpacing: '1em 0' }}>
+            <thead>
+              <tr>
+                <th>Population</th>
+                <th>Percent</th>
+                <th>Census</th>
+              </tr>
+            </thead>
+            <tbody>
+              {censusRecords
+                .sort((a, b) => b.populationPercent - a.populationPercent)
+                .map((censusEstimate) => (
+                  <tr key={censusEstimate.census.ID}>
+                    <td style={{ textAlign: 'right' }}>
+                      {censusEstimate.populationEstimate.toLocaleString()}
+                    </td>
+                    <td style={{ textAlign: 'right' }}>
+                      {numberToFixedUnlessSmall(censusEstimate.populationPercent)}%
+                    </td>
+                    <td>
+                      <HoverableObjectName object={censusEstimate.census} />
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
The census information is much better if you can actually see it in other places. While there are more places we need to plug it into, the first thing is to at least list it in the locale entries.

|Page|Before|After|
|--|--|--|
|[Canada Census details](https://translation-commons.github.io/lang-nav/?objectType=Census&view=Details&objectID=ca2021.1&limit=0)|<img width="771" alt="Screenshot 2025-06-03 at 14 34 39" src="https://github.com/user-attachments/assets/104cbf7e-d48e-4e43-b89b-7d7c6117e46f" />|<img width="772" alt="Screenshot 2025-06-03 at 14 34 24" src="https://github.com/user-attachments/assets/d80098a6-a9f1-4c3c-ad0a-f498b85411cb" />
|[French (Canada) details](https://translation-commons.github.io/lang-nav/?objectType=Locale&view=Details&objectID=fra_CA&limit=0)|<img width="509" alt="Screenshot 2025-06-03 at 14 36 15" src="https://github.com/user-attachments/assets/e5b6ee0b-2c3c-4836-8415-b749345cc62f" />|<img width="510" alt="Screenshot 2025-06-03 at 14 35 58" src="https://github.com/user-attachments/assets/d8055899-0a75-47c3-95db-45f64253dc49" />

Note something weird you will see is that the % in territory for fra_CA is different in the census data versus in the main number -- that's because the denominator for the main number is based on today's population, not the population @ the census. It should be adjusted, but I'll leave that for another PR.
