### PR TITLE
Added column filtering for tables #91

### DIFF
--- a/src/views/census/TableOfAllCensuses.tsx
+++ b/src/views/census/TableOfAllCensuses.tsx
@@ -16,6 +16,7 @@ const TableOfAllCensuses: React.FC = () => {
         CodeColumn,
         NameColumn,
         {
+          key: 'Languages',
           label: 'Languages',
           render: (census) => census.languageCount,
           isNumeric: true,

--- a/src/views/census/TableOfAllCensuses.tsx
+++ b/src/views/census/TableOfAllCensuses.tsx
@@ -17,7 +17,6 @@ const TableOfAllCensuses: React.FC = () => {
         NameColumn,
         {
           key: 'Languages',
-          label: 'Languages',
           render: (census) => census.languageCount,
           isNumeric: true,
           sortParam: SortBy.Population,

--- a/src/views/census/TableOfLanguagesInCensus.tsx
+++ b/src/views/census/TableOfLanguagesInCensus.tsx
@@ -86,6 +86,7 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
         columns={[
           CodeColumn,
           {
+            key: 'Languages',
             label: 'Language',
             render: (object) => (
               <HoverableObject object={object.language}>
@@ -98,12 +99,14 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
             sortParam: SortBy.Name,
           },
           {
+            key: 'Population',
             label: 'Population',
             render: (loc) => loc.populationSpeaking,
             isNumeric: true,
             sortParam: SortBy.Population,
           },
           {
+            key: 'PercentWithinTerritory',
             label: 'Percent within Territory',
             render: (loc) =>
               loc.populationSpeakingPercent != null
@@ -112,11 +115,13 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
             isNumeric: true,
           },
           {
+            key: 'Scope',
             label: 'Scope',
             render: (loc) => loc.language?.scope,
             isNumeric: false,
           },
           {
+            key: 'LocaleEntry',
             label: (
               <Hoverable hoverContent="The locale dataset has a canonical population estimate and may refer to estimates from multiple censuses. Hover for the canonical locale entry or click to see more details. The locale dataset does not contain every combination of language + territory so some may not be found.">
                 Locale Entry
@@ -125,6 +130,7 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
             render: getActualLocaleInfoButton,
           },
           {
+            key: 'PopulationDifference',
             label: (
               <Hoverable hoverContent="The difference the population estimate in this census is compared to the canonical locale population estimate. This compares percentages, so 8.3% - 10.4% is -2.1 pp (percentage points). Values are colored if the difference is more than 10%.">
                 Population Difference

--- a/src/views/census/TableOfLanguagesInCensus.tsx
+++ b/src/views/census/TableOfLanguagesInCensus.tsx
@@ -87,7 +87,6 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
           CodeColumn,
           {
             key: 'Languages',
-            label: 'Language',
             render: (object) => (
               <HoverableObject object={object.language}>
                 <ObjectFieldHighlightedByPageSearch
@@ -100,14 +99,12 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
           },
           {
             key: 'Population',
-            label: 'Population',
             render: (loc) => loc.populationSpeaking,
             isNumeric: true,
             sortParam: SortBy.Population,
           },
           {
-            key: 'PercentWithinTerritory',
-            label: 'Percent within Territory',
+            key: 'Percent Within Territory',
             render: (loc) =>
               loc.populationSpeakingPercent != null
                 ? numberToFixedUnlessSmall(loc.populationSpeakingPercent) + '%'
@@ -116,12 +113,11 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
           },
           {
             key: 'Scope',
-            label: 'Scope',
             render: (loc) => loc.language?.scope,
             isNumeric: false,
           },
           {
-            key: 'LocaleEntry',
+            key: 'Locale Entry',
             label: (
               <Hoverable hoverContent="The locale dataset has a canonical population estimate and may refer to estimates from multiple censuses. Hover for the canonical locale entry or click to see more details. The locale dataset does not contain every combination of language + territory so some may not be found.">
                 Locale Entry
@@ -130,7 +126,7 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
             render: getActualLocaleInfoButton,
           },
           {
-            key: 'PopulationDifference',
+            key: 'Population Difference',
             label: (
               <Hoverable hoverContent="The difference the population estimate in this census is compared to the canonical locale population estimate. This compares percentages, so 8.3% - 10.4% is -2.1 pp (percentage points). Values are colored if the difference is more than 10%.">
                 Population Difference

--- a/src/views/common/table/CommonColumns.tsx
+++ b/src/views/common/table/CommonColumns.tsx
@@ -7,7 +7,6 @@ import { TableColumn } from './ObjectTable';
 
 export const CodeColumn: TableColumn<ObjectData> = {
   key: 'ID',
-  label: 'ID',
   render: (object) => (
     <ObjectFieldHighlightedByPageSearch object={object} field={SearchableField.Code} />
   ),
@@ -16,7 +15,6 @@ export const CodeColumn: TableColumn<ObjectData> = {
 
 export const NameColumn: TableColumn<ObjectData> = {
   key: 'Name',
-  label: 'Name',
   render: (object) => (
     <ObjectFieldHighlightedByPageSearch object={object} field={SearchableField.EngName} />
   ),
@@ -25,7 +23,6 @@ export const NameColumn: TableColumn<ObjectData> = {
 
 export const InfoButtonColumn: TableColumn<ObjectData> = {
   key: 'Info',
-  label: 'Info',
   render: (object) => (
     <HoverableObject object={object}>
       <button className="InfoButton">&#x24D8;</button>

--- a/src/views/common/table/CommonColumns.tsx
+++ b/src/views/common/table/CommonColumns.tsx
@@ -6,6 +6,7 @@ import { ObjectFieldHighlightedByPageSearch } from '../ObjectField';
 import { TableColumn } from './ObjectTable';
 
 export const CodeColumn: TableColumn<ObjectData> = {
+  key: 'ID',
   label: 'ID',
   render: (object) => (
     <ObjectFieldHighlightedByPageSearch object={object} field={SearchableField.Code} />
@@ -14,6 +15,7 @@ export const CodeColumn: TableColumn<ObjectData> = {
 };
 
 export const NameColumn: TableColumn<ObjectData> = {
+  key: 'Name',
   label: 'Name',
   render: (object) => (
     <ObjectFieldHighlightedByPageSearch object={object} field={SearchableField.EngName} />
@@ -22,6 +24,7 @@ export const NameColumn: TableColumn<ObjectData> = {
 };
 
 export const InfoButtonColumn: TableColumn<ObjectData> = {
+  key: 'Info',
   label: 'Info',
   render: (object) => (
     <HoverableObject object={object}>

--- a/src/views/common/table/ObjectTable.tsx
+++ b/src/views/common/table/ObjectTable.tsx
@@ -72,8 +72,11 @@ function ObjectTable<T extends ObjectData>({ objects, columns }: Props<T>) {
         nOverall={objects.length}
         objectType={objects[0]?.type}
       />
-      <div className="column-toggler" style={{ margin: '1rem 0', display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
-        <strong>Show/Hide Columns:</strong>
+      <details className="column-toggler" style={{ margin: '1rem 0', gap: '1rem' }}>
+        <summary className="collapsible-summary" style={{ cursor: 'pointer' }}>
+          {currentlyVisibleColumns.length}/{columns.length} columns visible, click here to toggle.
+        </summary>
+        <div className="column-toggler" style={{ margin: '1rem 0', display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
         {columns.map(column => (
           <label key={column.key} style={{ cursor: 'pointer' }}>
             <input
@@ -85,7 +88,8 @@ function ObjectTable<T extends ObjectData>({ objects, columns }: Props<T>) {
             {column.label ?? column.key}
           </label>
         ))}
-      </div>
+        </div>
+      </details>
 
       <table className="ObjectTable">
         <thead>

--- a/src/views/common/table/tableStyles.css
+++ b/src/views/common/table/tableStyles.css
@@ -30,3 +30,17 @@
     background-color: var(--color-button-primary);
     color: var(--color-background);
 }
+
+.collapsible-summary {
+  padding: 4px 8px; 
+  border-radius: 4px;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.collapsible-summary:hover {
+  background-color: #2a2a2a; 
+}
+
+.collapsible-summary:focus {
+  outline: none;
+}

--- a/src/views/language/LanguageTable.tsx
+++ b/src/views/language/LanguageTable.tsx
@@ -24,19 +24,16 @@ const LanguageTable: React.FC = () => {
         NameColumn,
         {
           key: 'Scope',
-          label: 'Scope',
           render: (lang) => lang.scope ?? lang.scope,
         },
         {
           key: 'Population', 
-          label: 'Population',
           render: (lang) => lang.populationCited,
           isNumeric: true,
           sortParam: SortBy.Population,
         },
         {
-          key: 'InternetTechnologies',
-          label: 'Internet Technologies',
+          key: 'Internet Technologies',
           render: (lang) => <CLDRCoverageInfo object={lang} />,
         },
         InfoButtonColumn,

--- a/src/views/language/LanguageTable.tsx
+++ b/src/views/language/LanguageTable.tsx
@@ -23,16 +23,19 @@ const LanguageTable: React.FC = () => {
         CodeColumn,
         NameColumn,
         {
+          key: 'Scope',
           label: 'Scope',
           render: (lang) => lang.scope ?? lang.scope,
         },
         {
+          key: 'Population', 
           label: 'Population',
           render: (lang) => lang.populationCited,
           isNumeric: true,
           sortParam: SortBy.Population,
         },
         {
+          key: 'InternetTechnologies',
           label: 'Internet Technologies',
           render: (lang) => <CLDRCoverageInfo object={lang} />,
         },

--- a/src/views/locale/LocaleTable.tsx
+++ b/src/views/locale/LocaleTable.tsx
@@ -23,14 +23,12 @@ const LocaleTable: React.FC = () => {
         NameColumn,
         {
           key: 'Population',
-          label: 'Population',
           render: (object) => object.populationSpeaking,
           isNumeric: true,
           sortParam: SortBy.Population,
         },
         {
           key: 'Population Source',
-          label: 'Population Source',
           render: (object) => <LocaleCensusCitation locale={object} size="short" />,
         },
         InfoButtonColumn,

--- a/src/views/locale/LocaleTable.tsx
+++ b/src/views/locale/LocaleTable.tsx
@@ -22,12 +22,14 @@ const LocaleTable: React.FC = () => {
         CodeColumn,
         NameColumn,
         {
+          key: 'Population',
           label: 'Population',
           render: (object) => object.populationSpeaking,
           isNumeric: true,
           sortParam: SortBy.Population,
         },
         {
+          key: 'Population Source',
           label: 'Population Source',
           render: (object) => <LocaleCensusCitation locale={object} size="short" />,
         },

--- a/src/views/territory/TerritoryTable.tsx
+++ b/src/views/territory/TerritoryTable.tsx
@@ -17,19 +17,22 @@ const TerritoryTable: React.FC = () => {
       columns={[
         CodeColumn,
         NameColumn,
-        {
+        { 
+          key : 'Population',
           label: 'Population',
           render: (object) => object.population,
           isNumeric: true,
           sortParam: SortBy.Population,
         },
         {
+          key: 'Literacy',
           label: 'Literacy',
           render: (object) =>
             object.literacyPercent != null ? object.literacyPercent.toFixed(1) + '%' : null,
           isNumeric: true,
         },
         {
+          key: 'Languages',
           label: 'Languages',
           render: (object) =>
             object.locales.length > 0 && (
@@ -48,6 +51,7 @@ const TerritoryTable: React.FC = () => {
           isNumeric: true,
         },
         {
+          key: 'Biggest Language',
           label: 'Biggest Language',
           render: (object) =>
             object.locales.length > 0 && (
@@ -59,6 +63,7 @@ const TerritoryTable: React.FC = () => {
             ),
         },
         {
+          key: 'Type',
           label: 'Type',
           render: (object) => object.territoryType,
         },

--- a/src/views/territory/TerritoryTable.tsx
+++ b/src/views/territory/TerritoryTable.tsx
@@ -19,21 +19,18 @@ const TerritoryTable: React.FC = () => {
         NameColumn,
         { 
           key : 'Population',
-          label: 'Population',
           render: (object) => object.population,
           isNumeric: true,
           sortParam: SortBy.Population,
         },
         {
           key: 'Literacy',
-          label: 'Literacy',
           render: (object) =>
             object.literacyPercent != null ? object.literacyPercent.toFixed(1) + '%' : null,
           isNumeric: true,
         },
         {
           key: 'Languages',
-          label: 'Languages',
           render: (object) =>
             object.locales.length > 0 && (
               <Hoverable
@@ -52,7 +49,6 @@ const TerritoryTable: React.FC = () => {
         },
         {
           key: 'Biggest Language',
-          label: 'Biggest Language',
           render: (object) =>
             object.locales.length > 0 && (
               <HoverableObjectName
@@ -64,7 +60,6 @@ const TerritoryTable: React.FC = () => {
         },
         {
           key: 'Type',
-          label: 'Type',
           render: (object) => object.territoryType,
         },
         InfoButtonColumn,

--- a/src/views/writingsystem/WritingSystemTable.tsx
+++ b/src/views/writingsystem/WritingSystemTable.tsx
@@ -16,6 +16,7 @@ const WritingSystemTable: React.FC = () => {
         CodeColumn,
         NameColumn,
         {
+          key: 'Population',
           label: 'Population',
           render: (object) => object.populationUpperBound,
           isNumeric: true,

--- a/src/views/writingsystem/WritingSystemTable.tsx
+++ b/src/views/writingsystem/WritingSystemTable.tsx
@@ -17,7 +17,6 @@ const WritingSystemTable: React.FC = () => {
         NameColumn,
         {
           key: 'Population',
-          label: 'Population',
           render: (object) => object.populationUpperBound,
           isNumeric: true,
           sortParam: SortBy.Population,


### PR DESCRIPTION
This pull request implements the column filtering feature for the `ObjectTable` component, resolving Issue [#91](https://github.com/Translation-Commons/lang-nav/issues/91).

**Changes made:**
- Updated the `TableColumn` interface in `ObjectTable.tsx` to require a unique `key` property.
- Added state management within `ObjectTable.tsx` to track and toggle column visibility.
- Added a checkbox UI to allow users to control which columns are shown.
- Updated all existing tables (`Languages`, `Censuses`, etc.) to provide the required `key` for each column definition.

Fixes #91 
