### PR TITLE
Replaced unicode characters with Lucide icons (fixes #86)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "cldr-core": "^47.0.0",
+        "lucide-react": "^0.525.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.5.1"
@@ -3883,6 +3884,14 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/make-dir": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "cldr-core": "^47.0.0",
+    "lucide-react": "^0.525.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.5.1"

--- a/src/controls/components/Selector.tsx
+++ b/src/controls/components/Selector.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import Hoverable from '../../generic/Hoverable';
 
 type Props = {
   appearance?: 'rounded' | 'tabs';
   children: React.ReactNode;
-  selectorLabel?: string;
+  selectorLabel?: ReactNode;
   selectorDescription?: React.ReactNode;
   size?: 'regular' | 'compact';
 };

--- a/src/controls/components/TextInput.tsx
+++ b/src/controls/components/TextInput.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { Search, ExternalLink, X } from 'lucide-react';
 
 import HoverableButton from '../../generic/HoverableButton';
 import { View } from '../../types/PageParamTypes';
@@ -118,7 +119,7 @@ const TextInput: React.FC<Props> = ({
           setShowSuggestions(false);
         }}
       >
-        &#x2716;
+        <X size="12px" style={{ color: 'white' }} />
       </button>
     </>
   );
@@ -171,13 +172,13 @@ const SuggestionRow: React.FC<SuggestionRowProps> = ({
     <div className="SuggestionRowWithMultipleInteractions">
       <div>{label}</div>
       <HoverableButton hoverContent={<>Filter by &quot;{searchString}&quot;</>} onClick={setFilter}>
-        &#x1F50E;
+        <Search size="1em" />
       </HoverableButton>
       <HoverableButton
         hoverContent={<>Go to the details page for {searchString}</>}
         onClick={goToDetails}
       >
-        &#x2197;
+        <ExternalLink size="1em" />
       </HoverableButton>
     </div>
   );

--- a/src/controls/selectors/SearchBar.tsx
+++ b/src/controls/selectors/SearchBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Search } from 'lucide-react';
 
 import { SearchableField, View } from '../../types/PageParamTypes';
 import Selector from '../components/Selector';
@@ -13,7 +14,7 @@ const SearchBar: React.FC = () => {
   const getSearchSuggestions = useSearchSuggestions();
 
   return (
-    <Selector selectorLabel="🔎">
+    <Selector selectorLabel={<Search size="12px" />}>
       <TextInput
         inputStyle={{ minWidth: '20em' }}
         getSuggestions={getSearchSuggestions}

--- a/src/generic/LinkButton.tsx
+++ b/src/generic/LinkButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ExternalLink } from 'lucide-react';
 
 export default function LinkButton({
   href,
@@ -11,6 +12,7 @@ export default function LinkButton({
     <a href={href}>
       <button className="LinkButton" role="link">
         {children}
+        <ExternalLink size="1em" style={{ marginLeft: '4px' }} />
       </button>
     </a>
   );

--- a/src/views/AboutPage.tsx
+++ b/src/views/AboutPage.tsx
@@ -139,6 +139,25 @@ const AboutPage: React.FC = () => {
           long as you give appropriate credit, provide a link to the license, and indicate if
           changes were made.
         </p>
+        <p>
+          Icons used in this website are provided by{' '}
+          <a 
+            href="https://lucide.dev" 
+            target="_blank" 
+            rel="noopener noreferrer"
+          >
+            Lucide
+          </a>
+          , and are distributed under the ISC License. You can view the license{' '}
+          <a 
+            href="https://lucide.dev/license" 
+            target="_blank" 
+            rel="noopener noreferrer"
+          >
+            here
+          </a>
+          .
+        </p>
         <CreativeCommonsLicense />
         <p>
           The source code is available in a{' '}

--- a/src/views/ViewModal.tsx
+++ b/src/views/ViewModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { ExternalLink, X } from 'lucide-react';
 
 import { usePageParams } from '../controls/PageParamsContext';
 import Hoverable from '../generic/Hoverable';
@@ -54,11 +55,13 @@ const ViewModal: React.FC = () => {
                   })
                 }
               >
-                &#x2197;
+                <ExternalLink size="1em" />
               </button>
             </Hoverable>
             <Hoverable hoverContent="Close modal">
-              <button onClick={onClose}>&#x2716;</button>
+              <button onClick={onClose}>
+                <X size="1em" />
+              </button>
             </Hoverable>
           </div>
         </div>

--- a/src/views/census/TableOfLanguagesInCensus.tsx
+++ b/src/views/census/TableOfLanguagesInCensus.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { Info } from 'lucide-react';
 
 import { usePageParams } from '../../controls/PageParamsContext';
 import { useDataContext } from '../../data/DataContext';
@@ -151,7 +152,9 @@ const ActualLocaleInfoButton: React.FC<{ actualLocale?: LocaleData }> = ({ actua
   }
   return (
     <HoverableObject object={actualLocale}>
-      <button className="InfoButton">&#x24D8;</button>
+      <button className="InfoButton">
+        <Info size="1em" />
+      </button>
     </HoverableObject>
   );
 };

--- a/src/views/common/CLDRCoverageInfo.tsx
+++ b/src/views/common/CLDRCoverageInfo.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { AlertTriangle, CheckCircle2, Info, XCircle } from 'lucide-react';
 
 import Hoverable from '../../generic/Hoverable';
 import { CLDRCoverageLevel } from '../../types/CLDRTypes';
@@ -47,7 +48,10 @@ export const CLDRCoverageInfo: React.FC<Props> = ({ object, parentNotes }) => {
         {cldrCoverage.actualCoverageLevel}
       </span>{' '}
       coverage by {cldrCoverage.countOfCLDRLocales} locale
-      {cldrCoverage.countOfCLDRLocales > 1 && 's'}. ICU: {cldrCoverage.inICU ? '✅' : '❌'}
+      {cldrCoverage.countOfCLDRLocales > 1 && 's'}. ICU: {cldrCoverage.inICU ? 
+  <CheckCircle2 style={{ color: 'var(--color-text-green)' }} size={'1em'} /> : 
+  <XCircle style={{ color: 'var(--color-text-red)' }} size={'1em'} />
+}
     </>
   );
 };
@@ -76,7 +80,11 @@ const NotesIcon: React.FC<{
       hoverContent={formattedNotes}
       style={{ textDecoration: 'none', marginRight: '0.25em' }}
     >
-      {warningNotes ? '⚠️' : 'ⓘ'}
+      {warningNotes ? (
+  <AlertTriangle style={{ color: 'var(--color-text-yellow)' }} size={'1em'} />
+) : (
+  <Info style={{ color: 'var(--color-text-blue)' }} size={'1em'} />
+)}
     </Hoverable>
   );
 };

--- a/src/views/common/TreeList/TreeListNode.tsx
+++ b/src/views/common/TreeList/TreeListNode.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Info } from 'lucide-react';
 
 import { usePageParams } from '../../../controls/PageParamsContext';
 import { ObjectData } from '../../../types/DataTypes';
@@ -77,7 +78,9 @@ const TreeListNode: React.FC<Props> = ({ nodeData, isExpandedInitially = false }
         )}
         {showInfoButton && (
           <HoverableObject object={object}>
-            <button className="InfoButton">&#x24D8;</button>
+            <button className="InfoButton">
+              <Info size="1em" />
+            </button>
           </HoverableObject>
         )}
         {showPopulation && population > 0 && (

--- a/src/views/common/table/CommonColumns.tsx
+++ b/src/views/common/table/CommonColumns.tsx
@@ -1,3 +1,5 @@
+import { Info } from 'lucide-react';
+
 import { ObjectData } from '../../../types/DataTypes';
 import { SearchableField, SortBy } from '../../../types/PageParamTypes';
 import HoverableObject from '../HoverableObject';
@@ -25,7 +27,9 @@ export const InfoButtonColumn: TableColumn<ObjectData> = {
   key: 'Info',
   render: (object) => (
     <HoverableObject object={object}>
-      <button className="InfoButton">&#x24D8;</button>
+      <button className="InfoButton">
+        <Info size="1em" />
+      </button>
     </HoverableObject>
   ),
 };

--- a/src/views/styles.css
+++ b/src/views/styles.css
@@ -76,12 +76,8 @@ a:hover {
 
 .LinkButton {
     margin-left: 1em;
+    margin-bottom: 0.5em;
     padding: 4px;
-}
-
-.LinkButton::after {
-    content: '↗';
-    margin-left: 4px;
 }
 
 .compact button, .compact input, .compact label, button.compact {


### PR DESCRIPTION
This pull request resolves issue #86 by replacing all instances of Unicode characters and HTML entities used as icons with modern, consistent SVG icons from the "lucide-react" library.

### Key Changes

- **Installed `lucide-react`:** Added the new icon library as a project dependency.
- **Replaced Unicode Icons:** Systematically replaced all targeted Unicode characters (e.g., ✅, 🔎, ↗) with their corresponding `lucide-react` components. This affected numerous components, including `CLDRCoverageInfo`, `ViewModal`, `LinkButton`, `SearchBar`, and various tables.
- **Refactored CSS Icon:** Removed a CSS rule that used `content: '↗'` and moved the icon directly into the `LinkButton` component for consistency.
- **Updated About Page:** Added the required license and attribution for the Lucide library to the `AboutPage.tsx`.
- **Corrected `Selector.tsx` Prop Type:** While implementing the new icons, a related bug was fixed. The `selectorLabel` prop in the `Selector.tsx` component was updated from `string` to `React.ReactNode` to resolve a TypeScript error and allow it to accept icon components as labels.

Here are few screenshots:
![image](https://github.com/user-attachments/assets/6481ce36-2e24-471e-9889-f6cb2c9b18b6)
![image](https://github.com/user-attachments/assets/45793215-5039-4c32-a588-904cece60f2d)

Fixes #86 
