### PR TITLE
Update ObjectType Selector

### DIFF
--- a/src/controls/selectors/ObjectTypeSelector.tsx
+++ b/src/controls/selectors/ObjectTypeSelector.tsx
@@ -18,6 +18,8 @@ const ObjectTypeSelector: React.FC = () => {
       updatePageParams({
         objectType,
         view: objectAmbiguousViews.includes(view) ? View.CardList : view,
+        searchString: undefined,
+        page: 1,
       });
     },
     [updatePageParams, view],


### PR DESCRIPTION
When a user switches between object types (e.g., from Census to Locale), we want to:

Clear any previous search filters (searchString: undefined)

Reset pagination to the first page (page: 1)