### PR TITLE
Census: Add Spain census data (#88)

### DIFF
--- a/public/data/census/README.md
+++ b/public/data/census/README.md
@@ -87,6 +87,8 @@ More is better, but also if you don't have a value, leave it empty. For instance
 * **Population surveyed**
   * `geographicScope`: The geographic scope of the data (e.g., "whole country", "mainland -- without dependencies")
   * `age`: The age of the people surveyed (e.g., "0+" for  "all ages", "15+" for 15 years and older)
+  * `nationality`: The nationality of the people surveyed (e.g., "citizens", "residents", "visitors")
+  * `residentLocation`: How people are associated with geographic areas "de jure" (where people are registered) or "de facto" (where people are currently living or visiting at the time of census)
   * `notes`: Any additional notes about the data
   * `responsesPerIndividual`: The number of responses per individual (e.g., "1+" for one or more responses, "1" if every individual has exactly one response)
     * If the number of responses is 1 then we can add up the data without worrying about double counting.

--- a/public/data/census/es2021.tsv
+++ b/public/data/census/es2021.tsv
@@ -1,0 +1,60 @@
+#codeDisplay																			ea2021.1	ea2021.2	ea2021.3	ea2021.4	ic2021.1	ic2021.2	ic2021.3	ic2021.4
+#nameDisplay		Spain 2021 Understands	Spain 2021 Writes	Spain 2021 Speaks	Spain 2021 Reads	Spain 2021 Understands (from C.A.)	Spain 2021 Writes (from C.A.)	Spain 2021 Speaks (from C.A.)	Spain 2021 Reads (from C.A.)	Spain 2021 Uses with Friends	Spain 2021 Uses at Work	Spain 2021 Uses with Family	Spain 2021 L1	Spain 2021 L1 v2	Spain 2021 Understands (ISO Country)	Spain 2021 Writes (ISO Country)	Spain 2021 Speaks (ISO Country)	Spain 2021 Reads (ISO Country)	Ceuta & Melilla 2021 Understands	Ceuta & Melilla 2021 Writes	Ceuta & Melilla 2021 Speaks	Ceuta & Melilla 2021 Reads	Canary Islands 2021 Understands	Canary Islands 2021 Writes	Canary Islands 2021 Speaks	Canary Islands 2021 Reads
+#isoRegionCode	ES														ES	ES	ES	ES	EA	EA	EA	EA	IC	IC	IC	IC
+#yearCollected	2021																									
+#url	https://www.ine.es/dynt3/inebase/index.htm?padre=8981&capsel=9008													https://en.wikipedia.org/wiki/Languages_of_Spain#2021_Census_data												
+#tableName		Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Frecuencia y lugar de uso de las principales lenguas	Frecuencia y lugar de uso de las principales lenguas	Frecuencia y lugar de uso de las principales lenguas	Lengua inicial													
+#columnName		Entiende	Escribe	Habla	Lee	Entiende	Escribe	Habla	Lee	Con amigos	En el trabajo	En familia	Personas según la lengua inicial más frecuente 		Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas	Nivel de conocimiento de las principales lenguas
+#datePublished	2023-10-10																									
+#collectorName	Instituto Nacional de Estadística 																									
+#collectorType	Government																									
+#citation	Instituto Nacional de Estadística. (2023). Censo de población y viviendas 2021. https://www.ine.es/censos2021/																									
+#dateAccessed	2025-06-24																									
+#geographicScope	Country and dependencies														Strict ISO 3166 bounds	Strict ISO 3166 bounds	Strict ISO 3166 bounds	Strict ISO 3166 bounds	Strict ISO 3166 bounds	Strict ISO 3166 bounds	Strict ISO 3166 bounds	Strict ISO 3166 bounds	Strict ISO 3166 bounds	Strict ISO 3166 bounds	Strict ISO 3166 bounds	Strict ISO 3166 bounds
+#age	2+																									
+#gender	Any																									
+#modality		Understands	Written	Spoken	Reading	Understands	Written	Spoken	Reading	Uses	Uses	Uses	Uses	Uses	Understands	Written	Spoken	Reading	Understands	Written	Spoken	Reading	Understands	Written	Spoken	Reading
+#proficiency		Good	Good	Good	Good	Good	Good	Good	Good	Always or Frequently	Always or Frequently	Always or Frequently			Good	Good	Good	Good	Good	Good	Good	Good	Good	Good	Good	Good
+#domain										Friends	Work	Family														
+#acquisitionOrder	Any												L1	L1												
+#responsesPerIndividual	1+																									
+#sampleRate	1																									
+#eligiblePopulation	46,181,637					46181636	46181636	46181636	46181636						43812921	43812921	43812921	43812921	161776	161776	161776	161776	2206939	2206939	2206939	2206939
+#nationality	Residents																									
+#residentLocation	De jure																									
+#notes						Summed up from separate reports by autonomous communities, not all communities reported all languages	Summed up from separate reports by autonomous communities, not all communities reported all languages	Summed up from separate reports by autonomous communities, not all communities reported all languages	Summed up from separate reports by autonomous communities, not all communities reported all languages				There are 3 rows that list Spanish plus another language. The individual row for Spanish is Spanish (only) and the number can be added to the rows with combined data	Aggregated by wikipedia	Summed up from the separate reports for the different autonomous communities, not counting Canarias (IC) or Ceuta & Melilla (EA)	Summed up from the separate reports for the different autonomous communities, not counting Canarias (IC) or Ceuta & Melilla (EA)	Summed up from the separate reports for the different autonomous communities, not counting Canarias (IC) or Ceuta & Melilla (EA)	Summed up from the separate reports for the different autonomous communities, not counting Canarias (IC) or Ceuta & Melilla (EA)								
+Language Code	Language Name	Spain 2021 Understands	Spain 2021 Writes	Spain 2021 Speaks	Spain 2021 Reads	Spain 2021 Understands (from C.A.)	Spain 2021 Writes (from C.A.)	Spain 2021 Speaks (from C.A.)	Spain 2021 Reads (from C.A.)	Spain 2021 Uses with Friends	Spain 2021 Uses at Work	Spain 2021 Uses with Family	Spain 2021 L1	Spain 2021 L1 v2	Spain 2021 Understands (ISO Country)	Spain 2021 Writes (ISO Country)	Spain 2021 Speaks (ISO Country)	Spain 2021 Reads (ISO Country)	Ceuta & Melilla 2021 Understands	Ceuta & Melilla 2021 Writes	Ceuta & Melilla 2021 Speaks	Ceuta & Melilla 2021 Reads	Canary Islands 2021 Understands	Canary Islands 2021 Writes	Canary Islands 2021 Speaks	Canary Islands 2021 Reads
+deu	Alemán					188,109	148,447	174,486	173,147				137,105	205,289	110,039	84,042	101,572	100727					78070	64405	72914	72420
+ara	Árabe	779,813	573,338	753,635	597,265	697,822	510,450	675,802	531,719	456,012	191,729	672,261	781,611	1,001,792	670,183	496,828	649,317	517287	27639	13622	26485	14432				
+ast	Asturiano					33,547	21,365	27,931	29,035					26,584	33,547	21,365	27,931	29035								
+spa	Castellano	44,917,121	41,896,526	44,330,689	42,752,478	44,917,120	41,896,524	44,330,691	42,752,477	40,045,225	39,280,989	39,549,712	34,477,775	37,650,425	42,643,478	39,760,627	42,076,127	40580244	155231	142363	152761	143567	2118411	1993534	2101803	2028666
+cat	Catalán	6,789,149	4,978,097	5,821,954	6,118,297	6,528,698	4,841,514	5,640,195	5,893,373	4,121,088	4,563,375	3,784,621	2,436,227	4,846,933	6,528,698	4,841,514	5,640,195	5893373								
+bale1256	Catalán (mallorquín, menorquín, ibicenco o formenterense)	894,445	594,610	713,736	773,810	887,059	591,139	708,310	767,686	484,390	525,280	465,854			887,059	591,139	708,310	767686								
+cat	#Balearic is a subset of Catalan but its counted separately without overlap so this row is meant to add it back to Catalan	894,445	594,610	713,736	773,810	887,059	591,139	708,310	767,686	484,390	525,280	465,854			887,059	591,139	708,310	767686								
+rif	Chelja, tarifit o rifeño					1,109	433	1,028	518										1109	433	1028	518				
+eus	Euskera	1,222,832	998,873	1,077,052	1,120,645	1,180,618	964,064	1,044,349	1,079,864	643,390	790,299	634,529		658,030	1,180,618	964,064	1,044,349	1079864								
+fra	Francés	2,058,695	1,581,891	1,698,525	2,172,612	2,058,695	1,581,892	1,698,527	2,172,613	266,978	519,389	177,138	207,865	432,209	1,975,049	1,516,202	1,626,655	2088153	5538	4797	4475	5893	78108	60893	67397	78567
+glg	Gallego	2,701,703	2,070,859	2,383,258	2,423,219	2,464,191	1,944,301	2,205,960	2,222,305	1,496,272	1,392,533	1,583,190	1,099,969	1,742,974	2,464,191	1,944,301	2,205,960	2222305								
+eng	Inglés	7,863,966	7,232,965	6,775,432	8,292,034	7,863,967	7,232,966	6,775,433	8,292,036	1,085,058	3,359,177	886,936	394,459	730,251	7,409,155	6,823,159	6,374,293	7826347	13801	13370	12010	14975	441011	396437	389130	450714
+ita	Italiano	571,483	365,706	464,559	516,153	321,062	212,354	266,267	285,845	113,148	99,370	163,175	125,870	188,651	254,846	159,848	206,234	226225					66216	52506	60033	59620
+por	Portugués					198,189	119,759	149,596	177,373					251,497	198,189	119,759	149,596	177373								
+ron	Rumano	509,179	454,271	486,222	469,176	316,825	278,516	301,441	289,189	168,602	107,504	274,144	585,908	664,407	316,825	278,516	301,441	289189								
+ber	Tamazight					4,837	1,348	4,373	1,620					59,797					4837	1348	4373	1620				
+cat_valencia	Valenciano	3,554,471	2,086,277	2,601,812	2,912,386	3,471,814	2,048,728	2,550,884	2,846,078	1,412,010	936,662	1,424,152	799,619		3,471,814	2,048,728	2,550,884	2846078								
+cat	#Valencian is a subset of Catalan but its counted separately without overlap so this row is meant to add it back to Catalan	3,554,471	2,086,277	2,601,812	2,912,386	3,471,814	2,048,728	2,550,884	2,846,078	1,412,010	936,662	1,424,152	799,619		3,471,814	2,048,728	2,550,884	2846078								
+und	Otra												3,435,571	347,363												
+spa	#Castellano y árabe												144,977													
+ara	#Castellano y árabe												144,977													
+spa	#Castellano y catalán												943,590													
+cat	#Castellano y catalán												943,590													
+spa	#Castellano y gallego												611,091													
+glg	#Castellano y gallego												611,091													
+zho	Chinese													221,331												
+bul	Bulgarian													152,037												
+rus	Russian													147,864												
+ukr	Ukrainian													76,297												
+pol	Polish													61,926												
+nld	Dutch													51,672												
+urd	Urdu													50,983												
+grn	Guarani													36,807												
+wol	Wolof													34,581												

--- a/src/data/CensusData.tsx
+++ b/src/data/CensusData.tsx
@@ -12,6 +12,7 @@ const CENSUS_FILENAMES = [
   'np2021', // Nepal 2021 Census
   'data.un.org/au', // Australia Censuses downloaded from UN data portal
   'data.un.org/ru', // Russia 2010 Census downloaded from UN data portal
+  'es2021', // Spain 2021 Census
   // Add more census files here as needed
 ];
 
@@ -152,7 +153,8 @@ function parseCensusImport(fileInput: string, filename: string): CensusImport {
 
     // The language name is in the second column
     let languageName = parts[1].trim();
-    if (languageName !== '') {
+    if (languageName !== '' && !languageName.startsWith('#')) {
+      // Leave out language names that start with a # -- that's a single it may not be a good name to add
       // If it starts with a number, that may just be a row number, so clip that out
       const match = languageName.match(/^\d+(.*)/);
       if (match != null) {

--- a/src/types/CensusTypes.tsx
+++ b/src/types/CensusTypes.tsx
@@ -28,6 +28,8 @@ export interface CensusData extends ObjectBase {
   geographicScope?: string; // eg. Whole Country, Mainland, Territories
   age?: string; // eg. 0+, 4+,
   gender?: string; // Any, Male, Female
+  nationality?: string; // eg. Citizens, Residents, Visitors
+  residentLocation?: string; // eg. de jure (people located by their usual residence), de facto (people located immediately, including visitors)
   sampleRate?: number; // eg. .1, .25, 1 (for 10%, 25%, 100%)
   respondingPopulation?: number; // The number of individuals who gave a response about their language
   responsesPerIndividual?: string; // eg. 1, 1+, 2+

--- a/src/types/LanguageTypes.tsx
+++ b/src/types/LanguageTypes.tsx
@@ -38,8 +38,10 @@ export enum LanguageModality {
   MostlySpoken = 'Mostly Spoken (but also written)',
   Spoken = 'Spoken',
   Sign = 'Sign',
+  Understands = 'Understands',
+  Reading = 'Reading',
+  Uses = 'Uses',
 }
-
 
 export enum LanguageScope {
   Family = 'Family',

--- a/src/views/common/table/tableStyles.css
+++ b/src/views/common/table/tableStyles.css
@@ -10,6 +10,12 @@
     border-spacing: 12px 0px;
 }
 
+thead {
+    position: sticky;
+    top: 0;
+    background-color: var(--color-background);
+}
+
 .numeric {
     /* align right for both LTR and RTL views */
     text-align: right;


### PR DESCRIPTION
This change adds the census data from the 2021 Spanish census. The website is in Spanish but I could read it and I was very happy by all of the breakdowns available. I got a bit carried away adding various different slides of the data.

While I added the various interpretations I also added more enum values for `LanguageModality` to compliment what we get in the census, added the ability to suppress language name rows using a `#` symbol if the row is just there for context, added sticky headers to the object table.

|What|Before|After|
|--|--|--|
|[Censuses table](https://translation-commons.github.io/lang-nav/?objectType=Census&view=Table) lots of new census records (scrolled down to see them since they only have a handful of langauges)|<img width="517" alt="Screenshot 2025-06-27 at 08 39 21" src="https://github.com/user-attachments/assets/724391b1-a45d-42a0-ae53-076ad4e1e9e0" />|<img width="563" alt="Screenshot 2025-06-27 at 08 24 33" src="https://github.com/user-attachments/assets/3b2ec66c-a047-4412-a062-964a267e8cd9" />
|[Basque (Spain)](https://translation-commons.github.io/lang-nav/?view=Details&objectType=Locale&objectID=eus_ES) -- many new counts|<img width="428" alt="Screenshot 2025-06-27 at 08 38 58" src="https://github.com/user-attachments/assets/67128421-1877-4f0f-a7f2-19db820d08c3" />|<img width="627" alt="Screenshot 2025-06-27 at 08 26 53" src="https://github.com/user-attachments/assets/d3591bd4-6a05-4c26-8f86-a2eeb6e04113" />|
|[Catalan (Spain)](https://translation-commons.github.io/lang-nav/?view=Details&objectType=Locale&objectID=eus_ES) -- many new counts, note the range of them|<img width="430" alt="Screenshot 2025-06-27 at 08 39 06" src="https://github.com/user-attachments/assets/6b891375-b373-4740-8d53-ee77c7f50a15" />|<img width="617" alt="Screenshot 2025-06-27 at 08 33 27" src="https://github.com/user-attachments/assets/7c114bc4-40b8-4024-bad4-a4ad0d93eba8" />|
