### PR TITLE
Censuses: Add population difference

### DIFF
--- a/src/generic/PercentageDifference.tsx
+++ b/src/generic/PercentageDifference.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+import Hoverable from './Hoverable';
+import { numberToFixedUnlessSmall } from './numberUtils';
+
+export const PercentageDifference: React.FC<{
+  percentNew: number;
+  percentOld?: number;
+}> = ({ percentNew, percentOld }) => {
+  if (percentOld == null) {
+    return (
+      <span className="unsupported" style={{ fontSize: '0.8em' }}>
+        n/a
+      </span>
+    );
+  }
+
+  const percentagePointDifference = percentNew - percentOld;
+
+  // Usually we can just compare regular values. However, if the percent is particularly low,
+  // we still want to enable comparison. For example, if an indigenous community has 1000
+  // speakers (<0.001% of the country), and this census estimates 2000 -- that's a big difference,
+  // even though of the territory it is small.
+  const relativeDifference = (percentagePointDifference * 100) / percentOld;
+  let renderedAmount = numberToFixedUnlessSmall(percentagePointDifference) + ' pp';
+
+  // Styling differences
+  let color = 'var(--color-text-secondary)';
+  let fontSize = '1em';
+  if (Math.abs(relativeDifference) > 10) {
+    // Great difference, >10% compared to the old value
+    if (percentagePointDifference > 0) {
+      color = 'var(--color-text-blue)';
+      renderedAmount = '+' + renderedAmount;
+    } else {
+      color = 'var(--color-text-orange)';
+    }
+  } else {
+    fontSize = '0.8em';
+    if (Math.abs(relativeDifference) > 1) {
+      // Minor difference
+      if (percentagePointDifference > 0) {
+        renderedAmount = '+' + renderedAmount;
+      }
+    } else if (percentagePointDifference == 0) {
+      // Identical values
+      renderedAmount = '=';
+    } else {
+      // Negligible difference
+      renderedAmount = '≈';
+    }
+  }
+
+  return (
+    <Hoverable
+      style={{ textDecoration: 'none', cursor: 'help' }}
+      hoverContent={
+        <>
+          <label>Old value:</label>
+          {numberToFixedUnlessSmall(percentOld)}%
+          <br />
+          <label>New value:</label>
+          {numberToFixedUnlessSmall(percentNew)}%
+          <br />
+          <label>Relative difference:</label>
+          {relativeDifference > 0 && '+'}
+          {numberToFixedUnlessSmall(relativeDifference)}%
+          <br />
+          <label>Percentage point difference:</label>
+          {percentagePointDifference > 0 && '+'}
+          {numberToFixedUnlessSmall(percentagePointDifference)} pp
+          <br />
+        </>
+      }
+    >
+      <span style={{ color, fontSize }}>{renderedAmount}</span>
+    </Hoverable>
+  );
+};

--- a/src/generic/numberUtils.tsx
+++ b/src/generic/numberUtils.tsx
@@ -28,7 +28,7 @@ export function numberToSigFigs(num: number, sigFigs: number): number {
  * this function will still show small numbers.
  */
 export function numberToFixedUnlessSmall(value: number, precision: number = 2): string {
-  if (value > 1) {
+  if (Math.abs(value) > 1) {
     return value.toFixed(precision);
   }
   return value.toPrecision(precision);

--- a/src/views/census/TableOfLanguagesInCensus.tsx
+++ b/src/views/census/TableOfLanguagesInCensus.tsx
@@ -4,6 +4,7 @@ import { usePageParams } from '../../controls/PageParamsContext';
 import { useDataContext } from '../../data/DataContext';
 import Hoverable from '../../generic/Hoverable';
 import { numberToFixedUnlessSmall } from '../../generic/numberUtils';
+import { PercentageDifference } from '../../generic/PercentageDifference';
 import { CensusData } from '../../types/CensusTypes';
 import { LocaleData } from '../../types/DataTypes';
 import { ObjectType, SortBy } from '../../types/PageParamTypes';
@@ -60,6 +61,16 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
     [locales],
   );
 
+  const getPopulationDifference = useCallback(
+    (mockedLocale: LocaleData): React.ReactNode => (
+      <PercentageDifference
+        percentNew={mockedLocale.populationSpeakingPercent || 0}
+        percentOld={locales[mockedLocale.ID]?.populationSpeakingPercent}
+      />
+    ),
+    [locales],
+  );
+
   return (
     <div>
       {langsNotFound.length > 0 && (
@@ -99,6 +110,15 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
               </Hoverable>
             ),
             render: getActualLocaleInfoButton,
+          },
+          {
+            label: (
+              <Hoverable hoverContent="The difference the population estimate in this census is compared to the canonical locale population estimate. This compares percentages, so 8.3% - 10.4% is -2.1 pp (percentage points). Values are colored if the difference is more than 10%.">
+                Population Difference
+              </Hoverable>
+            ),
+            render: getPopulationDifference,
+            isNumeric: true,
           },
         ]}
       />

--- a/src/views/locale/LocaleCard.tsx
+++ b/src/views/locale/LocaleCard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { usePageParams } from '../../controls/PageParamsContext';
+import { numberToFixedUnlessSmall } from '../../generic/numberUtils';
 import { LocaleData } from '../../types/DataTypes';
 import ObjectTitle from '../common/ObjectTitle';
 
@@ -28,7 +29,8 @@ const LocaleCard: React.FC<Props> = ({ locale }) => {
         {']'}
         {populationSpeakingPercent != null && (
           <div>
-            {populationSpeakingPercent.toFixed(1)}% of {territory?.territoryType ?? 'territory'}
+            {numberToFixedUnlessSmall(populationSpeakingPercent)}% of{' '}
+            {territory?.territoryType ?? 'territory'}
           </div>
         )}
       </div>

--- a/src/views/locale/LocaleDetails.tsx
+++ b/src/views/locale/LocaleDetails.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { numberToFixedUnlessSmall, numberToSigFigs } from '../../generic/numberUtils';
+import { PercentageDifference } from '../../generic/PercentageDifference';
 import { LocaleData } from '../../types/DataTypes';
 import HoverableObjectName from '../common/HoverableObjectName';
 
@@ -139,6 +140,7 @@ const LocalePopulationSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
                 <th>Population</th>
                 <th>Percent</th>
                 <th>Census</th>
+                <th>Difference</th>
               </tr>
             </thead>
             <tbody>
@@ -154,6 +156,12 @@ const LocalePopulationSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
                     </td>
                     <td>
                       <HoverableObjectName object={censusEstimate.census} />
+                    </td>
+                    <td style={{ textAlign: 'right' }}>
+                      <PercentageDifference
+                        percentNew={censusEstimate.populationPercent}
+                        percentOld={populationSpeakingPercent}
+                      />
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
This change adds a component that shows differences in percentages. It uses that new component to show the different of imported census data from the canonical locale population in the Census Details as well as the Locale Details.

|View|Before|After
|--|--|--
|[Locale Details for hi_IN](https://translation-commons.github.io/lang-nav/?objectType=Locale&view=Details&objectID=hin_IN&limit=0)|<img width="464" alt="Screenshot 2025-06-11 at 12 54 53" src="https://github.com/user-attachments/assets/895dbd8d-6c02-40f8-9c4a-4ba346666a94" />|<img width="542" alt="Screenshot 2025-06-11 at 12 54 58" src="https://github.com/user-attachments/assets/2de8bfda-feb5-4084-9e93-c801f25a38ad" />
|[Census Details for India 2011 L1](https://translation-commons.github.io/lang-nav/?objectType=Locale&view=Details&objectID=hin_IN&limit=0)|<img width="785" alt="Screenshot 2025-06-11 at 12 54 34" src="https://github.com/user-attachments/assets/7b14e6e6-ea9e-4e00-9900-32673d0fda5b" />|<img width="826" alt="Screenshot 2025-06-11 at 12 54 12" src="https://github.com/user-attachments/assets/8cb81551-9152-4fc1-a3ec-b7e1e474c5df" />

See the tooltips:
<img width="293" alt="Screenshot 2025-06-11 at 12 55 24" src="https://github.com/user-attachments/assets/0ebb3f93-2968-47ad-b97c-7d01c400a41b" />
<img width="354" alt="Screenshot 2025-06-11 at 12 55 20" src="https://github.com/user-attachments/assets/f3f5fe1b-0ace-45a0-b8d9-65cf81639988" />
