### PR TITLE
Census: Import "CLDR" population estimates

### DIFF
--- a/src/data/CensusData.tsx
+++ b/src/data/CensusData.tsx
@@ -1,5 +1,5 @@
 import { toTitleCase } from '../generic/stringUtils';
-import { CensusData } from '../types/CensusTypes';
+import { CensusCollectorType, CensusData } from '../types/CensusTypes';
 import { LanguageCode } from '../types/LanguageTypes';
 import { ObjectType } from '../types/PageParamTypes';
 
@@ -61,7 +61,7 @@ function parseCensusImport(fileInput: string, filename: string): CensusImport {
     yearCollected: 0,
     eligiblePopulation: 0,
     languageEstimates: {},
-    collectorType: '',
+    collectorType: CensusCollectorType.Government,
   }));
 
   // Iterate through the rest of the lines to collect metadata until we hit the break line
@@ -95,6 +95,8 @@ function parseCensusImport(fileInput: string, filename: string): CensusImport {
           censuses[index][key] = Number.parseInt(value.replace(/,/g, ''));
         } else if (key === 'sampleRate') {
           censuses[index][key] = Number.parseFloat(value);
+        } else if (key === 'collectorType') {
+          censuses[index][key] = value as CensusCollectorType;
         } else if (
           key === 'languageCount' ||
           key === 'languageEstimates' ||

--- a/src/data/PopulationData.tsx
+++ b/src/data/PopulationData.tsx
@@ -1,3 +1,4 @@
+import { getCensusCollectorTypeRank } from '../types/CensusTypes';
 import {
   BCP47LocaleCode,
   LocaleData,
@@ -14,6 +15,11 @@ type CensusCmp = (a: LocaleInCensus, b: LocaleInCensus) => number;
 const POPULATION_ESTIMATE_RULES: CensusCmp[] = [
   // Potential filters:
   // acquisitionOrder: Any > L1 > L2 > L3
+
+  // Prefer government sources over CLDR
+  (a, b) =>
+    getCensusCollectorTypeRank(a.census.collectorType) -
+    getCensusCollectorTypeRank(b.census.collectorType),
 
   // Get the most recent census estimate
   (a, b) => b.census.yearCollected - a.census.yearCollected,

--- a/src/data/SupplementalData.tsx
+++ b/src/data/SupplementalData.tsx
@@ -5,7 +5,7 @@ import {
   computeLocaleWritingPopulation,
 } from './PopulationData';
 import { computeContainedTerritoryStats, loadTerritoryGDPLiteracy } from './TerritoryData';
-import { loadCLDRCoverage } from './UnicodeData';
+import { getLanguageCountsFromCLDR, loadCLDRCoverage } from './UnicodeData';
 
 /**
  * Get more data that is not necessary for the initial page load
@@ -24,6 +24,8 @@ export async function loadSupplementalData(coreData: CoreData): Promise<void> {
       addCensusData(coreData, censusImport);
     }
   });
+  const cldrCensuses = getLanguageCountsFromCLDR(coreData);
+  addCensusData(coreData, { censuses: cldrCensuses, languageNames: {} });
 
   // 001 is the UN code for the World
   computeContainedTerritoryStats(coreData.territories['001']);

--- a/src/data/UnicodeData.tsx
+++ b/src/data/UnicodeData.tsx
@@ -90,11 +90,14 @@ export function addCLDRLanguageDetails(languagesBySchema: LanguagesBySchema): vo
       if (constituentLang != null && macroLang != null) {
         // Add notes to the macrolanguage entry
         macroLang.cldrDataProvider = constituentLang;
-        macroLang.schemaSpecific.CLDR.code = undefined;
+        macroLang.schemaSpecific.CLDR.code = macroLangCode + '**'; // Distinguish the macrolanguage from the constituent language
         macroLang.schemaSpecific.CLDR.scope = LanguageScope.Macrolanguage;
+        macroLang.schemaSpecific.CLDR.childLanguages = [constituentLang];
         macroLang.schemaSpecific.CLDR.notes = notes;
-        // Remove the symbolic reference in the CLDR list to the macrolanguage object
+        macroLang.schemaSpecific.CLDR.name = macroLang?.nameCanonical + ' (macrolanguage)';
+        // Remove the regular symbolic reference in the CLDR list to the macrolanguage object (since it will be replaced below)
         delete cldrLanguages[macroLangCode];
+        cldrLanguages[macroLangCode + '**'] = macroLang; // But put it back in with ** to distinguish it
       }
 
       // Now set the replacement (cmn) as the canonical language for its macrolanguage (zh)

--- a/src/data/UnicodeData.tsx
+++ b/src/data/UnicodeData.tsx
@@ -82,6 +82,7 @@ export function addCLDRLanguageDetails(languagesBySchema: LanguagesBySchema): vo
       // Get the constituent language and the macrolanguage that will be replaced by it
       const constituentLangCode = alias.original; // eg. `cmn`
       const macroLangCode = alias.replacement; // eg. `zh`
+      const macroLangAltCode = macroLangCode + '**';
       const constituentLang = cldrLanguages[alias.original]; // eg. Mandarin Chinese `cmn` in ISO but effective `zh` in CLDR
       const macroLang = cldrLanguages[alias.replacement]; // eg. Chinese (macrolanguage) `zho`/`zh` in ISO
       const notes = (
@@ -98,14 +99,14 @@ export function addCLDRLanguageDetails(languagesBySchema: LanguagesBySchema): vo
       if (constituentLang != null && macroLang != null) {
         // Add notes to the macrolanguage entry
         macroLang.cldrDataProvider = constituentLang;
-        macroLang.schemaSpecific.CLDR.code = macroLangCode + '**'; // Distinguish the macrolanguage from the constituent language
+        macroLang.schemaSpecific.CLDR.code = macroLangAltCode; // Distinguish the macrolanguage from the constituent language
         macroLang.schemaSpecific.CLDR.scope = LanguageScope.Macrolanguage;
         macroLang.schemaSpecific.CLDR.childLanguages = [constituentLang];
         macroLang.schemaSpecific.CLDR.notes = notes;
         macroLang.schemaSpecific.CLDR.name = macroLang?.nameCanonical + ' (macrolanguage)';
         // Remove the regular symbolic reference in the CLDR list to the macrolanguage object (since it will be replaced below)
         delete cldrLanguages[macroLangCode];
-        cldrLanguages[macroLangCode + '**'] = macroLang; // But put it back in with ** to distinguish it
+        cldrLanguages[macroLangAltCode] = macroLang; // But put it back in with ** to distinguish it
       }
 
       // Now set the replacement (cmn) as the canonical language for its macrolanguage (zh)
@@ -113,8 +114,7 @@ export function addCLDRLanguageDetails(languagesBySchema: LanguagesBySchema): vo
         cldrLanguages[macroLangCode] = constituentLang;
         constituentLang.schemaSpecific.CLDR.code = macroLangCode;
         constituentLang.schemaSpecific.CLDR.notes = notes;
-        constituentLang.schemaSpecific.CLDR.parentLanguageCode = macroLangCode + '**';
-        // constituentLang.schemaSpecific.CLDR.parentLanguage = macroLang;
+        constituentLang.schemaSpecific.CLDR.parentLanguageCode = macroLangAltCode;
 
         // Remove the old link (eg. from cmn) since it's now canonical for the macrolanguage code (zh)
         delete cldrLanguages[constituentLangCode];

--- a/src/types/CensusTypes.tsx
+++ b/src/types/CensusTypes.tsx
@@ -4,6 +4,11 @@ import { ObjectType } from './PageParamTypes';
 
 // Unique identifier for the census or other source of population data
 export type CensusID = string; // eg. 'ca2021.2', 'us2013.1'
+export enum CensusCollectorType {
+  Government = 'Government',
+  CLDR = 'CLDR',
+  Study = 'Study',
+}
 
 export interface CensusData extends ObjectBase {
   type: ObjectType.Census;
@@ -15,7 +20,7 @@ export interface CensusData extends ObjectBase {
   nameDisplay: string;
   isoRegionCode: TerritoryCode;
   yearCollected: number; // eg. 2021, 2013
-  collectorType: string; // Type of organization (e.g., Government, NGO, Academic)
+  collectorType: CensusCollectorType; // Type of organization (e.g., Government, CLDR)
 
   // Kind of language data collected
   modality?: string; // eg. Spoken, Written, Sign
@@ -51,3 +56,16 @@ export interface CensusData extends ObjectBase {
   // Connections to other objects loaded after the fact
   territory?: TerritoryData;
 }
+
+export const getCensusCollectorTypeRank = (collectorType: CensusCollectorType): number => {
+  switch (collectorType) {
+    case CensusCollectorType.Government:
+      return 1; // Highest priority
+    case CensusCollectorType.Study:
+      return 2; // Medium priority
+    case CensusCollectorType.CLDR:
+      return 3; // Lowest priority
+    default:
+      return 4; // Unknown or unranked
+  }
+};

--- a/src/views/locale/LocaleCensusCitation.tsx
+++ b/src/views/locale/LocaleCensusCitation.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { CensusCollectorType } from '../../types/CensusTypes';
 import { LocaleData, PopulationSourceCategory } from '../../types/DataTypes';
 import HoverableObject from '../common/HoverableObject';
 
@@ -12,6 +13,14 @@ const LocaleCensusCitation: React.FC<Props> = ({ locale, size = 'full' }) => {
   const { populationCensus } = locale;
   if (populationCensus != null) {
     const { yearCollected, collectorName, collectorType } = populationCensus;
+    if (collectorType === CensusCollectorType.CLDR) {
+      // Leave out the date from CLDR, it's not available from the source
+      return (
+        <HoverableObject object={populationCensus}>
+          {collectorName ?? collectorType}
+        </HoverableObject>
+      );
+    }
     let name = collectorName;
     if (name == null || name === '' || size === 'short') {
       switch (collectorType) {

--- a/src/views/locale/PotentialLocales.tsx
+++ b/src/views/locale/PotentialLocales.tsx
@@ -308,7 +308,7 @@ function partitionPotentialLocales(
     .forEach((locale) => {
       const descendentLocaleInTerritory = findLocaleDescendingFromThisLocale(
         locale,
-        locale.language?.childLanguages,
+        [locale.language].filter((l) => l != null),
       );
       if (!descendentLocaleInTerritory) {
         locale.containedLocales = [localesSorted[0]];

--- a/src/views/locale/PotentialLocales.tsx
+++ b/src/views/locale/PotentialLocales.tsx
@@ -7,7 +7,12 @@ import { usePageParams } from '../../controls/PageParamsContext';
 import { useDataContext } from '../../data/DataContext';
 import { numberToFixedUnlessSmall } from '../../generic/numberUtils';
 import { CensusData } from '../../types/CensusTypes';
-import { BCP47LocaleCode, LocaleData, PopulationSourceCategory } from '../../types/DataTypes';
+import {
+  BCP47LocaleCode,
+  LocaleData,
+  PopulationSourceCategory,
+  TerritoryCode,
+} from '../../types/DataTypes';
 import { LanguageCode, LanguageData } from '../../types/LanguageTypes';
 import { LocaleSeparator, ObjectType, SortBy } from '../../types/PageParamTypes';
 import { getLanguageScopeLevel, getTerritoryScopeLevel, ScopeLevel } from '../../types/ScopeLevel';
@@ -289,10 +294,14 @@ function partitionPotentialLocales(
   // If the largest locale is from the census data (not in the regular input list) then suggest it as a locale here
   if (largestLocale.localeSource === 'census') {
     // Some censuses include language families -- that's nice complementary data but its usually not a priority
-    const descendentLocaleInTerritory = findLocaleDescendingFromThisLocale(
-      largestLocale,
-      largestLocale.language?.childLanguages,
-    );
+    const descendentLocaleInTerritory = largestLocale.language
+      ? findExtantLocaleInTerritoryDescendingFromLanguage(
+          // start with the language of the locale to find alt codes eg. nan -> nan_Hant
+          // Then it will search child languages and dialects
+          [largestLocale.language],
+          largestLocale.territoryCode,
+        )
+      : null;
     if (!descendentLocaleInTerritory) {
       largestLocale.containedLocales = [localesSorted[1]];
       partitionedLocales.largest.push(largestLocale);
@@ -306,10 +315,14 @@ function partitionPotentialLocales(
   localesOfTheSameLanguage
     .filter((locale) => locale !== largestLocale && locale.localeSource === 'census')
     .forEach((locale) => {
-      const descendentLocaleInTerritory = findLocaleDescendingFromThisLocale(
-        locale,
-        [locale.language].filter((l) => l != null),
-      );
+      const descendentLocaleInTerritory = locale.language
+        ? findExtantLocaleInTerritoryDescendingFromLanguage(
+            // start with the language of the locale to find alt codes eg. nan -> nan_Hant
+            // Then it will search child languages and dialects
+            [locale.language],
+            locale.territoryCode,
+          )
+        : null;
       if (!descendentLocaleInTerritory) {
         locale.containedLocales = [localesSorted[0]];
         partitionedLocales.significant.push(locale);
@@ -322,14 +335,17 @@ function partitionPotentialLocales(
   return partitionedLocales;
 }
 
-function findLocaleDescendingFromThisLocale(
-  locale: LocaleData,
+function findExtantLocaleInTerritoryDescendingFromLanguage(
   languages?: LanguageData[],
+  territoryCode?: TerritoryCode,
 ): LocaleData | null {
-  const directDescendent = findLocaleWithSameTerritory(locale, languages);
+  const directDescendent = findLocaleWithSameTerritory(languages, territoryCode);
   const recursiveDescendents =
-    languages?.map((lang) => findLocaleDescendingFromThisLocale(locale, lang.childLanguages)) ?? [];
+    languages?.map((lang) =>
+      findExtantLocaleInTerritoryDescendingFromLanguage(lang.childLanguages, territoryCode),
+    ) ?? [];
   return (
+    // Sort to pick the most populous locale
     [directDescendent, ...recursiveDescendents].filter(Boolean).sort((a, b) => {
       return (b?.populationSpeaking ?? 0) - (a?.populationSpeaking ?? 0);
     })[0] ?? null
@@ -337,15 +353,12 @@ function findLocaleDescendingFromThisLocale(
 }
 
 function findLocaleWithSameTerritory(
-  locale: LocaleData,
   languages?: LanguageData[],
+  territoryCode?: TerritoryCode,
 ): LocaleData | null {
   return (
     languages
-      ?.map(
-        (lang) =>
-          lang.locales.filter((loc) => loc.territoryCode === locale.territoryCode)[0] ?? null,
-      )
+      ?.map((lang) => lang.locales.filter((loc) => loc.territoryCode === territoryCode)[0] ?? null)
       .filter(Boolean)[0] ?? null
   );
 }


### PR DESCRIPTION
CLDR population estimates are available in the CLDR json package. This imports those estimates and ranks them lower than the actual censuses. CLDR has data for every country, we get a lot more values. It will be better to get census and other sources but this helps fill in missing values.

|Page|Changes|Before|After|
|--|--|--|--|
|[Locale Table](https://translation-commons.github.io/lang-nav/?objectType=Locale&view=Table)|You see a number of entries now have a new population source -- CLDR (underlined) -- which you can hover over to get more information about the source. It doesn't replace the actual census values (since CLDR is ranked lower in accuracy). The population numbers are updated and sorted slightly differently now too. Urdu and Panjabi (Pakistan) jumped up, others increased and others decreased in rank like Japanese (JP) and Spanish (MX).|<img width="756" height="822" alt="Screenshot 2025-07-16 at 09 54 00" src="https://github.com/user-attachments/assets/1fcb8494-350c-4446-b0f8-cb77712818a1" />|<img width="752" height="811" alt="Screenshot 2025-07-16 at 09 16 02" src="https://github.com/user-attachments/assets/4d71dfb9-3c12-47ea-a86a-94cca5432217" />
|[Locale Details (Russian in Russia)](https://translation-commons.github.io/lang-nav/?objectType=Locale&view=Details&objectID=rus_RU)|You can see a new population record from CLDR but it doesn't change the population because its ranked lower.|<img width="505" height="506" alt="Screenshot 2025-07-16 at 10 20 53" src="https://github.com/user-attachments/assets/1531fa4a-c396-491c-bd0c-a2f9267a2785" />|<img width="504" height="537" alt="Screenshot 2025-07-16 at 10 20 29" src="https://github.com/user-attachments/assets/9f8b9cc2-d292-4dda-95f6-c3d556946c3e" />
|[Locale Reports: Potential Locales](https://translation-commons.github.io/lang-nav/?objectType=Locale&view=Reports)|No changes for the largest locales, but more secondary territories for language populations show up. The majority of them are already expressed with a similar-looking locale (eg. it has _Hant in it).|<img width="1213" height="737" alt="Screenshot 2025-07-16 at 09 54 18" src="https://github.com/user-attachments/assets/a48a4a22-0fe8-4a0f-8008-577205e64f66" />|<img width="1223" height="873" alt="Screenshot 2025-07-16 at 09 47 29" src="https://github.com/user-attachments/assets/3246f809-a421-4142-adc2-925c8395190b" />
