### PR TITLE
Censuses: Add better citation when possible

### DIFF
--- a/public/data/census/ca2021.tsv
+++ b/public/data/census/ca2021.tsv
@@ -6,6 +6,8 @@
 #columnName		Total - Single and multiple responses of knowledge of languages	Total - Single and multiple responses of language spoken at home	Total - Single and multiple mother tongue responses	Total - Single and multiple responses of language spoken at home6, 7
 #datePublished		2022-08-17	2025-02-19	2024-10-23	2022-08-17
 #citation		Statistics Canada. Table 98-10-0294-01  Knowledge of Indigenous languages by single and multiple knowledge of languages responses and Indigenous language acquisition: Canada, provinces and territories	Statistics Canada. Table 98-10-0299-01  Indigenous language spoken at home by single and multiple responses of language spoken at home: Canada, provinces and territories	Statistics Canada. Table 98-10-0298-01  Indigenous mother tongue by single and multiple mother tongue responses and Indigenous identity: Canada, provinces and territories, census divisions and census subdivisions	Statistics Canada. Table 98-10-0201-01  Language spoken at home by single and multiple responses of language spoken at home and mother tongue: Canada, provinces and territories, census metropolitan areas and census agglomerations with parts
+#collectorName	Statistics Canada				
+#collectorType	Government				
 #dateAccessed	2025-05-30				
 #geographicScope	Whole Country				
 #age	0+				

--- a/src/views/common/HoverableObject.tsx
+++ b/src/views/common/HoverableObject.tsx
@@ -41,6 +41,9 @@ const HoverableObject: React.FC<Props> = ({ object, children }) => {
           {view == 'Details'
             ? 'change page to see the details for:'
             : 'open modal with more information for:'}
+          <div>
+            <strong>{object.type}</strong>
+          </div>
           {getHoverContent()}
         </>
       }

--- a/src/views/locale/LocaleCard.tsx
+++ b/src/views/locale/LocaleCard.tsx
@@ -5,7 +5,8 @@ import { numberToFixedUnlessSmall } from '../../generic/numberUtils';
 import { LocaleData } from '../../types/DataTypes';
 import ObjectTitle from '../common/ObjectTitle';
 
-import { getOfficialLabel, getPopulationCitation } from './LocaleStrings';
+import LocaleCensusCitation from './LocaleCensusCitation';
+import { getOfficialLabel } from './LocaleStrings';
 
 interface Props {
   locale: LocaleData;
@@ -25,7 +26,7 @@ const LocaleCard: React.FC<Props> = ({ locale }) => {
         <h4>Speakers</h4>
         {populationSpeaking.toLocaleString()}
         {' ['}
-        {getPopulationCitation(locale)}
+        <LocaleCensusCitation locale={locale} size="short" />
         {']'}
         {populationSpeakingPercent != null && (
           <div>

--- a/src/views/locale/LocaleCensusCitation.tsx
+++ b/src/views/locale/LocaleCensusCitation.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import { LocaleData, PopulationSourceCategory } from '../../types/DataTypes';
+import HoverableObject from '../common/HoverableObject';
+
+type Props = {
+  locale: LocaleData;
+  size?: 'short' | 'full';
+};
+
+const LocaleCensusCitation: React.FC<Props> = ({ locale, size = 'full' }) => {
+  const { populationCensus } = locale;
+  if (populationCensus != null) {
+    const { yearCollected, collectorName, collectorType } = populationCensus;
+    let name = collectorName;
+    if (name == null || name === '' || size === 'short') {
+      switch (collectorType) {
+        case 'Government':
+          name = locale.territory?.nameDisplay ?? locale.territoryCode;
+          break;
+        default:
+          name = collectorType;
+      }
+    }
+    return (
+      <HoverableObject object={populationCensus}>
+        {name} {yearCollected}
+      </HoverableObject>
+    );
+  }
+  if (size === 'short') {
+    switch (locale.populationSource) {
+      case PopulationSourceCategory.Census:
+      case PopulationSourceCategory.Study:
+      case PopulationSourceCategory.Ethnologue:
+        break; // Use the name below
+      case PopulationSourceCategory.EDL:
+        return 'EDL';
+      case PopulationSourceCategory.NoSource:
+        return <span className="unsupported">no source</span>;
+      case PopulationSourceCategory.OtherCitation:
+      case PopulationSourceCategory.GeneralizedData:
+      case PopulationSourceCategory.Fallback:
+      case PopulationSourceCategory.Aggregated:
+        return <span className="unsupported">rough estimate</span>;
+    }
+  }
+
+  switch (locale.populationSource) {
+    case PopulationSourceCategory.Census:
+      return (locale.territory?.nameDisplay ?? locale.territoryCode) + ' census'; // TODO add year
+    case PopulationSourceCategory.Study:
+      return 'Study'; // TODO add author, year
+    case PopulationSourceCategory.Ethnologue:
+      return 'Ethnologue'; // TODO add year
+    case PopulationSourceCategory.EDL:
+      return 'Endangered Languages Project'; // TODO add year
+    case PopulationSourceCategory.OtherCitation:
+      return 'weak source, better citation needed'; // TODO add info about the weak source
+    case PopulationSourceCategory.GeneralizedData:
+      return 'added up from other cited estimates';
+    case PopulationSourceCategory.Fallback:
+      return 'upper bound based on language / country populations';
+    case PopulationSourceCategory.NoSource:
+      return 'no source';
+    case PopulationSourceCategory.Aggregated:
+      return 'aggregated from other sources';
+  }
+};
+
+export default LocaleCensusCitation;

--- a/src/views/locale/LocaleDetails.tsx
+++ b/src/views/locale/LocaleDetails.tsx
@@ -5,7 +5,8 @@ import { PercentageDifference } from '../../generic/PercentageDifference';
 import { LocaleData } from '../../types/DataTypes';
 import HoverableObjectName from '../common/HoverableObjectName';
 
-import { getOfficialLabel, getPopulationCitation } from './LocaleStrings';
+import LocaleCensusCitation from './LocaleCensusCitation';
+import { getOfficialLabel } from './LocaleStrings';
 
 type Props = {
   locale: LocaleData;
@@ -103,7 +104,7 @@ const LocalePopulationSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
         <label>Speakers:</label>
         {populationSpeaking.toLocaleString()}
         {' ['}
-        {getPopulationCitation(locale)}
+        <LocaleCensusCitation locale={locale} />
         {']'}
       </div>
       {populationSpeakingPercent != null && (

--- a/src/views/locale/LocaleStrings.tsx
+++ b/src/views/locale/LocaleStrings.tsx
@@ -1,4 +1,4 @@
-import { LocaleData, OfficialStatus, PopulationSourceCategory } from '../../types/DataTypes';
+import { LocaleData, OfficialStatus } from '../../types/DataTypes';
 
 export function getLocaleName(locale: LocaleData): string {
   const languageName = locale.language?.nameDisplay ?? locale.languageCode;
@@ -9,30 +9,6 @@ export function getLocaleName(locale: LocaleData): string {
   return (
     languageName + ' (' + [territoryName, scriptName, variantName].filter(Boolean).join(', ') + ')'
   );
-}
-
-// TODO Add full Citation information, including URLs, potentially as a hovercard
-export function getPopulationCitation(locale: LocaleData): string {
-  switch (locale.populationSource) {
-    case PopulationSourceCategory.Census:
-      return locale.territoryCode + ' census'; // TODO add year
-    case PopulationSourceCategory.Study:
-      return 'Study'; // TODO add author, year
-    case PopulationSourceCategory.Ethnologue:
-      return 'Ethnologue'; // TODO add year
-    case PopulationSourceCategory.EDL:
-      return 'Endangered Languages Project'; // TODO add year
-    case PopulationSourceCategory.OtherCitation:
-      return 'weak source, better citation needed'; // TODO add info about the weak source
-    case PopulationSourceCategory.GeneralizedData:
-      return 'added up from other cited estimates';
-    case PopulationSourceCategory.Fallback:
-      return 'upper bound based on language / country populations';
-    case PopulationSourceCategory.NoSource:
-      return 'no source';
-    case PopulationSourceCategory.Aggregated:
-      return 'aggregated from other sources';
-  }
 }
 
 export function getOfficialLabel(officialStatus: OfficialStatus): string {

--- a/src/views/locale/LocaleTable.tsx
+++ b/src/views/locale/LocaleTable.tsx
@@ -6,6 +6,8 @@ import { SortBy } from '../../types/PageParamTypes';
 import { CodeColumn, InfoButtonColumn, NameColumn } from '../common/table/CommonColumns';
 import ObjectTable from '../common/table/ObjectTable';
 
+import LocaleCensusCitation from './LocaleCensusCitation';
+
 const LocaleTable: React.FC = () => {
   const { locales } = useDataContext();
 
@@ -20,6 +22,10 @@ const LocaleTable: React.FC = () => {
           render: (object) => object.populationSpeaking,
           isNumeric: true,
           sortParam: SortBy.Population,
+        },
+        {
+          label: 'Population Source',
+          render: (object) => <LocaleCensusCitation locale={object} size="short" />,
         },
         InfoButtonColumn,
       ]}


### PR DESCRIPTION
Now that we are starting to import files from the censuses, we can provide proper citations. This change improves the legibility of the citations and it also adds a HoverCard interaction so people can click to learn more about the census.

|What|Difference|Before|After|
|--|--|--|--|
|[Locale Cards](https://translation-commons.github.io/lang-nav/?objectType=Locale)|Citations shorted, and when it comes from a census there is now a way to hover over to get more details.|<img width="1319" alt="Screenshot 2025-06-17 at 15 25 13" src="https://github.com/user-attachments/assets/16b4be30-2570-4f5f-aac7-db5db864c9d8" />|<img width="1317" alt="Screenshot 2025-06-17 at 15 25 03" src="https://github.com/user-attachments/assets/58476c2d-7578-419a-8b59-cea84cb262e6" />
|[Locale Table](https://translation-commons.github.io/lang-nav/?objectType=Locale&view=Table)|There's a new column that includes the citation now|<img width="721" alt="Screenshot 2025-06-17 at 15 28 34" src="https://github.com/user-attachments/assets/0fe38491-7e91-45f4-a8bc-c4218adfc2af" />|<img width="775" alt="Screenshot 2025-06-17 at 15 28 42" src="https://github.com/user-attachments/assets/e33c0b76-91e0-4896-be25-b99fa0ab3ed4" />
|[Locale Details, in this case for English (Canada)](https://translation-commons.github.io/lang-nav/?objectType=Locale&view=Details&objectID=eng_CA)|When possible, it includes the hoverable citation. In this case we have more space so we can cite the organization that did the collection itself rather than just the shorter country name.|<img width="535" alt="Screenshot 2025-06-17 at 15 29 44" src="https://github.com/user-attachments/assets/3a021448-bbf1-4145-9766-960beef7bd59" />|<img width="524" alt="Screenshot 2025-06-17 at 15 29 40" src="https://github.com/user-attachments/assets/f107ef7a-a66d-4228-ab96-5ec28d185910" />


Also note that by default I added the object type in HoverCards. Since we're using more and more hovercards it can be hard to know what you are hovering over -- like going from a Language to a Locale, or a Locale to a Census, etc. It's handy to know what kind of data the hovercard is.
<img width="500" alt="Screenshot 2025-06-17 at 15 24 11" src="https://github.com/user-attachments/assets/6c9e231e-f0a7-47be-89f5-e9f56eee2eba" />

