### PR TITLE
UX: Move controls to sidepanel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import PageNavBar from './controls/PageNavBar';
 import { PageParamsProvider } from './controls/PageParamsContext';
+import SearchBar from './controls/selectors/SearchBar';
+import SidePanel from './controls/SidePanel';
 import { DataProvider } from './data/DataContext';
 import Footer from './Footer';
 import { HoverCardProvider } from './generic/HoverCardContext';
@@ -12,8 +14,21 @@ function App() {
       <DataProvider>
         <HoverCardProvider>
           <PageNavBar />
-          <div className="Body">
-            <MainViews />
+          <div style={{ display: 'flex', minHeight: '100vh' }}>
+            <SidePanel />
+            <main style={{ padding: '1em', flex: 1, overflow: 'auto', width: '100%' }}>
+              <SearchBar />
+              <div
+                style={{
+                  maxWidth: '1280px',
+                  margin: '0 auto',
+                  padding: '1rem 2rem',
+                  textAlign: 'center',
+                }}
+              >
+                <MainViews />
+              </div>
+            </main>
           </div>
           <ViewModal />
           <Footer />

--- a/src/controls/PageNavBar.tsx
+++ b/src/controls/PageNavBar.tsx
@@ -1,39 +1,57 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-import ControlsBar from './ControlsBar';
 import ObjectTypeSelector from './selectors/ObjectTypeSelector';
-import SearchBar from './selectors/SearchBar';
 import ViewSelector from './selectors/ViewSelector';
 
 import './controls.css';
 
 const PageNavBar: React.FC = () => {
-  const [showFilters, setShowFilters] = useState(false);
-
   return (
-    <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-      <div className="NavBar">
-        <h1>
-          <a href="/lang-nav/">
-            <strong>Lang</strong>uage <strong>Nav</strong>igator
-          </a>
-        </h1>
-        <ObjectTypeSelector />
-        <ViewSelector />
-      </div>
-      <span className="Options">
-        <SearchBar />
-        {showFilters && <ControlsBar />}
-        <div className="selector rounded">
-          <button
-            className={showFilters ? 'selected' : ''}
-            onClick={() => setShowFilters((prev) => !prev)}
-          >
-            Options {showFilters ? `▲` : `▶`}
-          </button>
-        </div>
-      </span>
+    <NavBarContainer>
+      <NavBarTitle>
+        <a href="/lang-nav/" style={{ fontWeight: 'lighter' }}>
+          <strong>Lang</strong>uage <strong>Nav</strong>igator
+        </a>
+      </NavBarTitle>
+      <ObjectTypeSelector />
+      <ViewSelector />
+    </NavBarContainer>
+  );
+};
+
+const NavBarContainer: React.FC<React.PropsWithChildren> = ({ children }) => {
+  return (
+    <div
+      className="NavBar"
+      style={{
+        alignItems: 'center',
+        display: 'flex',
+        flexWrap: 'wrap',
+        marginTop: '0em',
+        borderBottom: '0.125em solid var(--color-button-primary)',
+        width: '100%',
+        rowGap: '0.5em',
+        color: 'var(--color-background)',
+        backgroundColor: 'var(--color-button-primary)',
+      }}
+    >
+      {children}
     </div>
+  );
+};
+
+const NavBarTitle: React.FC<React.PropsWithChildren> = ({ children }) => {
+  return (
+    <h1
+      style={{
+        fontSize: '1.5em',
+        whiteSpace: 'nowrap',
+        lineHeight: '1.5',
+        margin: '0em 0.5em',
+      }}
+    >
+      {children}
+    </h1>
   );
 };
 

--- a/src/controls/SidePanel.tsx
+++ b/src/controls/SidePanel.tsx
@@ -9,6 +9,8 @@ import LocaleSeparatorSelector from './selectors/LocaleSeparatorSelector';
 import ScopeFilterSelector from './selectors/ScopeFilterSelector';
 import SortBySelector from './selectors/SortBySelector';
 
+const PANEL_WIDTH = '16em';
+
 const SidePanel: React.FC = () => {
   const [isOpen, setIsOpen] = React.useState(true);
 
@@ -43,7 +45,7 @@ const LeftAlignedPanel: React.FC<React.PropsWithChildren<{ isOpen: boolean }>> =
   return (
     <aside
       style={{
-        width: isOpen ? '16em' : '0',
+        width: isOpen ? PANEL_WIDTH : '0',
         overflowY: 'auto',
         borderRight: '2px solid var(--color-button-border)',
         transition: 'width 0.3s ease-in-out',
@@ -68,7 +70,7 @@ const SidePanelToggleButton: React.FC<{
         style={{
           position: 'fixed',
           top: '50%',
-          left: isOpen ? '16em' : '1.5em',
+          left: isOpen ? PANEL_WIDTH : '1.5em',
           transform: 'translateX(-50%) translateY(-50%)', // move it to the center of its position
           zIndex: 1000,
           transition: 'left 0.3s ease-in-out',
@@ -86,7 +88,7 @@ const SidePanelSection: React.FC<React.PropsWithChildren> = ({ children }) => {
     <div
       style={{
         borderBottom: '0.125em solid var(--color-button-border)',
-        width: '16em',
+        width: PANEL_WIDTH,
         padding: '0.25em 0.5em',
         marginBottom: '0.5em',
       }}

--- a/src/controls/SidePanel.tsx
+++ b/src/controls/SidePanel.tsx
@@ -1,0 +1,107 @@
+import { FilterIcon } from 'lucide-react';
+import React from 'react';
+
+import HoverableButton from '../generic/HoverableButton';
+
+import LanguageSchemaSelector from './selectors/LanguageSchemaSelector';
+import LimitInput from './selectors/LimitInput';
+import LocaleSeparatorSelector from './selectors/LocaleSeparatorSelector';
+import ScopeFilterSelector from './selectors/ScopeFilterSelector';
+import SortBySelector from './selectors/SortBySelector';
+
+const SidePanel: React.FC = () => {
+  const [isOpen, setIsOpen] = React.useState(true);
+
+  return (
+    <LeftAlignedPanel isOpen={isOpen}>
+      <SidePanelSection>
+        <SidePanelSectionTitle>Data</SidePanelSectionTitle>
+        <LanguageSchemaSelector />
+      </SidePanelSection>
+
+      <SidePanelSection>
+        <SidePanelSectionTitle>Filters</SidePanelSectionTitle>
+        <ScopeFilterSelector />
+      </SidePanelSection>
+
+      <SidePanelSection>
+        <SidePanelSectionTitle>View Options</SidePanelSectionTitle>
+        <LimitInput />
+        <SortBySelector />
+        <LocaleSeparatorSelector />
+      </SidePanelSection>
+
+      <SidePanelToggleButton isOpen={isOpen} onClick={() => setIsOpen((open) => !open)} />
+    </LeftAlignedPanel>
+  );
+};
+
+const LeftAlignedPanel: React.FC<React.PropsWithChildren<{ isOpen: boolean }>> = ({
+  children,
+  isOpen,
+}) => {
+  return (
+    <aside
+      style={{
+        width: isOpen ? '16em' : '0',
+        overflowY: 'auto',
+        borderRight: '2px solid var(--color-button-border)',
+        transition: 'width 0.3s ease-in-out',
+        paddingTop: '0.5em',
+      }}
+    >
+      {children}
+    </aside>
+  );
+};
+
+const SidePanelToggleButton: React.FC<{
+  isOpen: boolean;
+  onClick: () => void;
+}> = ({ isOpen, onClick }) => {
+  return (
+    <div className="selector rounded">
+      <HoverableButton
+        hoverContent={isOpen ? 'Close side panel' : 'Open side panel to customize view'}
+        className={isOpen ? 'selected' : ''}
+        onClick={onClick}
+        style={{
+          position: 'fixed',
+          top: '50%',
+          left: isOpen ? '16em' : '1.5em',
+          transform: 'translateX(-50%) translateY(-50%)', // move it to the center of its position
+          zIndex: 1000,
+          transition: 'left 0.3s ease-in-out',
+        }}
+        aria-label={isOpen ? 'Close side panel' : 'Open side panel to customize view'}
+      >
+        <FilterIcon size="1em" display="block" />
+      </HoverableButton>
+    </div>
+  );
+};
+
+const SidePanelSection: React.FC<React.PropsWithChildren> = ({ children }) => {
+  return (
+    <div
+      style={{
+        borderBottom: '0.125em solid var(--color-button-border)',
+        width: '16em',
+        padding: '0.25em 0.5em',
+        marginBottom: '0.5em',
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+const SidePanelSectionTitle: React.FC<React.PropsWithChildren> = ({ children }) => {
+  return (
+    <div style={{ fontSize: '1.2em', fontWeight: 'lighter', marginBottom: '0.5em' }}>
+      {children}
+    </div>
+  );
+};
+
+export default SidePanel;

--- a/src/controls/controls.css
+++ b/src/controls/controls.css
@@ -1,41 +1,8 @@
-.NavBar {
-  align-items: center;
-  display: flex;
-  flex-wrap: wrap;
-  margin-top: 0em;
-  border-bottom: 0.125em solid var(--color-button-primary);
-  margin-bottom: 0.5em;
-  width: 100%;
-  row-gap: 0.5em;
-  color: var(--color-background);
-  background-color: var(--color-button-primary);
-}
-
-.NavBar h1 {
-  font-size: 1.5em;
-  white-space: nowrap;
-  line-height: 1.5;
-}
-
-.NavBar h1 a {
-  font-weight: lighter;
-}
-
 .NavBar .selector {
   font-size: 1.2em;
   line-height: 1.2em;
   align-content: center;
-}
-
-.NavBar .selector,
-.NavBar h1 {
-  margin: 0em 0.5em 0em 0.5em;
-}
-
-.Options {
-  margin: 0 1em;
-  display: flex;
-  flex-wrap: wrap;
+  margin: 0em 0.5em;
 }
 
 .selector.tabs button,

--- a/src/index.css
+++ b/src/index.css
@@ -51,15 +51,6 @@ body {
   min-height: 100vh;
 }
 
-.Body {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 1rem 2rem;
-  text-align: center;
-
-  flex: 1;
-}
-
 h1 {
   font-size: 3.2em;
   line-height: 1.1;

--- a/src/views/common/CardList.tsx
+++ b/src/views/common/CardList.tsx
@@ -6,6 +6,8 @@ import { ObjectData } from '../../types/DataTypes';
 import ViewCard from '../ViewCard';
 import VisibleItemsMeter from '../VisibleItemsMeter';
 
+const CARD_MIN_WIDTH = 300; // Including margins
+
 interface Props<T> {
   objects: T[];
   renderCard: (object: T) => React.ReactNode;
@@ -55,7 +57,7 @@ const ResponsiveGrid: React.FC<React.PropsWithChildren> = ({ children }) => {
     return () => observer.disconnect();
   }, []);
 
-  const nColumns = width > 0 ? Math.floor(width / 300) : 1;
+  const nColumns = width > 0 ? Math.floor(width / CARD_MIN_WIDTH) : 1;
 
   return (
     <div

--- a/src/views/common/CardList.tsx
+++ b/src/views/common/CardList.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import { getScopeFilter, getSliceFunction, getSubstringFilter } from '../../controls/filter';
 import { getSortFunction } from '../../controls/sort';
@@ -24,17 +24,51 @@ function CardList<T extends ObjectData>({ objects, renderCard }: Props<T>) {
   );
 
   return (
-    <div>
-      <div className="CardListDescription">
+    <>
+      <div style={{ marginBottom: '1em' }}>
         <VisibleItemsMeter objects={objects} />
       </div>
-      <div className="CardList">
+      <ResponsiveGrid>
         {objectsVisible.map((object) => (
           <ViewCard key={object.ID}>{renderCard(object)}</ViewCard>
         ))}
-      </div>
-    </div>
+      </ResponsiveGrid>
+    </>
   );
 }
+
+const ResponsiveGrid: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry.contentRect) {
+        setWidth(entry.contentRect.width);
+      }
+    });
+
+    if (containerRef.current) {
+      observer.observe(containerRef.current);
+    }
+
+    return () => observer.disconnect();
+  }, []);
+
+  const nColumns = width > 0 ? Math.floor(width / 300) : 1;
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        display: 'grid',
+        gridGap: '1.5em',
+        gridTemplateColumns: `repeat(${nColumns}, 1fr)`,
+      }}
+    >
+      {children}
+    </div>
+  );
+};
 
 export default CardList;

--- a/src/views/styles.css
+++ b/src/views/styles.css
@@ -1,4 +1,3 @@
-
 .ViewCard {
   border-width: 1px;
   border-radius: 5px;

--- a/src/views/styles.css
+++ b/src/views/styles.css
@@ -1,12 +1,3 @@
-.CardList {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(0, 1fr));
-  grid-gap: 25px;
-}
-
-.CardListDescription {
-  margin-bottom: 1em;
-}
 
 .ViewCard {
   border-width: 1px;
@@ -139,28 +130,4 @@ dt {
   gap: 0.25em;
   flex-wrap: wrap;
   justify-content: center;
-}
-
-@media (min-width: 0px) {
-  .CardList {
-    grid-template-columns: repeat(1, 1fr);
-  }
-}
-
-@media (min-width: 500px) {
-  .CardList {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-@media (min-width: 800px) {
-  .CardList {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-@media (min-width: 1100px) {
-  .CardList {
-    grid-template-columns: repeat(4, 1fr);
-  }
 }


### PR DESCRIPTION
This moves the controls that you can toggle to view or hide to a toggleable sidebar.

I'd love to get design feedback. Just note I don't update the selectors in this change because I realized I needed a more thorough refactor because the CSS styles have become too complex.

While I was here I also moved some styles from .css files to be inline instead. After working on this program for awhile I realized I was adding some modern anti-patterns. If you put too many styles in CSS files then it can be harder to understand. Inline styles muck up files, but you can improve this by adding Container/Body/Header... components inside the file.

Also note I did a quick refactor of the CardList component as well because I noticed it was responsive to the whole window width, rather than the container width.

|State|Before|After|
|--|--|--|
|Options closed|<img width="1123" height="630" alt="Screenshot 2025-07-23 at 09 59 32" src="https://github.com/user-attachments/assets/f5f68ad6-4448-45bc-8f32-6b04e16f6179" />|<img width="1125" height="633" alt="Screenshot 2025-07-23 at 09 59 17" src="https://github.com/user-attachments/assets/65fe273d-6b61-4400-be0e-2c731d110fe3" />
|Options open|<img width="1122" height="624" alt="Screenshot 2025-07-23 at 09 59 37" src="https://github.com/user-attachments/assets/e115bb1c-0303-43cd-a558-e110bfe0424f" />|<img width="1126" height="639" alt="Screenshot 2025-07-23 at 09 59 24" src="https://github.com/user-attachments/assets/0ac85217-8188-4887-b14e-5966cd59019e" />

