### PR TITLE
Censuses: Add alternative language names from census imports

### DIFF
--- a/src/generic/stringUtils.tsx
+++ b/src/generic/stringUtils.tsx
@@ -8,7 +8,7 @@ export function separateTitleAndSubtitle(str: string): [string, string | undefin
 }
 
 export function toTitleCase(str: string): string {
-  return str.replace(/\b\w/g, (char) => char.toUpperCase());
+  return str.toLowerCase().replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
 export function toSentenceCase(str: string): string {

--- a/src/views/census/TableOfLanguagesInCensus.tsx
+++ b/src/views/census/TableOfLanguagesInCensus.tsx
@@ -6,10 +6,11 @@ import Hoverable from '../../generic/Hoverable';
 import { numberToFixedUnlessSmall } from '../../generic/numberUtils';
 import { CensusData } from '../../types/CensusTypes';
 import { LocaleData } from '../../types/DataTypes';
-import { ObjectType, SortBy } from '../../types/PageParamTypes';
+import { ObjectType, SearchableField, SortBy } from '../../types/PageParamTypes';
 import { getLanguageScopeLevel, ScopeLevel } from '../../types/ScopeLevel';
 import HoverableObject from '../common/HoverableObject';
-import { CodeColumn, NameColumn } from '../common/table/CommonColumns';
+import { ObjectFieldHighlightedByPageSearch } from '../common/ObjectField';
+import { CodeColumn } from '../common/table/CommonColumns';
 import ObjectTable from '../common/table/ObjectTable';
 
 type Props = {
@@ -72,7 +73,18 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
         objects={languagesInCensus}
         columns={[
           CodeColumn,
-          NameColumn,
+          {
+            label: 'Language',
+            render: (object) => (
+              <HoverableObject object={object.language}>
+                <ObjectFieldHighlightedByPageSearch
+                  object={object}
+                  field={SearchableField.EngName}
+                />
+              </HoverableObject>
+            ),
+            sortParam: SortBy.Name,
+          },
           {
             label: 'Population',
             render: (loc) => loc.populationSpeaking,

--- a/src/views/common/HoverableObject.tsx
+++ b/src/views/common/HoverableObject.tsx
@@ -11,12 +11,15 @@ import TerritoryCard from '../territory/TerritoryCard';
 import WritingSystemCard from '../writingsystem/WritingSystemCard';
 
 type Props = {
-  object: ObjectData;
+  object?: ObjectData;
   children: React.ReactNode;
 };
 
 const HoverableObject: React.FC<Props> = ({ object, children }) => {
   const { view, updatePageParams } = usePageParams();
+  if (object == null) {
+    return <>{children}</>;
+  }
 
   const getHoverContent = () => {
     switch (object.type) {


### PR DESCRIPTION
When importing census data, sometimes the census has slightly different names for languages. This adds those names to the languages' list of alternative names.

btw the edits to LanguageDetails.tsx are mostly a refactor -- breaking the large component into subcomponents. However I did change the othernames algorithm to actually use the names attribute (it wasn't yet, I had forgotten to do that).

|Example Locale|Before|After|
|--|--|--|
|[Bodo](https://translation-commons.github.io/lang-nav/?view=Details&objectID=brx&objectType=Language)|![Screenshot 2025-06-04 at 17 28 32](https://github.com/user-attachments/assets/1fbd4262-592a-4b6f-b230-7ab54fa974b2)|![Screenshot 2025-06-04 at 17 28 05](https://github.com/user-attachments/assets/ab5e576a-e698-47e1-883b-71ad776c1b75)
|[Rakhine](https://translation-commons.github.io/lang-nav/?view=Details&objectID=rki&objectType=Language)|![Screenshot 2025-06-04 at 17 28 28](https://github.com/user-attachments/assets/3c0798eb-7e83-44f6-b15d-28183d2beb7b)|![Screenshot 2025-06-04 at 17 28 02](https://github.com/user-attachments/assets/1426dbbb-1e3d-4591-8d0c-17557eb9c9a5)
