### PR TITLE
Filters: Show why there are hidden entries. (#111)

### DIFF
--- a/src/views/VisibleItemsMeter.tsx
+++ b/src/views/VisibleItemsMeter.tsx
@@ -1,86 +1,72 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
+import { getScopeFilter, getSubstringFilter } from '../controls/filter';
 import { usePageParams } from '../controls/PageParamsContext';
 import PaginationControls from '../controls/selectors/PaginationControls';
-import { LanguageSchema } from '../types/LanguageTypes';
-import { ObjectType } from '../types/PageParamTypes';
-
-import { getObjectTypeLabelPlural } from './common/getObjectName';
+import Deemphasized from '../generic/Deemphasized';
+import Hoverable from '../generic/Hoverable';
+import { ObjectData } from '../types/DataTypes';
 
 interface Props {
-  nShown: number;
-  nFiltered: number;
-  nOverall: number;
-  objectType?: ObjectType;
+  objects: ObjectData[];
 }
 
-const VisibleItemsMeter: React.FC<Props> = ({ nShown, nFiltered, nOverall, objectType }) => {
+const VisibleItemsMeter: React.FC<Props> = ({ objects }) => {
   const { page, limit } = usePageParams();
+  const substringFilter = getSubstringFilter() ?? (() => true);
+  const scopeFilter = getScopeFilter();
 
+  // Compute amounts
+  const nOverall = objects.length;
   if (nOverall === 0) {
     return 'Data is still loading. If you are waiting awhile there could be an error in the data.';
   }
-  const totalItemsLoaded = (
-    <>
-      {nOverall > nFiltered && <> There are {<strong>{nOverall}</strong>} total</>}{' '}
-      <ObjectTypeLabel manualObjectType={objectType} />.
-    </>
+
+  // nFiltered
+  const nInScope = useMemo(() => objects.filter(scopeFilter).length, [objects, scopeFilter]);
+  const nMatchingSubstring = useMemo(
+    () => objects.filter(scopeFilter).filter(substringFilter).length,
+    [objects, scopeFilter, substringFilter],
   );
+  const nFilteredByScope = nOverall - nInScope;
+  const nFilteredBySubstring = nInScope - nMatchingSubstring;
+  const nFiltered = nMatchingSubstring;
+  const nPages = limit < 1 ? 1 : Math.ceil(nFiltered / limit);
 
-  if (nFiltered === 0) {
-    return (
-      <div style={{ display: 'inline-block' }}>
-        No results found with current filters.{totalItemsLoaded}
-      </div>
-    );
-  }
-
-  if (nFiltered === nOverall) {
-    // Easy case, no filter changing results
-    return (
-      <div style={{ display: 'inline-block' }}>
-        Showing <strong>{nShown}</strong>
-        {nOverall > nShown && <> of {<strong>{nOverall}</strong>}</>}{' '}
-        <ObjectTypeLabel manualObjectType={objectType} />.{' '}
-        <PaginationControls
-          currentPage={page}
-          totalPages={limit < 1 ? 1 : Math.ceil(nFiltered / limit)}
-        />
-      </div>
-    );
-  }
+  // nShown
+  let nShown = limit;
+  if (page > nPages || limit < 1) nShown = 0;
+  if (page === nPages /* last page */) nShown = nFiltered - (nPages - 1) * limit;
 
   return (
-    <div>
-      Showing <strong>{nShown}</strong>
-      {nFiltered > nShown && <> of {<strong>{nFiltered}</strong>}</>} filtered{' '}
-      <ObjectTypeLabel manualObjectType={objectType} />.{nOverall > nFiltered && totalItemsLoaded}{' '}
-      <PaginationControls
-        currentPage={page}
-        totalPages={limit < 1 ? 1 : Math.ceil(nFiltered / limit)}
-      />
+    <div className="VisibleItemsMeter">
+      <div>
+        Showing <strong>{nShown.toLocaleString()}</strong>
+        {nFiltered > nShown && <> of {<strong>{nFiltered.toLocaleString()}</strong>}</>} results.
+      </div>
+      {nOverall > nFiltered && (
+        <Hoverable
+          hoverContent={
+            <>
+              {nFilteredByScope > 0 && <div>Out of scope: {nFilteredByScope.toLocaleString()}</div>}
+              {nFilteredBySubstring > 0 && (
+                <div>Not matching substring: {nFilteredBySubstring.toLocaleString()}</div>
+              )}
+            </>
+          }
+          style={{ textDecoration: 'none' }}
+        >
+          <Deemphasized>{(nOverall - nFiltered).toLocaleString()} filtered out.</Deemphasized>
+        </Hoverable>
+      )}
+      {nPages > 1 && (
+        <div>
+          On <PaginationControls currentPage={page} totalPages={nPages} />
+          of {nPages.toLocaleString()}.
+        </div>
+      )}
     </div>
   );
-};
-
-const ObjectTypeLabel: React.FC<{ manualObjectType?: ObjectType }> = ({ manualObjectType }) => {
-  const { languageSchema, objectType: pageObjectType } = usePageParams();
-  const objectType = manualObjectType ?? pageObjectType;
-
-  if (objectType === ObjectType.Language) {
-    switch (languageSchema) {
-      case LanguageSchema.Glottolog:
-        return 'glottolog languages';
-      case LanguageSchema.Inclusive:
-        return 'languages and language-like entities';
-      case LanguageSchema.ISO:
-        return 'ISO languages';
-      case LanguageSchema.UNESCO:
-      case LanguageSchema.CLDR:
-        break; // fall back to the regular plural (languages)
-    }
-  }
-  return getObjectTypeLabelPlural(objectType);
 };
 
 export default VisibleItemsMeter;

--- a/src/views/common/CardList.tsx
+++ b/src/views/common/CardList.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { getScopeFilter, getSliceFunction, getSubstringFilter } from '../../controls/filter';
 import { getSortFunction } from '../../controls/sort';
@@ -17,19 +17,16 @@ function CardList<T extends ObjectData>({ objects, renderCard }: Props<T>) {
   const filterByScope = getScopeFilter();
   const sliceFunction = getSliceFunction<T>();
 
-  // Filter results);
-  const objectsFiltered = objects.filter(filterByScope).filter(filterBySubstring);
-  // Sort results & limit how many are visible
-  const objectsVisible = sliceFunction(objectsFiltered.sort(sortBy));
+  // Filter results
+  const objectsVisible = useMemo(
+    () => sliceFunction(objects.filter(filterByScope).filter(filterBySubstring).sort(sortBy)),
+    [objects, filterByScope, filterBySubstring, sortBy, sliceFunction],
+  );
 
   return (
     <div>
       <div className="CardListDescription">
-        <VisibleItemsMeter
-          nShown={objectsVisible.length}
-          nFiltered={objectsFiltered.length}
-          nOverall={objects.length}
-        />
+        <VisibleItemsMeter objects={objects} />
       </div>
       <div className="CardList">
         {objectsVisible.map((object) => (

--- a/src/views/common/table/ObjectTable.tsx
+++ b/src/views/common/table/ObjectTable.tsx
@@ -28,9 +28,8 @@ interface Props<T> {
  * A page that shows tips about problems in the data that may need to be addressed
  */
 function ObjectTable<T extends ObjectData>({ objects, columns }: Props<T>) {
-  const { limit } = usePageParams();
   const sortBy = getSortFunction();
-  const substringFilter = getSubstringFilter();
+  const substringFilter = getSubstringFilter() ?? (() => true);
   const scopeFilter = getScopeFilter();
   const [sortDirectionIsNormal, setSortDirectionIsNormal] = useState(true);
 
@@ -52,7 +51,7 @@ function ObjectTable<T extends ObjectData>({ objects, columns }: Props<T>) {
   const sliceFunction = getSliceFunction<T>();
 
   const objectsFilteredAndSorted = useMemo(() => {
-    let result = objects.filter(substringFilter ?? (() => true)).filter(scopeFilter);
+    let result = objects.filter(scopeFilter).filter(substringFilter);
     if (sortDirectionIsNormal) {
       result = result.sort(sortBy);
     } else {
@@ -60,19 +59,10 @@ function ObjectTable<T extends ObjectData>({ objects, columns }: Props<T>) {
     }
     return result;
   }, [sortBy, objects, substringFilter, scopeFilter, sortDirectionIsNormal]);
-  const nRowsAfterFilter = useMemo(
-    () => objectsFilteredAndSorted.length,
-    [objectsFilteredAndSorted],
-  );
 
   return (
     <div className="ObjectTableContainer">
-      <VisibleItemsMeter
-        nShown={nRowsAfterFilter < limit || limit < 1 ? nRowsAfterFilter : limit}
-        nFiltered={nRowsAfterFilter}
-        nOverall={objects.length}
-        objectType={objects[0]?.type}
-      />
+      <VisibleItemsMeter objects={objects} />
       <details style={{ margin: '.5em 0 1em 0', gap: '.5em 1em' }}>
         <summary style={{ cursor: 'pointer' }}>
           {currentlyVisibleColumns.length}/{columns.length} columns visible, click here to toggle.

--- a/src/views/language/LanguageTable.tsx
+++ b/src/views/language/LanguageTable.tsx
@@ -1,6 +1,5 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 
-import { getScopeFilter } from '../../controls/filter';
 import { useDataContext } from '../../data/DataContext';
 import { LanguageData } from '../../types/LanguageTypes';
 import { SortBy } from '../../types/PageParamTypes';
@@ -10,15 +9,10 @@ import ObjectTable from '../common/table/ObjectTable';
 
 const LanguageTable: React.FC = () => {
   const { languages } = useDataContext();
-  const scopeFilter = getScopeFilter();
-  const languagesFiltered = useMemo(
-    () => Object.values(languages).filter(scopeFilter),
-    [scopeFilter],
-  );
 
   return (
     <ObjectTable<LanguageData>
-      objects={languagesFiltered}
+      objects={Object.values(languages)}
       columns={[
         CodeColumn,
         NameColumn,

--- a/src/views/styles.css
+++ b/src/views/styles.css
@@ -133,6 +133,14 @@ dt {
   margin-bottom: 1em;
 }
 
+.VisibleItemsMeter {
+  display: flex;
+  flex-direction: row;
+  gap: 0.25em;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
 @media (min-width: 0px) {
   .CardList {
     grid-template-columns: repeat(1, 1fr);


### PR DESCRIPTION
This change refactors the VisibleItemsMeter, simplifying the code and improving the communication about what is filtered out. Now it has 3 discrete sections: "Showing X of Y results", "Z filtered out", "On Page < W > of V". If you hover of the filtered out section it provides a bit more context -- I'd like to add more but right now I'm working on refactoring the code that will appear there so I think its better to start with this and incrementally update.

|Before|After|
|--|--|
<img width="677" height="285" alt="स्क्रीनशॉट 2025-07-15, 12 59 53 पर" src="https://github.com/user-attachments/assets/5e58e2dc-9e88-4596-876f-7b305e91af0f" />|<img width="653" height="293" alt="स्क्रीनशॉट 2025-07-15, 13 01 35 पर"
src="https://github.com/user-attachments/assets/94013354-bb98-41dc-9834-d26622e34f46" />

And see here how what it looks like 
<img width="1136" height="318" alt="स्क्रीनशॉट 2025-07-15, 13 15 05 पर" src="https://github.com/user-attachments/assets/e6afb9a0-67b2-4274-ba03-b80e2904cac2" />