### PR TITLE
Censuses: Show potential locales

### DIFF
--- a/src/data/DataParsing.tsx
+++ b/src/data/DataParsing.tsx
@@ -82,6 +82,7 @@ export function parseLocaleLine(line: string): LocaleData {
     codeDisplay: parts[0],
     // All locales from the locale input file should be at the country or smaller level
     scope: variantTag ? ScopeLevel.Parts : ScopeLevel.Individuals,
+    localeSource: 'regularInput',
 
     nameDisplay: parts[1],
     nameEndonym: parts[2] != '' ? parts[2] : undefined,

--- a/src/data/IANAData.tsx
+++ b/src/data/IANAData.tsx
@@ -65,6 +65,7 @@ export function addIANAVariantLocales(
         variantTag: variant.tag,
         nameDisplay: variant.name,
         scope: ScopeLevel.Parts,
+        localeSource: 'IANA',
         codeDisplay: localeCode,
         type: ObjectType.Locale,
         populationSource: PopulationSourceCategory.NoSource,

--- a/src/data/PopulationData.tsx
+++ b/src/data/PopulationData.tsx
@@ -75,7 +75,10 @@ function recomputeRegionalLocalePopulation(territory: TerritoryData): void {
         // potentially different years, we use the population percent of the contained locales
         // and compute the current population based on the latest population of the territory.
         (sum, loc) =>
-          sum + ((loc.populationSpeakingPercent || 0) * (loc.territory?.population || 0)) / 100,
+          sum +
+          Math.round(
+            ((loc.populationSpeakingPercent || 0) * (loc.territory?.population || 0)) / 100,
+          ),
         0,
       ) || 0;
     // The percent needs to be aggregated relative to the size of the child territory in the parent territory
@@ -83,8 +86,10 @@ function recomputeRegionalLocalePopulation(territory: TerritoryData): void {
       locale.containedLocales?.reduce(
         (sum, loc) =>
           sum +
-          ((loc.populationSpeakingPercent || 0) * (loc.territory?.population || 0)) /
-            territory.population,
+          Math.round(
+            ((loc.populationSpeakingPercent || 0) * (loc.territory?.population || 0)) /
+              territory.population,
+          ),
         0,
       ) || 0;
   });

--- a/src/types/DataTypes.tsx
+++ b/src/types/DataTypes.tsx
@@ -133,6 +133,7 @@ export interface LocaleData extends ObjectBase {
   ID: BCP47LocaleCode;
   codeDisplay: BCP47LocaleCode; // Changes based on the language schema
   scope: ScopeLevel;
+  localeSource: 'regularInput' | 'IANA' | 'census'; // Whether this locale is listed in the the regular locale list or not
 
   nameDisplay: string;
   nameEndonym?: string;

--- a/src/types/ScopeLevel.tsx
+++ b/src/types/ScopeLevel.tsx
@@ -43,7 +43,7 @@ export function getLanguageScopeLevel(lang: LanguageData): ScopeLevel {
   return ScopeLevel.Other;
 }
 
-function getTerritoryScopeLevel(territory: TerritoryData): ScopeLevel {
+export function getTerritoryScopeLevel(territory: TerritoryData): ScopeLevel {
   switch (territory.territoryType) {
     case TerritoryType.World:
     case TerritoryType.Continent:

--- a/src/views/ViewReports.tsx
+++ b/src/views/ViewReports.tsx
@@ -4,6 +4,7 @@ import { usePageParams } from '../controls/PageParamsContext';
 
 import DubiousLanguages from './language/DubiousLanguages';
 import LanguagesWithIdenticalNames from './language/LanguagesWithIdenticalNames';
+import PotentialLocales from './locale/PotentialLocales';
 
 /**
  * A page that shows tips about problems in the data that may need to be addressed.
@@ -13,13 +14,18 @@ const ViewReports: React.FC = () => {
   const { objectType } = usePageParams();
 
   let reports: React.ReactNode = 'There are no reports for this object type.';
-  if (objectType === 'Language') {
-    reports = (
-      <>
-        <DubiousLanguages />
-        <LanguagesWithIdenticalNames key="1" />
-      </>
-    );
+  switch (objectType) {
+    case 'Locale':
+      reports = <PotentialLocales />;
+      break;
+    case 'Language':
+      reports = (
+        <>
+          <DubiousLanguages />
+          <LanguagesWithIdenticalNames key="1" />
+        </>
+      );
+      break;
   }
 
   return <div className="ViewReports">{reports}</div>;

--- a/src/views/ViewReports.tsx
+++ b/src/views/ViewReports.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { usePageParams } from '../controls/PageParamsContext';
+import { ObjectType } from '../types/PageParamTypes';
 
 import DubiousLanguages from './language/DubiousLanguages';
 import LanguagesWithIdenticalNames from './language/LanguagesWithIdenticalNames';
@@ -13,22 +14,29 @@ import PotentialLocales from './locale/PotentialLocales';
 const ViewReports: React.FC = () => {
   const { objectType } = usePageParams();
 
-  let reports: React.ReactNode = 'There are no reports for this object type.';
+  return (
+    <div className="ViewReports">
+      <ReportsForObjectType objectType={objectType} />
+    </div>
+  );
+};
+
+const ReportsForObjectType: React.FC<{ objectType: ObjectType }> = ({ objectType }) => {
   switch (objectType) {
-    case 'Locale':
-      reports = <PotentialLocales />;
-      break;
-    case 'Language':
-      reports = (
+    case ObjectType.Locale:
+      return <PotentialLocales />;
+    case ObjectType.Language:
+      return (
         <>
           <DubiousLanguages />
           <LanguagesWithIdenticalNames key="1" />
         </>
       );
-      break;
+    case ObjectType.Census:
+    case ObjectType.Territory:
+    case ObjectType.WritingSystem:
+      return <div>There are no reports for this object type.</div>;
   }
-
-  return <div className="ViewReports">{reports}</div>;
 };
 
 export default ViewReports;

--- a/src/views/common/table/ObjectTable.tsx
+++ b/src/views/common/table/ObjectTable.tsx
@@ -73,14 +73,11 @@ function ObjectTable<T extends ObjectData>({ objects, columns }: Props<T>) {
         nOverall={objects.length}
         objectType={objects[0]?.type}
       />
-      <details className="column-toggler" style={{ margin: '.5em 0', gap: '.5em 1em' }}>
-        <summary className="collapsible-summary" style={{ cursor: 'pointer' }}>
+      <details style={{ margin: '.5em 0 1em 0', gap: '.5em 1em' }}>
+        <summary style={{ cursor: 'pointer' }}>
           {currentlyVisibleColumns.length}/{columns.length} columns visible, click here to toggle.
         </summary>
-        <div
-          className="column-toggler"
-          style={{ margin: '1rem 0', display: 'flex', flexWrap: 'wrap', gap: '1em' }}
-        >
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '.5em' }}>
           {columns.map((column) => (
             <label key={column.key} style={{ cursor: 'pointer' }}>
               <input

--- a/src/views/common/table/tableStyles.css
+++ b/src/views/common/table/tableStyles.css
@@ -37,16 +37,16 @@ thead {
   color: var(--color-background);
 }
 
-.collapsible-summary {
+summary {
   padding: 4px 8px;
   border-radius: 4px;
   transition: background-color 0.2s ease-in-out;
 }
 
-.collapsible-summary:hover {
+summary:hover {
   background-color: var(--color-button-hover);
 }
 
-.collapsible-summary:focus {
+summary:focus {
   outline: none;
 }

--- a/src/views/language/DubiousLanguages.tsx
+++ b/src/views/language/DubiousLanguages.tsx
@@ -26,7 +26,7 @@ const DubiousLanguages: React.FC = () => {
     .filter((lang) => lang.codeDisplay.match('xx.-|^[0-9]'));
 
   return (
-    <details>
+    <details className="collapsible-report">
       <summary>Dubious languages ({languages.length})</summary>
       These languages have strange language codes and maybe should be removed from the list of
       languages. Some possibilities are:

--- a/src/views/language/LanguagesWithIdenticalNames.tsx
+++ b/src/views/language/LanguagesWithIdenticalNames.tsx
@@ -44,7 +44,7 @@ const LanguagesWithIdenticalNames: React.FC = () => {
   );
 
   return (
-    <details>
+    <details className="collapsible-report">
       <summary>Languages with identical names ({Object.keys(langsWithDupNames).length})</summary>
       The following languages have identical names. This can happen when merging data from multiple
       sources. It gets confusing to find the right language when names overlap. To fix this we

--- a/src/views/locale/PotentialLocales.tsx
+++ b/src/views/locale/PotentialLocales.tsx
@@ -2,20 +2,26 @@ import React, { useMemo } from 'react';
 
 import Selector from '../../controls/components/Selector';
 import TextInput from '../../controls/components/TextInput';
+import { getScopeFilter } from '../../controls/filter';
 import { usePageParams } from '../../controls/PageParamsContext';
 import { useDataContext } from '../../data/DataContext';
+import { numberToFixedUnlessSmall } from '../../generic/numberUtils';
+import { CensusData } from '../../types/CensusTypes';
 import { BCP47LocaleCode, LocaleData, PopulationSourceCategory } from '../../types/DataTypes';
-import { ObjectType, SortBy } from '../../types/PageParamTypes';
-import { getLanguageScopeLevel, ScopeLevel } from '../../types/ScopeLevel';
-import { CodeColumn, InfoButtonColumn, NameColumn } from '../common/table/CommonColumns';
+import { LanguageCode, LanguageData } from '../../types/LanguageTypes';
+import { LocaleSeparator, ObjectType, SortBy } from '../../types/PageParamTypes';
+import { getLanguageScopeLevel, getTerritoryScopeLevel, ScopeLevel } from '../../types/ScopeLevel';
+import HoverableObjectName from '../common/HoverableObjectName';
+import { InfoButtonColumn } from '../common/table/CommonColumns';
 import ObjectTable from '../common/table/ObjectTable';
 
 import LocaleCensusCitation from './LocaleCensusCitation';
 
 type PartitionedLocales = {
-  indigenous: LocaleData[];
-  largePopulation: LocaleData[];
-  maybeRedundant: LocaleData[];
+  largest: LocaleData[];
+  largestButDescendentExists: LocaleData[];
+  significant: LocaleData[];
+  significantButMaybeRedundant: LocaleData[];
 };
 
 const PotentialLocales: React.FC = () => {
@@ -25,12 +31,169 @@ const PotentialLocales: React.FC = () => {
     languagesBySchema: { Inclusive: languages },
   } = useDataContext();
   const { localeSeparator } = usePageParams();
-  const [percentThreshold, setPercentThreshold] = React.useState(0.01);
+  const [percentThreshold, setPercentThreshold] = React.useState(0.05);
+  const potentialLocales = getPotentialLocales(
+    Object.values(censuses),
+    locales,
+    languages,
+    localeSeparator,
+    percentThreshold,
+  );
 
+  return (
+    <div>
+      <h1>Potential Locales</h1>
+      <p>
+        This page lists locales from Census data that are not in the list of defined locales. There
+        are too many possible combinations of language + territory + variation information, so the
+        number of actualized locales is smaller than the possible ones. However ones that appear
+        here may be worth considering.
+      </p>
+      <Selector
+        selectorLabel="Percent Threshold:"
+        selectorDescription={`Limit results by the minimum percent population in a territory that uses the language.`}
+      >
+        <TextInput
+          inputStyle={{ width: '3em' }}
+          getSuggestions={async () => [
+            { searchString: '0.001', label: '0.001%' },
+            { searchString: '0.005', label: '0.005%' },
+            { searchString: '0.01', label: '0.01%' },
+            { searchString: '0.05', label: '0.05%' },
+            { searchString: '0.1', label: '0.1%' },
+            { searchString: '0.5', label: '0.5%' },
+            { searchString: '1', label: '1%' },
+            { searchString: '5', label: '5%' },
+            { searchString: '10', label: '10%' },
+          ]}
+          onChange={(percent: string) => setPercentThreshold(Number(percent))}
+          placeholder=""
+          value={Number.isNaN(percentThreshold) ? '' : percentThreshold.toString()}
+        />
+      </Selector>
+
+      <SubReport title="Largest Populations" locales={potentialLocales.largest}>
+        Of all of the census records collected so far, these locales have more people speaking it
+        than the other instantiated locales. This likely means the world population is indigenous to
+        this country. However, since we do not have full census coverage it is very possible that
+        the language is native to a different country without an inputted census record.
+        Additionally, some of these locales are macrolanguages or constituents thereof, so we may
+        actually have the language but represented by a different aspect.
+      </SubReport>
+      <SubReport
+        title="Largest ** with caveats"
+        locales={potentialLocales.largestButDescendentExists}
+      >
+        The locales represent the largest population of a language in a territory, but a language or
+        dialect of that locale is already present for that locale, so it may not be necessary or it
+        may be a language family not consistently listed in other censuses.
+        <div style={{ height: '0.5em' }} />
+        For example, the Canadian [CA] census includes Indo-European [ine] as an entry. Since few
+        censuses include Indo-European, it looks as if ine_CA is native to Canada. That is a data
+        coverage issue -- not a real origin for the language group. Indo-European contains other
+        languages that are listed in other parts of the same census like Italian eng_CA.
+      </SubReport>
+      <SubReport title="Significant Population" locales={potentialLocales.significant}>
+        This is the list of locales native to other countries, but with a significant population in
+        other countries.
+      </SubReport>
+      <SubReport
+        title="Significant ** with caveats"
+        locales={potentialLocales.significantButMaybeRedundant}
+      >
+        Locales in this table reflect languages that already have other locales in territories but a
+        consistent of the same language not necessarily the same locale. For example, they may have
+        an entry with a writing system specified.
+      </SubReport>
+    </div>
+  );
+};
+
+const SubReport: React.FC<{
+  children: React.ReactNode;
+  locales: LocaleData[];
+  title: string;
+}> = ({ title, children, locales }) => {
+  const filterByScope = getScopeFilter();
+  return (
+    <details className="collapsible-report">
+      <summary>
+        {title} ({locales.filter(filterByScope).length})
+      </summary>
+      {children}
+      <PotentialLocalesTable locales={locales} />
+    </details>
+  );
+};
+
+const PotentialLocalesTable: React.FC<{
+  locales: LocaleData[];
+  showRelatedLocales?: boolean;
+}> = ({ locales }) => {
+  return (
+    <ObjectTable<LocaleData>
+      objects={locales}
+      columns={[
+        {
+          key: 'Potential Locale',
+          render: (object) => <HoverableObjectName object={object} labelSource="code" />,
+          sortParam: SortBy.Code,
+        },
+        {
+          key: 'Language',
+          render: (object) =>
+            object.language ? (
+              <HoverableObjectName object={object.language} />
+            ) : (
+              object.languageCode
+            ),
+          sortParam: SortBy.Name,
+        },
+        {
+          key: 'Population',
+          render: (object) => object.populationSpeaking,
+          isNumeric: true,
+          sortParam: SortBy.Population,
+        },
+        {
+          key: '% in Territory',
+          render: (object) =>
+            object.populationSpeakingPercent &&
+            numberToFixedUnlessSmall(object.populationSpeakingPercent),
+          isNumeric: true,
+        },
+        {
+          key: 'Population Source',
+          render: (object) => <LocaleCensusCitation locale={object} size="short" />,
+        },
+        InfoButtonColumn,
+        {
+          key: 'Related Locale',
+          render: (object) => {
+            const descendentLocale = object.containedLocales ? object.containedLocales[0] : null;
+            return (
+              descendentLocale && (
+                <HoverableObjectName object={descendentLocale} labelSource="code" />
+              )
+            );
+          },
+        },
+      ]}
+    />
+  );
+};
+
+function getPotentialLocales(
+  censuses: CensusData[],
+  locales: Record<BCP47LocaleCode, LocaleData>,
+  languages: Record<LanguageCode, LanguageData>,
+  localeSeparator: LocaleSeparator,
+  percentThreshold: number,
+): PartitionedLocales {
   // Iterate through all censuses and find locales that are not listed
   const allMissingLocales = useMemo(
     () =>
-      Object.values(censuses).reduce<Record<BCP47LocaleCode, LocaleData>>((missing, census) => {
+      censuses.reduce<Record<BCP47LocaleCode, LocaleData>>((missing, census) => {
         Object.entries(census.languageEstimates ?? {})?.forEach(([langID, populationEstimate]) => {
           const localeID = langID + '_' + census.isoRegionCode;
           const lang = languages[langID];
@@ -44,6 +207,7 @@ const PotentialLocales: React.FC = () => {
 
           if (missing[localeID] == null) {
             missing[localeID] = {
+              localeSource: 'census',
               type: ObjectType.Locale,
               ID: langID + '_' + census.isoRegionCode,
               codeDisplay: lang.codeDisplay + localeSeparator + census.isoRegionCode,
@@ -51,7 +215,7 @@ const PotentialLocales: React.FC = () => {
               language: lang,
               nameDisplay: lang.nameDisplay,
               names: lang.names,
-              scope: lang.scope != null ? getLanguageScopeLevel(lang) : ScopeLevel.Other,
+              scope: getLanguageScopeLevel(lang) ?? ScopeLevel.Other,
 
               territory: census.territory,
               territoryCode: census.isoRegionCode,
@@ -81,117 +245,109 @@ const PotentialLocales: React.FC = () => {
     [censuses, languages, locales, localeSeparator, percentThreshold],
   );
 
-  // Maybe break it down by territory instead.
-  // For each territory, find the listed locales & find the potential locales.
-
-  // Partition the locales into 3 types:
-  // 1. Locales where the language is indigenous
-  // 2. Locales who has no other equivalent in the same territory
-  // 3. All others, may not be a priority
-  const partitionedLocales = Object.values(allMissingLocales).reduce<PartitionedLocales>(
-    (partitions, locale) => {
-      const siblingLocales = locale.language?.locales ?? [];
-      // If the language is not listed in any locale in the territory.
-      if (!siblingLocales.some((l) => l.territoryCode === locale.territoryCode)) {
-        if (siblingLocales.some((l) => l.populationSpeaking < locale.populationSpeaking)) {
-          partitions.largePopulation.push(locale);
-        } else {
-          partitions.indigenous.push(locale);
-        }
-      } else {
-        // A similar locale already exists in the territory, this may not be necessary or maybe the locales need to be clarified
-        partitions.maybeRedundant.push(locale);
+  // Group all locales (actual & missing) by language
+  const allLocalesByLanguage = useMemo(() => {
+    return [...Object.values(locales), ...Object.values(allMissingLocales)].reduce<
+      Record<LanguageCode, LocaleData[]>
+    >((byLanguage, locale) => {
+      if (
+        locale.territory == null ||
+        getTerritoryScopeLevel(locale.territory) === ScopeLevel.Groups
+      ) {
+        return byLanguage; // Skip regional locales, censuses are not at the regional level
       }
 
-      return partitions;
-    },
-    {
-      indigenous: [],
-      largePopulation: [],
-      maybeRedundant: [],
-    },
-  );
+      const langCode = locale.languageCode;
+      if (!byLanguage[langCode]) {
+        byLanguage[langCode] = [];
+      }
+      byLanguage[langCode].push(locale);
+      return byLanguage;
+    }, {});
+  }, [allMissingLocales]);
 
-  return (
-    <div>
-      <h1>Potential Locales</h1>
-      <p>
-        This page will list locales from Census data that are not in the list of defined locales.
-        There are too many possible combinations of language + territory + variation information, so
-        the number of actualized locales is smaller than the possible ones. However ones that appear
-        here may be worth considering.
-      </p>
-      <Selector
-        selectorLabel="Percent Threshold:"
-        selectorDescription={`Limit results by the minimum percent population in a territory that uses the language.`}
-      >
-        <TextInput
-          inputStyle={{ width: '3em' }}
-          getSuggestions={async () => [
-            { searchString: '0.001', label: '0.001%' },
-            { searchString: '0.005', label: '0.005%' },
-            { searchString: '0.01', label: '0.01%' },
-            { searchString: '0.05', label: '0.05%' },
-            { searchString: '0.1', label: '0.1%' },
-            { searchString: '0.5', label: '0.5%' },
-            { searchString: '1', label: '1%' },
-            { searchString: '5', label: '5%' },
-            { searchString: '10', label: '10%' },
-          ]}
-          onChange={(percent: string) => setPercentThreshold(Number(percent))}
-          placeholder=""
-          value={Number.isNaN(percentThreshold) ? '' : percentThreshold.toString()}
-        />
-      </Selector>
-      <details className="collapsible-report">
-        <summary>Indigenous ({partitionedLocales.indigenous.length})</summary>
-        Of all of the census records collected so far, these locales have more people speaking it
-        than the other instantiated locales. This likely means the world population is indigenous to
-        this country. However, since we do not have full census coverage it is very possible that
-        the language is native to a different country without an inputted census record.
-        Additionally, some of these locales are macrolanguages or constituents thereof, so we may
-        actually have the language but represented by a different aspect.
-        <LocaleTable locales={partitionedLocales.indigenous} />
-      </details>
-      <details className="collapsible-report">
-        <summary>Large Population ({partitionedLocales.largePopulation.length})</summary>
-        This is the list of locales native to other countries, but with a significant population in
-        other countries.
-        <LocaleTable locales={partitionedLocales.largePopulation} />
-      </details>
-      <details className="collapsible-report">
-        <summary>Likely Redundant ({partitionedLocales.maybeRedundant.length})</summary>
-        Locales in this table reflect languages that already exist in territories but not in this
-        specific locale ID. For example, they may have an entry with a writing system specified.
-        <LocaleTable locales={partitionedLocales.maybeRedundant} />
-      </details>
-    </div>
-  );
-};
+  return Object.values(allLocalesByLanguage).reduce<PartitionedLocales>(partitionPotentialLocales, {
+    largest: [],
+    largestButDescendentExists: [],
+    significant: [],
+    significantButMaybeRedundant: [],
+  });
+}
 
-const LocaleTable: React.FC<{
-  locales: LocaleData[];
-}> = ({ locales }) => {
+function partitionPotentialLocales(
+  partitionedLocales: PartitionedLocales,
+  localesOfTheSameLanguage: LocaleData[],
+): PartitionedLocales {
+  // Iterate through the languages, finding the locale with the largest population.
+  // These are probably but not necessarily indigenous.
+  const localesSorted = localesOfTheSameLanguage.sort((a, b) => {
+    return (b.populationSpeaking ?? 0) - (a.populationSpeaking ?? 0);
+  });
+  const largestLocale = localesSorted.reduce((max, locale) => {
+    return locale.populationSpeaking > max.populationSpeaking ? locale : max;
+  }, localesSorted[0]);
+  // If the largest locale is from the census data (not in the regular input list) then suggest it as a locale here
+  if (largestLocale.localeSource === 'census') {
+    // Some censuses include language families -- that's nice complementary data but its usually not a priority
+    const descendentLocaleInTerritory = findLocaleDescendingFromThisLocale(
+      largestLocale,
+      largestLocale.language?.childLanguages,
+    );
+    if (!descendentLocaleInTerritory) {
+      largestLocale.containedLocales = [localesSorted[1]];
+      partitionedLocales.largest.push(largestLocale);
+    } else {
+      largestLocale.containedLocales = [descendentLocaleInTerritory];
+      partitionedLocales.largestButDescendentExists.push(largestLocale);
+    }
+  }
+
+  // Go through the other locales that are not the largest but come from census sources and add them to the other category.
+  localesOfTheSameLanguage
+    .filter((locale) => locale !== largestLocale && locale.localeSource === 'census')
+    .forEach((locale) => {
+      const descendentLocaleInTerritory = findLocaleDescendingFromThisLocale(
+        locale,
+        locale.language?.childLanguages,
+      );
+      if (!descendentLocaleInTerritory) {
+        locale.containedLocales = [localesSorted[0]];
+        partitionedLocales.significant.push(locale);
+      } else {
+        locale.containedLocales = [descendentLocaleInTerritory];
+        partitionedLocales.significantButMaybeRedundant.push(locale);
+      }
+    });
+
+  return partitionedLocales;
+}
+
+function findLocaleDescendingFromThisLocale(
+  locale: LocaleData,
+  languages?: LanguageData[],
+): LocaleData | null {
+  const directDescendent = findLocaleWithSameTerritory(locale, languages);
+  const recursiveDescendents =
+    languages?.map((lang) => findLocaleDescendingFromThisLocale(locale, lang.childLanguages)) ?? [];
   return (
-    <ObjectTable<LocaleData>
-      objects={locales}
-      columns={[
-        CodeColumn,
-        NameColumn,
-        {
-          key: 'Population',
-          render: (object) => object.populationSpeaking,
-          isNumeric: true,
-          sortParam: SortBy.Population,
-        },
-        {
-          key: 'Population Source',
-          render: (object) => <LocaleCensusCitation locale={object} size="short" />,
-        },
-        InfoButtonColumn,
-      ]}
-    />
+    [directDescendent, ...recursiveDescendents].filter(Boolean).sort((a, b) => {
+      return (b?.populationSpeaking ?? 0) - (a?.populationSpeaking ?? 0);
+    })[0] ?? null
   );
-};
+}
+
+function findLocaleWithSameTerritory(
+  locale: LocaleData,
+  languages?: LanguageData[],
+): LocaleData | null {
+  return (
+    languages
+      ?.map(
+        (lang) =>
+          lang.locales.filter((loc) => loc.territoryCode === locale.territoryCode)[0] ?? null,
+      )
+      .filter(Boolean)[0] ?? null
+  );
+}
 
 export default PotentialLocales;

--- a/src/views/locale/PotentialLocales.tsx
+++ b/src/views/locale/PotentialLocales.tsx
@@ -143,7 +143,7 @@ const PotentialLocales: React.FC = () => {
           value={Number.isNaN(percentThreshold) ? '' : percentThreshold.toString()}
         />
       </Selector>
-      <details>
+      <details className="collapsible-report">
         <summary>Indigenous ({partitionedLocales.indigenous.length})</summary>
         Of all of the census records collected so far, these locales have more people speaking it
         than the other instantiated locales. This likely means the world population is indigenous to
@@ -153,13 +153,13 @@ const PotentialLocales: React.FC = () => {
         actually have the language but represented by a different aspect.
         <LocaleTable locales={partitionedLocales.indigenous} />
       </details>
-      <details>
+      <details className="collapsible-report">
         <summary>Large Population ({partitionedLocales.largePopulation.length})</summary>
         This is the list of locales native to other countries, but with a significant population in
         other countries.
         <LocaleTable locales={partitionedLocales.largePopulation} />
       </details>
-      <details>
+      <details className="collapsible-report">
         <summary>Likely Redundant ({partitionedLocales.maybeRedundant.length})</summary>
         Locales in this table reflect languages that already exist in territories but not in this
         specific locale ID. For example, they may have an entry with a writing system specified.
@@ -179,13 +179,13 @@ const LocaleTable: React.FC<{
         CodeColumn,
         NameColumn,
         {
-          label: 'Population',
+          key: 'Population',
           render: (object) => object.populationSpeaking,
           isNumeric: true,
           sortParam: SortBy.Population,
         },
         {
-          label: 'Population Source',
+          key: 'Population Source',
           render: (object) => <LocaleCensusCitation locale={object} size="short" />,
         },
         InfoButtonColumn,

--- a/src/views/locale/PotentialLocales.tsx
+++ b/src/views/locale/PotentialLocales.tsx
@@ -1,0 +1,197 @@
+import React, { useMemo } from 'react';
+
+import Selector from '../../controls/components/Selector';
+import TextInput from '../../controls/components/TextInput';
+import { usePageParams } from '../../controls/PageParamsContext';
+import { useDataContext } from '../../data/DataContext';
+import { BCP47LocaleCode, LocaleData, PopulationSourceCategory } from '../../types/DataTypes';
+import { ObjectType, SortBy } from '../../types/PageParamTypes';
+import { getLanguageScopeLevel, ScopeLevel } from '../../types/ScopeLevel';
+import { CodeColumn, InfoButtonColumn, NameColumn } from '../common/table/CommonColumns';
+import ObjectTable from '../common/table/ObjectTable';
+
+import LocaleCensusCitation from './LocaleCensusCitation';
+
+type PartitionedLocales = {
+  indigenous: LocaleData[];
+  largePopulation: LocaleData[];
+  maybeRedundant: LocaleData[];
+};
+
+const PotentialLocales: React.FC = () => {
+  const {
+    locales,
+    censuses,
+    languagesBySchema: { Inclusive: languages },
+  } = useDataContext();
+  const { localeSeparator } = usePageParams();
+  const [percentThreshold, setPercentThreshold] = React.useState(0.01);
+
+  // Iterate through all censuses and find locales that are not listed
+  const allMissingLocales = useMemo(
+    () =>
+      Object.values(censuses).reduce<Record<BCP47LocaleCode, LocaleData>>((missing, census) => {
+        Object.entries(census.languageEstimates ?? {})?.forEach(([langID, populationEstimate]) => {
+          const localeID = langID + '_' + census.isoRegionCode;
+          const lang = languages[langID];
+          if (locales[localeID] || lang == null) {
+            return; // Locale already exists or language is missing, skip
+          }
+          const populationPercent = (populationEstimate * 100) / census.eligiblePopulation;
+          if (populationPercent < percentThreshold) {
+            return; // Skip if the population percentage is below the threshold
+          }
+
+          if (missing[localeID] == null) {
+            missing[localeID] = {
+              type: ObjectType.Locale,
+              ID: langID + '_' + census.isoRegionCode,
+              codeDisplay: lang.codeDisplay + localeSeparator + census.isoRegionCode,
+              languageCode: langID,
+              language: lang,
+              nameDisplay: lang.nameDisplay,
+              names: lang.names,
+              scope: lang.scope != null ? getLanguageScopeLevel(lang) : ScopeLevel.Other,
+
+              territory: census.territory,
+              territoryCode: census.isoRegionCode,
+
+              populationSource: PopulationSourceCategory.Census,
+              populationSpeaking: populationEstimate,
+              populationSpeakingPercent: populationPercent,
+              populationCensus: census,
+              censusRecords: [{ census, populationEstimate, populationPercent }],
+            };
+          } else {
+            if (missing[localeID].populationSpeaking < populationEstimate) {
+              // If we already have a locale but the population estimate is higher, update it
+              missing[localeID].populationSpeaking = populationEstimate;
+              missing[localeID].populationSpeakingPercent = populationPercent;
+              missing[localeID].populationCensus = census;
+            }
+            missing[localeID].censusRecords.push({
+              census,
+              populationEstimate,
+              populationPercent,
+            });
+          }
+        });
+        return missing;
+      }, {}),
+    [censuses, languages, locales, localeSeparator, percentThreshold],
+  );
+
+  // Maybe break it down by territory instead.
+  // For each territory, find the listed locales & find the potential locales.
+
+  // Partition the locales into 3 types:
+  // 1. Locales where the language is indigenous
+  // 2. Locales who has no other equivalent in the same territory
+  // 3. All others, may not be a priority
+  const partitionedLocales = Object.values(allMissingLocales).reduce<PartitionedLocales>(
+    (partitions, locale) => {
+      const siblingLocales = locale.language?.locales ?? [];
+      // If the language is not listed in any locale in the territory.
+      if (!siblingLocales.some((l) => l.territoryCode === locale.territoryCode)) {
+        if (siblingLocales.some((l) => l.populationSpeaking < locale.populationSpeaking)) {
+          partitions.largePopulation.push(locale);
+        } else {
+          partitions.indigenous.push(locale);
+        }
+      } else {
+        // A similar locale already exists in the territory, this may not be necessary or maybe the locales need to be clarified
+        partitions.maybeRedundant.push(locale);
+      }
+
+      return partitions;
+    },
+    {
+      indigenous: [],
+      largePopulation: [],
+      maybeRedundant: [],
+    },
+  );
+
+  return (
+    <div>
+      <h1>Potential Locales</h1>
+      <p>
+        This page will list locales from Census data that are not in the list of defined locales.
+        There are too many possible combinations of language + territory + variation information, so
+        the number of actualized locales is smaller than the possible ones. However ones that appear
+        here may be worth considering.
+      </p>
+      <Selector
+        selectorLabel="Percent Threshold:"
+        selectorDescription={`Limit results by the minimum percent population in a territory that uses the language.`}
+      >
+        <TextInput
+          inputStyle={{ width: '3em' }}
+          getSuggestions={async () => [
+            { searchString: '0.001', label: '0.001%' },
+            { searchString: '0.005', label: '0.005%' },
+            { searchString: '0.01', label: '0.01%' },
+            { searchString: '0.05', label: '0.05%' },
+            { searchString: '0.1', label: '0.1%' },
+            { searchString: '0.5', label: '0.5%' },
+            { searchString: '1', label: '1%' },
+            { searchString: '5', label: '5%' },
+            { searchString: '10', label: '10%' },
+          ]}
+          onChange={(percent: string) => setPercentThreshold(Number(percent))}
+          placeholder=""
+          value={Number.isNaN(percentThreshold) ? '' : percentThreshold.toString()}
+        />
+      </Selector>
+      <details>
+        <summary>Indigenous ({partitionedLocales.indigenous.length})</summary>
+        Of all of the census records collected so far, these locales have more people speaking it
+        than the other instantiated locales. This likely means the world population is indigenous to
+        this country. However, since we do not have full census coverage it is very possible that
+        the language is native to a different country without an inputted census record.
+        Additionally, some of these locales are macrolanguages or constituents thereof, so we may
+        actually have the language but represented by a different aspect.
+        <LocaleTable locales={partitionedLocales.indigenous} />
+      </details>
+      <details>
+        <summary>Large Population ({partitionedLocales.largePopulation.length})</summary>
+        This is the list of locales native to other countries, but with a significant population in
+        other countries.
+        <LocaleTable locales={partitionedLocales.largePopulation} />
+      </details>
+      <details>
+        <summary>Likely Redundant ({partitionedLocales.maybeRedundant.length})</summary>
+        Locales in this table reflect languages that already exist in territories but not in this
+        specific locale ID. For example, they may have an entry with a writing system specified.
+        <LocaleTable locales={partitionedLocales.maybeRedundant} />
+      </details>
+    </div>
+  );
+};
+
+const LocaleTable: React.FC<{
+  locales: LocaleData[];
+}> = ({ locales }) => {
+  return (
+    <ObjectTable<LocaleData>
+      objects={locales}
+      columns={[
+        CodeColumn,
+        NameColumn,
+        {
+          label: 'Population',
+          render: (object) => object.populationSpeaking,
+          isNumeric: true,
+          sortParam: SortBy.Population,
+        },
+        {
+          label: 'Population Source',
+          render: (object) => <LocaleCensusCitation locale={object} size="short" />,
+        },
+        InfoButtonColumn,
+      ]}
+    />
+  );
+};
+
+export default PotentialLocales;

--- a/src/views/styles.css
+++ b/src/views/styles.css
@@ -122,7 +122,7 @@ dt {
   text-align: start;
 }
 
-.ViewReports summary {
+.collapsible-report > summary {
   width: 100%;
   background-color: var(--color-button-secondary);
   padding: 0.5em;


### PR DESCRIPTION
This adds a report that shows locales derived from census data that seem like they should be added to the enumerated list of locales.

~~I'll note that of the indigenous languages listed -- most are macrolanguages or are just missing data. Hazaragi is a dialect of Dari (Persian) that would be biggest in Afghanistan. Funny enough, none in the screenshot seem to be good ideas -- but if you scroll down the list or change % thresholds you see better ones. For example, Tippera [tpe] should be listed a locale in India.~~ Resolved! I updated the algorithm

Link: https://translation-commons.github.io/lang-nav/?objectType=Locale&view=Reports
<img width="1010" height="620" alt="Screenshot 2025-07-14 at 11 59 08" src="https://github.com/user-attachments/assets/8ae87d1f-b24f-44e4-9b29-aa2146a53208" />

With the other options expanded
<img width="1009" height="663" alt="Screenshot 2025-07-14 at 11 59 45" src="https://github.com/user-attachments/assets/91ae8347-c39b-426a-95a3-a4c132dc2fe3" />

