### PR TITLE
Hierarchy: Add viewing options and update some language families

### DIFF
--- a/public/data/iso/families639-5.tsv
+++ b/public/data/iso/families639-5.tsv
@@ -1,3 +1,5 @@
+#url	https://www.loc.gov/standards/iso639-5/id.php
+#dateAccessed    2025-06-06
 ISO 639-5	Language family name	Parent
 aav	Austro-Asiatic languages	
 afa	Afro-Asiatic languages	

--- a/public/data/iso/familiesToLanguages.tsv
+++ b/public/data/iso/familiesToLanguages.tsv
@@ -1,3 +1,6 @@
+#sourceURL	https://github.com/unicode-org/cldr/blob/main/common/supplemental/languageGroup.xml
+#dateAccessed	2025-06-06
+#notes	Numerous manual edits attempting to fill in missing data and reconcile some linguistics debates
 ISO 639-5	Constituents
 aav	bbh bfw bru brv hre irr kdt ktv kuf mkh mmj mun ncq ngt nyl oog pac phg ply sct sss tth tto zng
 afa	aal ber btf bvw bxe cdc ckq cus egx glo hdy hig hwo jaf kbz kul kvj mes mlw mmf omv sem tdk tsh ttr xdm
@@ -27,10 +30,10 @@ cdc	ajw anc ank bcw bcy bde bdm bdn bid bol bta bvf bvh bwr bxq ckl cky cla daa 
 cdd	ari cad kii paw wic
 cel	br cnx cy ga gd ghc gv kw nrc oco owl pgl sth wlm xcb xce xga xlp xpi
 cmc	ace cja cje cjm hro huq ibh jra ocm rad rgs rog
-cpe	afs aig bah bi bzj bzk cpi djk fpe gcl gul gyn hwc icr jam kri kww ngm pcm pih pis rop srn tch tcs tpi trf vic wes lir
-cpf	acf cks crs gcf gcr ht lou mfe rcf scf
-cpp	aoa cri fab idb kea mcm mzs pov pre vkp
-crp	cpe cpf cpp sg
+cpe	afs aig bah bi bzj bzk cpi djk fpe gcl gul gyn hwc icr jam kri kww ngm pcm pih pis rop srn tch tcs tpi trf vic wes lir tgh svc gpe
+cpf	acf cks crs gcf gcr ht lou mfe rcf scf kmv
+cpp	aoa cri fab idb kea mcm mzs pov pre vkp tvy
+crp	cpe cpf cpp sg ycr sci hca ccm ccd brc skw nag bpl ihb njt onx mhh
 csu	aja avu bdh bex blm bmi bot bvq bxv dsi efe fgr fuu gbn gqr hor jyy kah kcm krs kwg kwv kxj lap led les lgg lmi log mdi mdj mgc mge mhi mne mwm mwu myb ndp niy nwm sba sbz snm yul
 cus	aa aas ahg arv awn bds bej bji bnl bob bsw byn dal dox drs dsh elo gax gdl gex gii gow gwd hae irk kxc om orc rel sid so ssn ssy tqq tsb wbj wka xan ymm
 day	bei bth byd lra sdo sne sre
@@ -44,7 +47,7 @@ fox	ami bnn byq bzg ckv dru fos kae ppu pwn pyu pzh ssf sxr szy tay trv tsu tvx 
 gem	gme gmq gmw
 gme	got xvn
 gmq	da fo is jut nb nn no non nrn ovd sv
-gmw	act af ang bar cim dcr de drt dum en enm frk frr frs fy gct geh gmh gml goh gpe gsw ksh lb li lng mhn nds nl odt ofs oor osx pdc pdt pfl sco sdz sli sth stl stq swg vel vls wae wep wym yec yi yih yol zea sxu hrx vmf
+gmw	act af ang bar cim dcr de drt dum en enm frk frr frs fy gct geh gmh gml goh gsw ksh lb li lng mhn nds nl odt ofs oor osx pdc pdt pfl sco sdz sli sth stl stq swg vel vls wae wep wym yec yi yih yol zea sxu hrx vmf
 grk	cpg el gmy grc pnt tsd
 hmx	bje bmt bpn buh bwn bwx cqd hma hmc hmd hme hmf hmg hmh hmi hmj hml hmm hmn hmp hmq hms hmv hmw hmy hmz hnj hrm huj ium mji mmr muq mww neo pha pnu sfm shx
 hok	acv atw boi chd cid clo coc coj crz dih esq inz kju klb kyh mov mrc obi peb pef pej peq pom poo ppi puy sei sht sln veo was ynn yuf yum
@@ -56,7 +59,7 @@ ine	aln bat cel cms gem grk hit hlu htx hyx iir imy itc nei oht plq rmd rmu scx 
 ira	ae atn avd bal bgn bhh bjm bqi bsg ckb def deh esh fa fay gbz glk goz gzi hac hrz isk jdt jpr kfm kgn kho kiu ku lki lrc lrl lsa luz mnj mzn ntz nyq okh oru os pal peo prc ps rat rdb sdb sdf sdh sgh sgr sgy shm siy smy sog soj sqo srh srz tg tks tly tov ttt vaf vmh wbl wne xbc xco xkc xkj xkp xme xmn xpr xsc yah yai ydg ysc zum zza pes prd prs haz
 iro	cay chr lre moh ntw one ono see sqn tus
 itc	la osc roa spx umc xae xfa xhr xum xve xvo xvs
-jpx	ja
+jpx	ams ja kzg mvi ojp okn ryn rys ryu tkn xug yoi yox
 kar	blk bwe eky ghk jkm jkp kjp kjt ksw kvl kvq kvt kvu kvy kxf kxk pdu pwo pww wea
 kdo	acz eli lmd taz tlo laf tag ras kcr tms dec jle tqr
 khi	gku gnk gwj hgm hio hnh hts huc knw kqu kqz ktz kwz naq ngh nhr nmn sad shg tyu vaj xam xii xuu
@@ -101,7 +104,7 @@ tai	aho aio blt eee kht ksu lo nod nrr nut pdi phk shn soa tdd th thi tnu tpo ts
 tbq	adi adl apt bee bft bfu bqh bro brx cda cdn cgk chx dka drd duu dz dzl ghe ghh ght gro gvr gyo hut jda jna jul kbg kfk khg kkf kte kzq lae lbf lbj lhm lkh loy mrg nbt neh njz nmm npa nun ola ole prx rgk rnp sbu scp scu sgt sip skj spt syw taj tdg tgf tgj ths tpq tsj tsk ttz twm xkf xkz xns xsr xzh zau adx phj my
 trk	aib alt atv az azb ba bgx chg cjs clw crh cv dlg gag ili jct kaa kdr kim kjh kk klj kmz krc kum ky nog otk oui qwm qxq sah slr sty tk tr tt tyv ug uum uz xbo xpc xqa ybe zkh zkz
 tup	aan ait ama api aqz arr arx asn asu aux avv awe awt cin cod eme gn gnw gub gui gun guq gvj gvo gyr jor jua jur kay kgk kpn ktn kuq kyr kyz mav mdz mnd mpu msp myu nhd omg oym paf pah pak pog psm pta pto skf srq sru taf tpj tpk tpn tpr tqb twt urb uru urz wir wyr xaj xiy xmo yrl yuq
-tut	ain ams jje kzg mvi ojp okm okn oko pkc ryn rys ryu tkn trk tuw xgn xhc xpy xug yoi yox zkg zkt
+tut	trk tuw xgn xhc zkt
 tuw	eve evn gld juc mnc neg oaa oac orh sjo ude ulc
 urj	fiu omk rts syd xcv ykg yux
 wak	dtd has hei kwk myh nuk

--- a/src/data/AddISOData.tsx
+++ b/src/data/AddISOData.tsx
@@ -114,7 +114,7 @@ export async function loadISOLanguageFamilies(): Promise<ISOLanguageFamilyData[]
     .then((text) => {
       return text
         .split('\n')
-        .slice(1)
+        .slice(3) // First 3 lines are headers and comments
         .map((line) => {
           const parts = line.split('\t');
           return { code: parts[0], name: parts[1], parent: parts[2] != '' ? parts[2] : undefined };
@@ -132,7 +132,7 @@ export async function loadISOFamiliesToLanguages(): Promise<Record<
     .then((text) => {
       return text
         .split('\n')
-        .slice(1)
+        .slice(4) // First 4 lines are headers and comments
         .reduce<Record<ISO6395LanguageCode, LanguageCode[]>>((families, line) => {
           const parts = line.split('\t');
           families[parts[0]] = parts[1].split(' ');

--- a/src/views/common/ObjectField.tsx
+++ b/src/views/common/ObjectField.tsx
@@ -4,7 +4,8 @@ import { usePageParams } from '../../controls/PageParamsContext';
 import Highlightable from '../../generic/Highlightable';
 import { anyWordStartsWith } from '../../generic/stringUtils';
 import { ObjectData } from '../../types/DataTypes';
-import { SearchableField } from '../../types/PageParamTypes';
+import { LanguageSchema } from '../../types/LanguageTypes';
+import { ObjectType, SearchableField } from '../../types/PageParamTypes';
 
 interface Props {
   object: ObjectData;
@@ -72,5 +73,33 @@ export function getSearchableField(object: ObjectData, field: SearchableField, q
     case SearchableField.NameOrCode:
     case SearchableField.Territory:
       return object.nameDisplay + ' [' + object.codeDisplay + ']';
+  }
+}
+
+export function getObjectPopulation(
+  object: ObjectData,
+  includeDescendents?: boolean,
+  languageSchema?: LanguageSchema,
+): number {
+  switch (object.type) {
+    case ObjectType.Language:
+      return (
+        (object.populationCited ?? 0) +
+        (includeDescendents && languageSchema
+          ? (object.schemaSpecific[languageSchema].populationOfDescendents ?? 0)
+          : 0)
+      );
+    case ObjectType.Locale:
+      return object.populationSpeaking;
+    case ObjectType.Census:
+      return object.languageCount;
+    case ObjectType.WritingSystem:
+      return (
+        object.populationUpperBound + (includeDescendents ? object.populationOfDescendents : 0)
+      );
+    case ObjectType.Territory:
+      return object.population;
+    default:
+      return 0; // Default case for other types
   }
 }

--- a/src/views/common/TreeList/TreeListOptions.tsx
+++ b/src/views/common/TreeList/TreeListOptions.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+
+interface TreeListOptions {
+  allExpanded: boolean;
+  showInfoButton: boolean;
+  showPopulation: boolean;
+  showObjectIDs: boolean;
+  setAllExpanded: (value: boolean) => void;
+  setShowInfoButton: (value: boolean) => void;
+  setShowPopulation: (value: boolean) => void;
+  setShowObjectIDs: (value: boolean) => void;
+}
+const TreeListOptionsContext = React.createContext<TreeListOptions>({
+  allExpanded: false,
+  showInfoButton: true,
+  showPopulation: false,
+  showObjectIDs: false,
+  setAllExpanded: () => {},
+  setShowInfoButton: () => {},
+  setShowPopulation: () => {},
+  setShowObjectIDs: () => {},
+});
+
+export const TreeListOptionsProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [allExpanded, setAllExpanded] = React.useState(false);
+  const [showInfoButton, setShowInfoButton] = React.useState(true);
+  const [showPopulation, setShowPopulation] = React.useState(false);
+  const [showObjectIDs, setShowObjectIDs] = React.useState(false);
+
+  const value = {
+    allExpanded,
+    showInfoButton,
+    showPopulation,
+    showObjectIDs,
+    setAllExpanded,
+    setShowInfoButton,
+    setShowPopulation,
+    setShowObjectIDs,
+  };
+
+  return (
+    <TreeListOptionsContext.Provider value={value}>{children}</TreeListOptionsContext.Provider>
+  );
+};
+
+export function useTreeListOptionsContext(): TreeListOptions {
+  const context = React.useContext(TreeListOptionsContext);
+  return context;
+}
+
+export function TreeListOptionsSelectors() {
+  const {
+    allExpanded,
+    showInfoButton,
+    showPopulation,
+    showObjectIDs,
+    setAllExpanded,
+    setShowInfoButton,
+    setShowPopulation,
+    setShowObjectIDs,
+  } = useTreeListOptionsContext();
+
+  return (
+    <div className="TreeListOptions">
+      <label>
+        <input
+          type="checkbox"
+          checked={allExpanded}
+          onChange={(e) => setAllExpanded(e.target.checked)}
+        />
+        Expand All
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={showInfoButton}
+          onChange={(e) => setShowInfoButton(e.target.checked)}
+        />
+        Show Info Button
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={showPopulation}
+          onChange={(e) => setShowPopulation(e.target.checked)}
+        />
+        Show Population
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={showObjectIDs}
+          onChange={(e) => setShowObjectIDs(e.target.checked)}
+        />
+        Show Object IDs
+      </label>
+    </div>
+  );
+}

--- a/src/views/common/TreeList/TreeListPageBody.tsx
+++ b/src/views/common/TreeList/TreeListPageBody.tsx
@@ -5,6 +5,7 @@ import { usePageParams } from '../../../controls/PageParamsContext';
 
 import { filterBranch } from './filterBranch';
 import { TreeNodeData } from './TreeListNode';
+import { TreeListOptionsProvider, TreeListOptionsSelectors } from './TreeListOptions';
 import TreeListRoot from './TreeListRoot';
 import './treelist.css';
 
@@ -19,13 +20,16 @@ const TreeListPageBody: React.FC<Props> = ({ rootNodes, description }) => {
 
   return (
     <div className="TreeListView">
-      <div style={{ marginBottom: 8 }}>{description}</div>
-      <TreeListRoot
-        rootNodes={rootNodes
-          .map((node) => filterBranch(node, substringFilterFunction))
-          .filter((node) => node != null)
-          .slice(0, limit > 0 ? limit : undefined)}
-      />
+      <TreeListOptionsProvider>
+        <div style={{ marginBottom: 8 }}>{description}</div>
+        <TreeListRoot
+          rootNodes={rootNodes
+            .map((node) => filterBranch(node, substringFilterFunction))
+            .filter((node) => node != null)
+            .slice(0, limit > 0 ? limit : undefined)}
+        />
+        <TreeListOptionsSelectors />
+      </TreeListOptionsProvider>
     </div>
   );
 };

--- a/src/views/common/TreeList/treelist.css
+++ b/src/views/common/TreeList/treelist.css
@@ -4,7 +4,8 @@
     margin: 0px auto;
 }
 
-ul.TreeListRoot, ul.TreeListBranch{
+ul.TreeListRoot,
+ul.TreeListBranch {
     list-style: none;
     margin: 0;
     position: relative;
@@ -42,7 +43,8 @@ ul.TreeListBranch::before {
     z-index: -1;
 }
 
-.TreeListExpandBranch, .TreeListSeeAllDescendents {
+.TreeListExpandBranch,
+.TreeListSeeAllDescendents {
     display: inline-block;
     margin: 0;
     margin-right: 4px;
@@ -62,4 +64,16 @@ ul.TreeListBranch::before {
 
 .TreeListExpandBranch:hover {
     background-color: var(--color-button-hover);
+}
+
+.TreeListPopulation {
+    display: inline-block;
+    position: absolute;
+    right: 0;
+}
+
+.TreeListOptions {
+    margin-top: 1em;
+    display: flex;
+    gap: .5em
 }


### PR DESCRIPTION
I'm preparing a report to IANA on oddities in language families and while I was collecting data I saw a few opportunities to fix the data and add visual display toggles.

Changes:
* Koreanic & Japonic languages removed from the disputed Altaic language family. Japonic ones moved to the `jpx` family
* Creoles and Pidgins that weren't grouped in the Creoles & Pidgins group are moved into it now
* Added 4 visual options for the hierarchy view. They are not tracked by page parameters since they are specific to that view. I'm happy to file other tasks to iterate on that.

|View|Before|After
|--|--|--
|[French languages](https://translation-commons.github.io/lang-nav/?view=Hierarchy&languageSchema=ISO&searchBy=English+Name&searchString=French)|<img width="385" alt="Screenshot 2025-06-06 at 16 10 31" src="https://github.com/user-attachments/assets/f855cfa1-22fd-43e0-a906-a81cf65fa1d7" />|<img width="608" alt="Screenshot 2025-06-06 at 16 12 04" src="https://github.com/user-attachments/assets/97f92301-6d31-49b2-9830-5f00121b4f59" />
|[Altaic languages](https://translation-commons.github.io/lang-nav/?view=Hierarchy&languageSchema=ISO&searchString=altaic)|<img width="350" alt="Screenshot 2025-06-06 at 16 08 20" src="https://github.com/user-attachments/assets/dcd02c2c-7e0e-4457-90dd-294c1630745d" />|<img width="197" alt="Screenshot 2025-06-06 at 16 08 11" src="https://github.com/user-attachments/assets/aacc30e5-8f8e-4cec-b260-4fc593443696" />
|[Japanese languages](https://translation-commons.github.io/lang-nav/?view=Hierarchy&languageSchema=ISO&searchString=Japanese)|<img width="303" alt="Screenshot 2025-06-06 at 16 08 53" src="https://github.com/user-attachments/assets/8441b62e-4ac2-484d-8c32-ae0e8b905bce" />|<img width="311" alt="Screenshot 2025-06-06 at 16 08 49" src="https://github.com/user-attachments/assets/5b65b502-6114-4f3c-97d8-a2a812b325e1" />


You can also see the effects of using different toggles

|View|Before|After|After(Toggled)
|--|--|--|--
|[French languages](https://translation-commons.github.io/lang-nav/?view=Hierarchy&languageSchema=ISO&searchBy=English+Name&searchString=French)|<img width="385" alt="Screenshot 2025-06-06 at 16 10 31" src="https://github.com/user-attachments/assets/f855cfa1-22fd-43e0-a906-a81cf65fa1d7" />|<img width="608" alt="Screenshot 2025-06-06 at 16 12 04" src="https://github.com/user-attachments/assets/97f92301-6d31-49b2-9830-5f00121b4f59" />|<img width="617" alt="Screenshot 2025-06-06 at 16 12 19" src="https://github.com/user-attachments/assets/2f35941f-40e9-47c3-8aa1-db5ba6b5b657" />
