### PR TITLE
Minor UX: Add links from languages to Wikipedia and Ethnologue

### DIFF
--- a/src/generic/LinkButton.tsx
+++ b/src/generic/LinkButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function LinkButton({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+} & React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+  return (
+    <a href={href}>
+      <button className="LinkButton" role="link">
+        {children}
+      </button>
+    </a>
+  );
+}

--- a/src/views/language/LanguageDetails.tsx
+++ b/src/views/language/LanguageDetails.tsx
@@ -61,7 +61,9 @@ const LanguageDetails: React.FC<Props> = ({ lang }) => {
             <>
               {Glottolog.code}
               <a href={`https://glottolog.org/resource/languoid/id/${Glottolog.code}`}>
-                <button className="LinkButton">Open in Glottolog</button>
+                <button className="LinkButton" role="link">
+                  Glottolog
+                </button>
               </a>
             </>
           ) : (
@@ -75,7 +77,9 @@ const LanguageDetails: React.FC<Props> = ({ lang }) => {
               {ISO.code}
               {codeISO6391 ? ` | ${codeISO6391}` : ''}
               <a href={`https://iso639-3.sil.org/code/${ISO.code}`}>
-                <button className="LinkButton">Open in ISO</button>
+                <button className="LinkButton" role="link">
+                  ISO Table
+                </button>
               </a>
             </>
           ) : (
@@ -90,13 +94,30 @@ const LanguageDetails: React.FC<Props> = ({ lang }) => {
               <a
                 href={`https://github.com/unicode-org/cldr/blob/main/common/main/${CLDR.code}.xml`}
               >
-                <button className="LinkButton">Open CLDR XML</button>
+                <button className="LinkButton" role="link">
+                  CLDR XML
+                </button>
               </a>
             </>
           ) : (
             <span className="unsupported">Not in CLDR</span>
           )}
         </div>
+        {ISO.code && (
+          <div>
+            <label>Other external links:</label>
+            <a href={`https://www.ethnologue.com/language/${ISO.code}`}>
+              <button className="LinkButton" role="link">
+                Ethnologue
+              </button>
+            </a>
+            <a href={`https://en.wikipedia.org/wiki/ISO_639:${ISO.code}`}>
+              <button className="LinkButton" role="link">
+                Wikipedia
+              </button>
+            </a>
+          </div>
+        )}
       </div>
       <div className="section">
         <h3>Attributes</h3>

--- a/src/views/language/LanguageDetails.tsx
+++ b/src/views/language/LanguageDetails.tsx
@@ -4,6 +4,7 @@ import { usePageParams } from '../../controls/PageParamsContext';
 import { getSortFunction } from '../../controls/sort';
 import CommaSeparated from '../../generic/CommaSeparated';
 import Hoverable from '../../generic/Hoverable';
+import LinkButton from '../../generic/LinkButton';
 import { CLDRCoverageLevel } from '../../types/CLDRTypes';
 import { LanguageData, LanguageScope } from '../../types/LanguageTypes';
 import HoverableObjectName from '../common/HoverableObjectName';
@@ -60,11 +61,9 @@ const LanguageDetails: React.FC<Props> = ({ lang }) => {
           {Glottolog.code ? (
             <>
               {Glottolog.code}
-              <a href={`https://glottolog.org/resource/languoid/id/${Glottolog.code}`}>
-                <button className="LinkButton" role="link">
-                  Glottolog
-                </button>
-              </a>
+              <LinkButton href={`https://glottolog.org/resource/languoid/id/${Glottolog.code}`}>
+                Glottolog
+              </LinkButton>
             </>
           ) : (
             <span className="unsupported">Not in Glottolog</span>
@@ -76,11 +75,7 @@ const LanguageDetails: React.FC<Props> = ({ lang }) => {
             <>
               {ISO.code}
               {codeISO6391 ? ` | ${codeISO6391}` : ''}
-              <a href={`https://iso639-3.sil.org/code/${ISO.code}`}>
-                <button className="LinkButton" role="link">
-                  ISO Table
-                </button>
-              </a>
+              <LinkButton href={`https://iso639-3.sil.org/code/${ISO.code}`}>ISO Table</LinkButton>
             </>
           ) : (
             <span className="unsupported">Not in ISO catalog</span>
@@ -91,13 +86,11 @@ const LanguageDetails: React.FC<Props> = ({ lang }) => {
           {CLDR.code ? (
             <>
               {CLDR.code}
-              <a
+              <LinkButton
                 href={`https://github.com/unicode-org/cldr/blob/main/common/main/${CLDR.code}.xml`}
               >
-                <button className="LinkButton" role="link">
-                  CLDR XML
-                </button>
-              </a>
+                CLDR XML
+              </LinkButton>
             </>
           ) : (
             <span className="unsupported">Not in CLDR</span>
@@ -106,16 +99,12 @@ const LanguageDetails: React.FC<Props> = ({ lang }) => {
         {ISO.code && (
           <div>
             <label>Other external links:</label>
-            <a href={`https://www.ethnologue.com/language/${ISO.code}`}>
-              <button className="LinkButton" role="link">
-                Ethnologue
-              </button>
-            </a>
-            <a href={`https://en.wikipedia.org/wiki/ISO_639:${ISO.code}`}>
-              <button className="LinkButton" role="link">
-                Wikipedia
-              </button>
-            </a>
+            <LinkButton href={`https://www.ethnologue.com/language/${ISO.code}`}>
+              Ethnologue
+            </LinkButton>
+            <LinkButton href={`https://en.wikipedia.org/wiki/ISO_639:${ISO.code}`}>
+              Wikipedia
+            </LinkButton>
           </div>
         )}
       </div>


### PR DESCRIPTION
When researching about languages it's handy to follow these links and fortunately there is a structured way to get to the articles in both resources.

|Before|After|
|--|--|
|![Screenshot 2025-06-05 at 11 45 15](https://github.com/user-attachments/assets/86cc60c3-943a-4aa7-9281-ccb51750bad9)|![Screenshot 2025-06-05 at 11 37 46](https://github.com/user-attachments/assets/723fc0dc-0647-486c-87dc-9eae6c985c68)
