### PR TITLE
Sorting: Add more sort options

### DIFF
--- a/src/controls/selectors/SortBySelector.tsx
+++ b/src/controls/selectors/SortBySelector.tsx
@@ -3,15 +3,17 @@ import React from 'react';
 import { SortBy } from '../../types/PageParamTypes';
 import Selector, { OptionsDisplay } from '../components/Selector';
 import { usePageParams } from '../PageParamsContext';
+import { getSortBysApplicableToObjectType } from '../sort';
 
 const SortBySelector: React.FC = () => {
-  const { sortBy, updatePageParams } = usePageParams();
+  const { sortBy, updatePageParams, objectType } = usePageParams();
+  const applicableSortBys = getSortBysApplicableToObjectType(objectType);
 
   return (
     <Selector
       selectorLabel="Sort by:"
       selectorDescription="Choose the order of items in the view."
-      options={Object.values(SortBy)}
+      options={Object.values(SortBy).filter((sb) => applicableSortBys.includes(sb))}
       onChange={(sortBy: SortBy) => updatePageParams({ sortBy })}
       selected={sortBy}
       optionsDisplay={OptionsDisplay.ButtonList}

--- a/src/controls/selectors/SortBySelector.tsx
+++ b/src/controls/selectors/SortBySelector.tsx
@@ -1,15 +1,11 @@
 import React from 'react';
 
-import { SortBy, View } from '../../types/PageParamTypes';
+import { SortBy } from '../../types/PageParamTypes';
 import Selector, { OptionsDisplay } from '../components/Selector';
 import { usePageParams } from '../PageParamsContext';
 
 const SortBySelector: React.FC = () => {
-  const { sortBy, updatePageParams, view } = usePageParams();
-  if (view === View.Table) {
-    // Supported in the table columns
-    return <></>;
-  }
+  const { sortBy, updatePageParams } = usePageParams();
 
   return (
     <Selector

--- a/src/controls/sort.tsx
+++ b/src/controls/sort.tsx
@@ -6,6 +6,7 @@ import { usePageParams } from './PageParamsContext';
 
 export type SortByFunctionType = (a: ObjectData, b: ObjectData) => number;
 
+// TODO, it may be more performant to make a sortKey function
 export function getSortFunction(languageSource?: LanguageSource): SortByFunctionType {
   const { sortBy, view, languageSource: languageSourcePageParam } = usePageParams();
   const effectiveLanguageSource = languageSource ?? languageSourcePageParam;
@@ -23,6 +24,52 @@ export function getSortFunction(languageSource?: LanguageSource): SortByFunction
         if (b.nameDisplay > a.nameDisplay) return -1;
         return 0;
       };
+    case SortBy.Endonym:
+      return (a: ObjectData, b: ObjectData) => {
+        if (a.nameEndonym == null) return b.nameEndonym == null ? 0 : 1;
+        if (b.nameEndonym == null) return -1;
+        if (a.nameEndonym > b.nameEndonym) return 1;
+        if (b.nameEndonym > a.nameEndonym) return -1;
+        return 0;
+      };
+    case SortBy.CountOfTerritories:
+      return (a: ObjectData, b: ObjectData) => {
+        switch (a.type) {
+          case ObjectType.Language:
+            return b.type === ObjectType.Language ? b.locales.length - a.locales.length : -1;
+          case ObjectType.Locale:
+            return 0; // Each locale only has one territory
+          case ObjectType.Census:
+            return 0; // Each census only has one territory
+          case ObjectType.WritingSystem:
+            return 0; // Not a useful sort for writing systems
+          case ObjectType.Territory:
+            return b.type === ObjectType.Territory
+              ? b.containsTerritories.length - a.containsTerritories.length
+              : -1;
+        }
+      };
+    case SortBy.CountOfLanguages:
+      return (a: ObjectData, b: ObjectData) => {
+        switch (a.type) {
+          case ObjectType.Language:
+            return b.type === ObjectType.Language
+              ? b.childLanguages.length - a.childLanguages.length
+              : -1;
+          case ObjectType.Locale:
+            return b.type === ObjectType.Locale
+              ? (b.containedLocales?.length || 0) - (a.containedLocales?.length || 0)
+              : -1;
+          case ObjectType.Census:
+            return b.type === ObjectType.Census ? b.languageCount - a.languageCount : -1;
+          case ObjectType.WritingSystem:
+            return b.type === ObjectType.WritingSystem
+              ? Object.values(b.languages).length - Object.values(a.languages).length
+              : -1;
+          case ObjectType.Territory:
+            return b.type === ObjectType.Territory ? b.locales.length - a.locales.length : -1;
+        }
+      };
     case SortBy.Population:
       return (a: ObjectData, b: ObjectData) => {
         switch (a.type) {
@@ -38,7 +85,7 @@ export function getSortFunction(languageSource?: LanguageSource): SortByFunction
           case ObjectType.Locale:
             return b.type === ObjectType.Locale ? b.populationSpeaking - a.populationSpeaking : -1;
           case ObjectType.Census:
-            return b.type === ObjectType.Census ? b.languageCount - a.languageCount : -1;
+            return b.type === ObjectType.Census ? b.eligiblePopulation - a.eligiblePopulation : -1;
           case ObjectType.WritingSystem:
             return b.type === ObjectType.WritingSystem
               ? b.populationUpperBound -
@@ -49,6 +96,25 @@ export function getSortFunction(languageSource?: LanguageSource): SortByFunction
               : -1;
           case ObjectType.Territory:
             return b.type === ObjectType.Territory ? b.population - a.population : -1;
+        }
+      };
+    case SortBy.Percent:
+      return (a: ObjectData, b: ObjectData) => {
+        switch (a.type) {
+          case ObjectType.Census:
+          case ObjectType.Language:
+          case ObjectType.WritingSystem:
+            // No percent to sort by
+            return 0;
+          case ObjectType.Locale:
+            return b.type === ObjectType.Locale
+              ? (b.populationSpeakingPercent ?? 0) - (a.populationSpeakingPercent ?? 0)
+              : -1;
+          case ObjectType.Territory:
+            return b.type === ObjectType.Territory
+              ? // Err, this is not the same percent as above.
+                (b.literacyPercent ?? 0) - (a.literacyPercent ?? 0)
+              : -1;
         }
       };
   }

--- a/src/controls/sort.tsx
+++ b/src/controls/sort.tsx
@@ -98,7 +98,7 @@ export function getSortFunction(languageSource?: LanguageSource): SortByFunction
             return b.type === ObjectType.Territory ? b.population - a.population : -1;
         }
       };
-    case SortBy.Percent:
+    case SortBy.RelativePopulation:
       return (a: ObjectData, b: ObjectData) => {
         switch (a.type) {
           case ObjectType.Census:
@@ -109,6 +109,27 @@ export function getSortFunction(languageSource?: LanguageSource): SortByFunction
           case ObjectType.Locale:
             return b.type === ObjectType.Locale
               ? (b.populationSpeakingPercent ?? 0) - (a.populationSpeakingPercent ?? 0)
+              : -1;
+          case ObjectType.Territory:
+            return b.type === ObjectType.Territory
+              ? // Err, this is not the same percent as above.
+                b.population / (b.parentUNRegion?.population ?? 1) -
+                  a.population / (a.parentUNRegion?.population ?? 1)
+              : -1;
+        }
+      };
+    case SortBy.Literacy:
+      return (a: ObjectData, b: ObjectData) => {
+        switch (a.type) {
+          case ObjectType.Census:
+          case ObjectType.Language:
+          case ObjectType.WritingSystem:
+            // No percent to sort by
+            return 0;
+          case ObjectType.Locale:
+            return b.type === ObjectType.Locale
+              ? (b.populationWriting ?? 0) / (b.populationSpeaking ?? 1) -
+                  (a.populationWriting ?? 0) / (a.populationSpeaking ?? 1)
               : -1;
           case ObjectType.Territory:
             return b.type === ObjectType.Territory

--- a/src/data/PopulationData.tsx
+++ b/src/data/PopulationData.tsx
@@ -106,12 +106,14 @@ export function computeLocaleWritingPopulation(locales: Record<BCP47LocaleCode, 
       (l) => !isTerritoryGroup(l.territory?.scope), // Skip regional locales
     )
     .forEach((locale) => {
-      const literacyPercent = locale.territory?.literacyPercent ?? 100;
+      locale.literacyPercent = locale.territory?.literacyPercent ?? 100;
 
-      locale.populationWriting = Math.round((locale.populationSpeaking * literacyPercent) / 100);
+      locale.populationWriting = Math.round(
+        (locale.populationSpeaking * locale.literacyPercent) / 100,
+      );
       if (locale.populationSpeakingPercent != null) {
         locale.populationWritingPercent =
-          (locale.populationSpeakingPercent * literacyPercent) / 100;
+          (locale.populationSpeakingPercent * locale.literacyPercent) / 100;
       }
     });
 }

--- a/src/generic/CommaSeparated.tsx
+++ b/src/generic/CommaSeparated.tsx
@@ -20,7 +20,13 @@ const CommaSeparated: React.FC<CommaSeparatedProps> = ({ children, limit = 4 }) 
         </React.Fragment>
       ))}{' '}
       {limit != null && childArray.length > limit && (
-        <button className="seeMore" onClick={() => setExpanded((prev) => !prev)}>
+        <button
+          style={{
+            padding: '0em 0.25em',
+            fontWeight: 'normal',
+          }}
+          onClick={() => setExpanded((prev) => !prev)}
+        >
           {expanded ? 'see less' : '+' + countOverLimit + ' more'}
         </button>
       )}

--- a/src/generic/Hoverable.tsx
+++ b/src/generic/Hoverable.tsx
@@ -38,6 +38,9 @@ const Hoverable: React.FC<HoverableProps> = ({ children, hoverContent, onClick, 
       style={{
         display: 'inline-block',
         textDecoration: 'underline',
+        textDecorationStyle: 'dashed',
+        textDecorationThickness: '1px',
+        textDecorationColor: 'var(--color-text-secondary)',
         cursor: onClick ? 'pointer' : 'help',
         ...style,
       }}

--- a/src/generic/HoverableEnumeration.tsx
+++ b/src/generic/HoverableEnumeration.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import Deemphasized from './Deemphasized';
+import Hoverable from './Hoverable';
+
+const HoverableEnumeration: React.FC<{
+  items?: string[];
+  limit?: number;
+}> = ({ items, limit = 20 }) => {
+  if (items == null) return null;
+  if (items.length === 0) return <Deemphasized>0</Deemphasized>;
+
+  return (
+    <Hoverable
+      hoverContent={items.slice(0, limit).join(', ') + (items.length > limit ? '...' : '')}
+    >
+      {items.length}
+    </Hoverable>
+  );
+};
+
+export default HoverableEnumeration;

--- a/src/generic/numberUtils.tsx
+++ b/src/generic/numberUtils.tsx
@@ -28,7 +28,9 @@ export function numberToSigFigs(num: number, sigFigs: number): number {
  * this function will still show small numbers.
  */
 export function numberToFixedUnlessSmall(value: number, precision: number = 2): string {
-  if (Math.abs(value) > 1) {
+  if (Math.abs(value) > 10) {
+    return value.toFixed(precision - 1);
+  } else if (Math.abs(value) > 1) {
     return value.toFixed(precision);
   }
   return value.toPrecision(precision);

--- a/src/generic/styles.css
+++ b/src/generic/styles.css
@@ -1,6 +1,7 @@
 .seeMore {
-  margin: 0px;
-  padding: 0.25em 0.5em;
+  margin: -0.25em 0;
+  padding: 0.25em 0.25em;
+  /* padding: 0; */
   font-weight: normal;
 }
 

--- a/src/generic/styles.css
+++ b/src/generic/styles.css
@@ -1,10 +1,3 @@
-.seeMore {
-  margin: -0.25em 0;
-  padding: 0.25em 0.25em;
-  /* padding: 0; */
-  font-weight: normal;
-}
-
 .HoverCard {
   background: var(--color-background);
   border-radius: 0.5em;

--- a/src/types/DataTypes.tsx
+++ b/src/types/DataTypes.tsx
@@ -164,6 +164,7 @@ export interface LocaleData extends ObjectBase {
 
   // Data added up some references
   populationSpeakingPercent?: number;
+  literacyPercent?: number;
   populationWriting?: number;
   populationWritingPercent?: number;
   populationCensus?: CensusData; // The census record that provides the population estimate

--- a/src/types/PageParamTypes.tsx
+++ b/src/types/PageParamTypes.tsx
@@ -22,10 +22,11 @@ export enum SortBy {
   Population = 'Population',
   Code = 'Code',
   Name = 'Name',
-  Percent = 'Percent',
   Endonym = 'Endonym',
   CountOfLanguages = 'Count of Languages',
   CountOfTerritories = 'Count of Territories',
+  RelativePopulation = 'Relative Population',
+  Literacy = 'Literacy',
 }
 
 export enum SearchableField {

--- a/src/types/PageParamTypes.tsx
+++ b/src/types/PageParamTypes.tsx
@@ -22,6 +22,10 @@ export enum SortBy {
   Population = 'Population',
   Code = 'Code',
   Name = 'Name',
+  Percent = 'Percent',
+  Endonym = 'Endonym',
+  CountOfLanguages = 'Count of Languages',
+  CountOfTerritories = 'Count of Territories',
 }
 
 export enum SearchableField {

--- a/src/views/census/TableOfAllCensuses.tsx
+++ b/src/views/census/TableOfAllCensuses.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import { useDataContext } from '../../data/DataContext';
-import CommaSeparated from '../../generic/CommaSeparated';
-import Hoverable from '../../generic/Hoverable';
+import HoverableEnumeration from '../../generic/HoverableEnumeration';
 import { CensusData } from '../../types/CensusTypes';
 import { SortBy } from '../../types/PageParamTypes';
 import { CodeColumn, InfoButtonColumn, NameColumn } from '../common/table/CommonColumns';
@@ -20,20 +19,24 @@ const TableOfAllCensuses: React.FC = () => {
         {
           key: 'Languages',
           render: (census) => (
-            <Hoverable
-              hoverContent={
-                <CommaSeparated>
-                  {Object.entries(census.languageEstimates)
-                    .sort((a, b) => b[1] - a[1])
-                    .map((lang) => languages[lang[0]]?.nameDisplay)}
-                </CommaSeparated>
-              }
-            >
-              {census.languageCount}
-            </Hoverable>
+            <HoverableEnumeration
+              items={Object.keys(census.languageEstimates).map(
+                (lang) => languages[lang]?.nameDisplay ?? lang,
+              )}
+            />
           ),
           isNumeric: true,
           sortParam: SortBy.CountOfLanguages,
+        },
+
+        {
+          key: 'Eligible Population',
+          render: (census) =>
+            census.eligiblePopulation != null
+              ? census.eligiblePopulation.toLocaleString()
+              : 'Unknown',
+          isNumeric: true,
+          sortParam: SortBy.Population,
         },
         InfoButtonColumn,
       ]}

--- a/src/views/census/TableOfAllCensuses.tsx
+++ b/src/views/census/TableOfAllCensuses.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 
 import { useDataContext } from '../../data/DataContext';
+import CommaSeparated from '../../generic/CommaSeparated';
+import Hoverable from '../../generic/Hoverable';
 import { CensusData } from '../../types/CensusTypes';
 import { SortBy } from '../../types/PageParamTypes';
 import { CodeColumn, InfoButtonColumn, NameColumn } from '../common/table/CommonColumns';
 import ObjectTable from '../common/table/ObjectTable';
 
 const TableOfAllCensuses: React.FC = () => {
-  const { censuses } = useDataContext();
+  const { censuses, languages } = useDataContext();
 
   return (
     <ObjectTable<CensusData>
@@ -17,9 +19,21 @@ const TableOfAllCensuses: React.FC = () => {
         NameColumn,
         {
           key: 'Languages',
-          render: (census) => census.languageCount,
+          render: (census) => (
+            <Hoverable
+              hoverContent={
+                <CommaSeparated>
+                  {Object.entries(census.languageEstimates)
+                    .sort((a, b) => b[1] - a[1])
+                    .map((lang) => languages[lang[0]]?.nameDisplay)}
+                </CommaSeparated>
+              }
+            >
+              {census.languageCount}
+            </Hoverable>
+          ),
           isNumeric: true,
-          sortParam: SortBy.Population,
+          sortParam: SortBy.CountOfLanguages,
         },
         InfoButtonColumn,
       ]}

--- a/src/views/common/table/CommonColumns.tsx
+++ b/src/views/common/table/CommonColumns.tsx
@@ -28,6 +28,7 @@ export const EndonymColumn: TableColumn<ObjectData> = {
   render: (object) => (
     <ObjectFieldHighlightedByPageSearch object={object} field={SearchableField.Endonym} />
   ),
+  sortParam: SortBy.Endonym,
   isInitiallyVisible: false,
 };
 

--- a/src/views/common/table/ObjectTable.tsx
+++ b/src/views/common/table/ObjectTable.tsx
@@ -20,7 +20,7 @@ export interface TableColumn<T> {
   isInitiallyVisible?: boolean;
   isNumeric?: boolean;
   key: string;
-  label?: React.ReactNode;
+  label?: React.ReactNode; // otherwise will use key as label
   render: (object: T) => React.ReactNode;
   sortParam?: SortBy;
 }

--- a/src/views/common/table/ObjectTable.tsx
+++ b/src/views/common/table/ObjectTable.tsx
@@ -34,7 +34,8 @@ interface Props<T> {
  * A page that shows tips about problems in the data that may need to be addressed
  */
 function ObjectTable<T extends ObjectData>({ objects, columns }: Props<T>) {
-  const sortBy = getSortFunction();
+  const { sortBy } = usePageParams();
+  const sortFunction = getSortFunction();
   const filterBySubstring = getFilterBySubstring();
   const filterByTerritory = getFilterByTerritory();
   const scopeFilter = getScopeFilter();
@@ -52,20 +53,27 @@ function ObjectTable<T extends ObjectData>({ objects, columns }: Props<T>) {
   }, []);
 
   const currentlyVisibleColumns = useMemo(
-    () => columns.filter((column) => visibleColumns[column.key]),
-    [columns, visibleColumns],
+    () => columns.filter((column) => visibleColumns[column.key] || column.sortParam === sortBy),
+    [columns, visibleColumns, sortBy],
   );
   const sliceFunction = getSliceFunction<T>();
 
   const objectsFilteredAndSorted = useMemo(() => {
     let result = objects.filter(scopeFilter).filter(filterByTerritory).filter(filterBySubstring);
     if (sortDirectionIsNormal) {
-      result = result.sort(sortBy);
+      result = result.sort(sortFunction);
     } else {
-      result = result.sort((a, b) => -sortBy(a, b));
+      result = result.sort((a, b) => -sortFunction(a, b));
     }
     return result;
-  }, [sortBy, objects, filterBySubstring, filterByTerritory, scopeFilter, sortDirectionIsNormal]);
+  }, [
+    sortFunction,
+    objects,
+    filterBySubstring,
+    filterByTerritory,
+    scopeFilter,
+    sortDirectionIsNormal,
+  ]);
 
   return (
     <div className="ObjectTableContainer">

--- a/src/views/language/LanguageTable.tsx
+++ b/src/views/language/LanguageTable.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
 import { useDataContext } from '../../data/DataContext';
+import CommaSeparated from '../../generic/CommaSeparated';
+import Hoverable from '../../generic/Hoverable';
 import { LanguageData } from '../../types/LanguageTypes';
 import { SortBy } from '../../types/PageParamTypes';
 import { CLDRCoverageInfo } from '../common/CLDRCoverageInfo';
@@ -37,6 +39,24 @@ const LanguageTable: React.FC = () => {
           key: 'Internet Technologies',
           render: (lang) => <CLDRCoverageInfo object={lang} />,
           isInitiallyVisible: false,
+        },
+        {
+          key: 'Dialects',
+          render: (lang) => (
+            <Hoverable
+              hoverContent={
+                <CommaSeparated>
+                  {lang.childLanguages
+                    .sort((a, b) => (b.populationCited ?? 0) - (a.populationCited ?? 0))
+                    .map((lang) => lang.nameDisplay)}
+                </CommaSeparated>
+              }
+            >
+              {lang.childLanguages.length}
+            </Hoverable>
+          ),
+          isInitiallyVisible: false,
+          sortParam: SortBy.CountOfLanguages,
         },
         InfoButtonColumn,
       ]}

--- a/src/views/language/LanguageTable.tsx
+++ b/src/views/language/LanguageTable.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
+import { getUniqueTerritoriesForLanguage } from '../../controls/sort';
 import { useDataContext } from '../../data/DataContext';
-import CommaSeparated from '../../generic/CommaSeparated';
-import Hoverable from '../../generic/Hoverable';
+import HoverableEnumeration from '../../generic/HoverableEnumeration';
 import { LanguageData } from '../../types/LanguageTypes';
 import { SortBy } from '../../types/PageParamTypes';
 import { CLDRCoverageInfo } from '../common/CLDRCoverageInfo';
@@ -16,6 +16,7 @@ import ObjectTable from '../common/table/ObjectTable';
 
 const LanguageTable: React.FC = () => {
   const { languages } = useDataContext();
+  const endonymColumn = { ...EndonymColumn, isInitiallyVisible: true };
 
   return (
     <ObjectTable<LanguageData>
@@ -23,7 +24,7 @@ const LanguageTable: React.FC = () => {
       columns={[
         CodeColumn,
         NameColumn,
-        EndonymColumn,
+        endonymColumn,
         {
           key: 'Scope',
           render: (lang) => lang.scope ?? lang.scope,
@@ -43,20 +44,19 @@ const LanguageTable: React.FC = () => {
         {
           key: 'Dialects',
           render: (lang) => (
-            <Hoverable
-              hoverContent={
-                <CommaSeparated>
-                  {lang.childLanguages
-                    .sort((a, b) => (b.populationCited ?? 0) - (a.populationCited ?? 0))
-                    .map((lang) => lang.nameDisplay)}
-                </CommaSeparated>
-              }
-            >
-              {lang.childLanguages.length}
-            </Hoverable>
+            <HoverableEnumeration
+              items={lang.childLanguages
+                .sort((a, b) => (b.populationCited ?? 0) - (a.populationCited ?? 0))
+                .map((lang) => lang.nameDisplay)}
+            />
           ),
           isInitiallyVisible: false,
           sortParam: SortBy.CountOfLanguages,
+        },
+        {
+          key: 'Territories',
+          render: (lang) => <HoverableEnumeration items={getUniqueTerritoriesForLanguage(lang)} />,
+          sortParam: SortBy.CountOfTerritories,
         },
         InfoButtonColumn,
       ]}

--- a/src/views/locale/LocaleTable.tsx
+++ b/src/views/locale/LocaleTable.tsx
@@ -2,9 +2,17 @@ import React from 'react';
 
 import { usePageParams } from '../../controls/PageParamsContext';
 import { useDataContext } from '../../data/DataContext';
+import CommaSeparated from '../../generic/CommaSeparated';
+import { numberToFixedUnlessSmall } from '../../generic/numberUtils';
 import { LocaleData } from '../../types/DataTypes';
 import { SortBy } from '../../types/PageParamTypes';
-import { CodeColumn, InfoButtonColumn, NameColumn } from '../common/table/CommonColumns';
+import HoverableObjectName from '../common/HoverableObjectName';
+import {
+  CodeColumn,
+  EndonymColumn,
+  InfoButtonColumn,
+  NameColumn,
+} from '../common/table/CommonColumns';
 import ObjectTable from '../common/table/ObjectTable';
 
 import LocaleCensusCitation from './LocaleCensusCitation';
@@ -21,6 +29,7 @@ const LocaleTable: React.FC = () => {
       columns={[
         CodeColumn,
         NameColumn,
+        EndonymColumn,
         {
           key: 'Population',
           render: (object) => object.populationSpeaking,
@@ -28,8 +37,29 @@ const LocaleTable: React.FC = () => {
           sortParam: SortBy.Population,
         },
         {
+          key: '% in Territory',
+          render: (object) =>
+            object.populationSpeakingPercent &&
+            numberToFixedUnlessSmall(object.populationSpeakingPercent),
+          isNumeric: true,
+          sortParam: SortBy.Percent,
+        },
+        {
           key: 'Population Source',
           render: (object) => <LocaleCensusCitation locale={object} size="short" />,
+        },
+        {
+          key: 'Contained Locales',
+          render: (loc) => (
+            <CommaSeparated limit={2}>
+              {loc.containedLocales?.map((child) => (
+                <HoverableObjectName object={child} key={child.ID} />
+              ))}
+            </CommaSeparated>
+          ),
+          isInitiallyVisible: false,
+          isNumeric: true,
+          sortParam: SortBy.CountOfLanguages,
         },
         InfoButtonColumn,
       ]}

--- a/src/views/locale/LocaleTable.tsx
+++ b/src/views/locale/LocaleTable.tsx
@@ -39,10 +39,9 @@ const LocaleTable: React.FC = () => {
         {
           key: 'Literacy',
           render: (object) =>
-            numberToFixedUnlessSmall(
-              ((object.populationWriting ?? 0) * 100) / object.populationSpeaking || 0,
-              1,
-            ),
+            object.literacyPercent != null
+              ? numberToFixedUnlessSmall(object.literacyPercent)
+              : null,
           isInitiallyVisible: false,
           isNumeric: true,
           sortParam: SortBy.Literacy,
@@ -50,8 +49,15 @@ const LocaleTable: React.FC = () => {
         {
           key: '% in Territory',
           render: (object) =>
-            object.populationSpeakingPercent &&
-            numberToFixedUnlessSmall(object.populationSpeakingPercent),
+            object.populationSpeakingPercent && (
+              <>
+                {numberToFixedUnlessSmall(object.populationSpeakingPercent)}
+                {/* If the number is greater than 10%, add an invisible 0 for alignment */}
+                {object.populationSpeakingPercent > 10 && (
+                  <span style={{ visibility: 'hidden' }}>0</span>
+                )}
+              </>
+            ),
           isNumeric: true,
           sortParam: SortBy.RelativePopulation,
         },

--- a/src/views/locale/LocaleTable.tsx
+++ b/src/views/locale/LocaleTable.tsx
@@ -37,12 +37,23 @@ const LocaleTable: React.FC = () => {
           sortParam: SortBy.Population,
         },
         {
+          key: 'Literacy',
+          render: (object) =>
+            numberToFixedUnlessSmall(
+              ((object.populationWriting ?? 0) * 100) / object.populationSpeaking || 0,
+              1,
+            ),
+          isInitiallyVisible: false,
+          isNumeric: true,
+          sortParam: SortBy.Literacy,
+        },
+        {
           key: '% in Territory',
           render: (object) =>
             object.populationSpeakingPercent &&
             numberToFixedUnlessSmall(object.populationSpeakingPercent),
           isNumeric: true,
-          sortParam: SortBy.Percent,
+          sortParam: SortBy.RelativePopulation,
         },
         {
           key: 'Population Source',

--- a/src/views/territory/TerritoryTable.tsx
+++ b/src/views/territory/TerritoryTable.tsx
@@ -28,13 +28,13 @@ const TerritoryTable: React.FC = () => {
           render: (object) =>
             object.literacyPercent != null ? object.literacyPercent.toFixed(1) + '%' : null,
           isNumeric: true,
+          sortParam: SortBy.Percent,
         },
         {
           key: 'Languages',
           render: (object) =>
             object.locales.length > 0 && (
               <Hoverable
-                style={{ textDecoration: 'none' }}
                 hoverContent={
                   object.locales
                     .slice(0, 20)
@@ -46,6 +46,7 @@ const TerritoryTable: React.FC = () => {
               </Hoverable>
             ),
           isNumeric: true,
+          sortParam: SortBy.CountOfLanguages,
         },
         {
           key: 'Biggest Language',

--- a/src/views/territory/TerritoryTable.tsx
+++ b/src/views/territory/TerritoryTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { useDataContext } from '../../data/DataContext';
-import Hoverable from '../../generic/Hoverable';
+import HoverableEnumeration from '../../generic/HoverableEnumeration';
 import { TerritoryData } from '../../types/DataTypes';
 import { SortBy } from '../../types/PageParamTypes';
 import HoverableObjectName from '../common/HoverableObjectName';
@@ -28,23 +28,15 @@ const TerritoryTable: React.FC = () => {
           render: (object) =>
             object.literacyPercent != null ? object.literacyPercent.toFixed(1) + '%' : null,
           isNumeric: true,
-          sortParam: SortBy.Percent,
+          sortParam: SortBy.Literacy,
         },
         {
           key: 'Languages',
-          render: (object) =>
-            object.locales.length > 0 && (
-              <Hoverable
-                hoverContent={
-                  object.locales
-                    .slice(0, 20)
-                    .map((l) => l.language?.nameDisplay ?? l.nameDisplay)
-                    .join(', ') + (object.locales.length > 20 ? '...' : '')
-                }
-              >
-                {object.locales.length}
-              </Hoverable>
-            ),
+          render: (object) => (
+            <HoverableEnumeration
+              items={object.locales.map((l) => l.language?.nameDisplay ?? l.nameDisplay)}
+            />
+          ),
           isNumeric: true,
           sortParam: SortBy.CountOfLanguages,
         },
@@ -59,6 +51,15 @@ const TerritoryTable: React.FC = () => {
               />
             ),
           isInitiallyVisible: false,
+        },
+        {
+          key: 'Contains Territories',
+          render: (object) => (
+            <HoverableEnumeration items={object.containsTerritories.map((t) => t.nameDisplay)} />
+          ),
+          isInitiallyVisible: false,
+          isNumeric: true,
+          sortParam: SortBy.CountOfTerritories,
         },
         {
           key: 'Type',

--- a/src/views/writingsystem/WritingSystemTable.tsx
+++ b/src/views/writingsystem/WritingSystemTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { useDataContext } from '../../data/DataContext';
+import HoverableEnumeration from '../../generic/HoverableEnumeration';
 import { WritingSystemData } from '../../types/DataTypes';
 import { SortBy } from '../../types/PageParamTypes';
 import {
@@ -13,6 +14,7 @@ import ObjectTable from '../common/table/ObjectTable';
 
 const WritingSystemTable: React.FC = () => {
   const { writingSystems } = useDataContext();
+  const endonymColumn = { ...EndonymColumn, isInitiallyVisible: true };
 
   return (
     <ObjectTable<WritingSystemData>
@@ -20,12 +22,22 @@ const WritingSystemTable: React.FC = () => {
       columns={[
         CodeColumn,
         NameColumn,
-        EndonymColumn,
+        endonymColumn,
         {
           key: 'Population',
           render: (object) => object.populationUpperBound,
           isNumeric: true,
           sortParam: SortBy.Population,
+        },
+        {
+          key: 'Languages',
+          render: (object) => (
+            <HoverableEnumeration
+              items={Object.values(object.languages).map((l) => l.nameDisplay)}
+            />
+          ),
+          isNumeric: true,
+          sortParam: SortBy.CountOfLanguages,
         },
         InfoButtonColumn,
       ]}


### PR DESCRIPTION
This change adds a lot more sorting options and table columns to show then.

Changes
* Add new sorting options
  * Endonym
  * Percent (%)
  * Count of Languages (#L)
  * Count of Territories (#T)
* New table columns
  * **Languages**: Endonyms, Dialects (#L)
  * **Locales**: Endonyms, % in Territory, Contained Locales (#L)
  * **Censuses**: <i>no change</i>
  * **Territories**: Only change is that the Literacy (%) & Languages (#L) columns are sortable
  * **Writing Systems**: Endonyms
* `isInitiallyVisible` option to table view to mitigate having so many new columns.

Not everything is final yet -- posting for feedback.


<img width="210" height="276" alt="Screenshot 2025-07-22 at 12 43 00" src="https://github.com/user-attachments/assets/6443ff37-a684-4a5a-a5fa-debf2f9f155c" />
