### PR TITLE
Controls: Separate Territory Filter control

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,39 +1,17 @@
 import PageNavBar from './controls/PageNavBar';
 import { PageParamsProvider } from './controls/PageParamsContext';
-import SearchBar from './controls/selectors/SearchBar';
-import SidePanel from './controls/SidePanel';
-import { DataProvider } from './data/DataContext';
 import Footer from './Footer';
 import { HoverCardProvider } from './generic/HoverCardContext';
-import MainViews from './views/MainViews';
-import ViewModal from './views/ViewModal';
+import PageContents from './views/PageContents';
 
 function App() {
   return (
     <PageParamsProvider>
-      <DataProvider>
-        <HoverCardProvider>
-          <PageNavBar />
-          <div style={{ display: 'flex', minHeight: '100vh' }}>
-            <SidePanel />
-            <main style={{ padding: '1em', flex: 1, overflow: 'auto', width: '100%' }}>
-              <SearchBar />
-              <div
-                style={{
-                  maxWidth: '1280px',
-                  margin: '0 auto',
-                  padding: '1rem 2rem',
-                  textAlign: 'center',
-                }}
-              >
-                <MainViews />
-              </div>
-            </main>
-          </div>
-          <ViewModal />
-          <Footer />
-        </HoverCardProvider>
-      </DataProvider>
+      <HoverCardProvider>
+        <PageNavBar />
+        <PageContents />
+        <Footer />
+      </HoverCardProvider>
     </PageParamsProvider>
   );
 }

--- a/src/controls/PageParamsContext.tsx
+++ b/src/controls/PageParamsContext.tsx
@@ -25,7 +25,7 @@ const PARAMS_THAT_CLEAR: PageParamKey[] = ['limit', 'page', 'searchString', 'sea
 export const PageParamsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [pageParams, setPageParams] = useSearchParams({});
 
-  const getParam = (key: string, fallback: string = '') => pageParams.get(key) ?? fallback;
+  const getParam = (key: PageParamKey, fallback: string = '') => pageParams.get(key) ?? fallback;
 
   const updatePageParams = (newParams: PageParamsOptional) => {
     setPageParams((prev) => getNewURLSearchParams(newParams, prev));
@@ -49,6 +49,7 @@ export const PageParamsProvider: React.FC<{ children: React.ReactNode }> = ({ ch
       searchBy: getParam('searchBy', defaults.searchBy) as SearchableField,
       searchString: getParam('searchString', defaults.searchString),
       sortBy: getParam('sortBy', defaults.sortBy) as SortBy,
+      territoryFilter: getParam('territoryFilter', defaults.territoryFilter),
       territoryScopes: getParam('territoryScopes', defaults.territoryScopes.join(','))
         .split(',')
         .map((s) => s as TerritoryScope)
@@ -83,6 +84,7 @@ function getDefaultParams(objectType: ObjectType, view: View): PageParams {
     searchString: '',
     sortBy: SortBy.Population,
     territoryScopes,
+    territoryFilter: '',
     view,
   };
 }

--- a/src/controls/SidePanel.tsx
+++ b/src/controls/SidePanel.tsx
@@ -9,6 +9,7 @@ import LimitInput from './selectors/LimitInput';
 import LocaleSeparatorSelector from './selectors/LocaleSeparatorSelector';
 import ObjectTypeSelector from './selectors/ObjectTypeSelector';
 import SortBySelector from './selectors/SortBySelector';
+import TerritoryFilter from './selectors/TerritoryFilter';
 import TerritoryScopeSelector from './selectors/TerritoryScopeSelector';
 import ViewSelector from './selectors/ViewSelector';
 
@@ -29,6 +30,7 @@ const SidePanel: React.FC = () => {
         <SidePanelSectionTitle>Filters</SidePanelSectionTitle>
         <LanguageScopeSelector />
         <TerritoryScopeSelector />
+        <TerritoryFilter />
       </SidePanelSection>
 
       <SidePanelSection>

--- a/src/controls/components/Selector.tsx
+++ b/src/controls/components/Selector.tsx
@@ -1,8 +1,9 @@
 import React, { ReactNode, useState } from 'react';
 
-import Hoverable from '../../generic/Hoverable';
 import HoverableButton from '../../generic/HoverableButton';
 import { useClickOutside } from '../../generic/useClickOutside';
+
+import SelectorLabel from './SelectorLabel';
 
 export enum OptionsDisplay {
   Dropdown = 'dropdown', // Formatting is still off for these
@@ -85,35 +86,6 @@ function Selector<T extends React.Key>({
     </div>
   );
 }
-
-type SelectorLabelProps = {
-  label?: ReactNode;
-  description?: ReactNode;
-  optionsDisplay: OptionsDisplay;
-};
-
-const SelectorLabel: React.FC<SelectorLabelProps> = ({ label, description, optionsDisplay }) => {
-  if (label == null) return null;
-  return (
-    <label
-      style={{
-        border:
-          optionsDisplay === OptionsDisplay.ButtonList
-            ? 'none'
-            : '0.125em solid var(--color-button-primary)',
-        marginLeft: optionsDisplay === OptionsDisplay.ButtonGroup ? '-0.125em' : '0',
-        marginRight: optionsDisplay === OptionsDisplay.ButtonGroup ? '-0.125em' : '0',
-        lineHeight: '1em',
-        padding: '0.5em',
-        whiteSpace: 'nowrap',
-      }}
-    >
-      <Hoverable hoverContent={description} style={{ textDecoration: 'none' }}>
-        {label}
-      </Hoverable>
-    </label>
-  );
-};
 
 type OptionsContainerProps = {
   isExpanded?: boolean;

--- a/src/controls/components/SelectorLabel.tsx
+++ b/src/controls/components/SelectorLabel.tsx
@@ -1,0 +1,36 @@
+import React, { ReactNode } from 'react';
+
+import Hoverable from '../../generic/Hoverable';
+
+import { OptionsDisplay } from './Selector';
+
+type Props = {
+  label?: ReactNode;
+  description?: ReactNode;
+  optionsDisplay: OptionsDisplay;
+};
+
+const SelectorLabel: React.FC<Props> = ({ label, description, optionsDisplay }) => {
+  if (label == null) return null;
+  return (
+    <label
+      style={{
+        border:
+          optionsDisplay === OptionsDisplay.ButtonList
+            ? 'none'
+            : '0.125em solid var(--color-button-primary)',
+        marginLeft: optionsDisplay === OptionsDisplay.ButtonGroup ? '-0.125em' : '0',
+        marginRight: optionsDisplay === OptionsDisplay.ButtonGroup ? '-0.125em' : '0',
+        lineHeight: '1em',
+        padding: '0.5em',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <Hoverable hoverContent={description} style={{ textDecoration: 'none' }}>
+        {label}
+      </Hoverable>
+    </label>
+  );
+};
+
+export default SelectorLabel;

--- a/src/controls/components/TextInput.tsx
+++ b/src/controls/components/TextInput.tsx
@@ -5,6 +5,8 @@ import HoverableButton from '../../generic/HoverableButton';
 import { View } from '../../types/PageParamTypes';
 import { usePageParams } from '../PageParamsContext';
 
+import { OptionsDisplay } from './Selector';
+
 export type Suggestion = {
   objectID?: string;
   searchString: string;
@@ -12,22 +14,24 @@ export type Suggestion = {
 };
 
 type Props = {
-  inputStyle?: React.CSSProperties;
   getSuggestions?: (query: string) => Promise<Suggestion[]>;
+  inputStyle?: React.CSSProperties;
   onChange: (value: string) => void;
+  optionsDisplay: OptionsDisplay;
+  placeholder?: string;
   showGoToDetailsButton?: boolean;
   showTextInputButton?: boolean;
-  placeholder?: string;
   value: string;
 };
 
 const TextInput: React.FC<Props> = ({
-  inputStyle,
   getSuggestions = () => [],
+  inputStyle,
   onChange,
+  optionsDisplay,
+  placeholder,
   showGoToDetailsButton = false,
   showTextInputButton = true,
-  placeholder,
   value,
 }) => {
   const spanRef = useRef<HTMLSpanElement>(null);
@@ -83,6 +87,7 @@ const TextInput: React.FC<Props> = ({
         onFocus={() => setShowSuggestions(true)}
         placeholder={placeholder}
         style={{
+          ...(optionsDisplay === OptionsDisplay.ButtonList ? { borderRadius: '0.5em' } : {}),
           ...inputStyle,
           width: inputWidth + 5,
         }}
@@ -114,16 +119,25 @@ const TextInput: React.FC<Props> = ({
           </div>
         </div>
       )}
-      <button
-        className="NoLeftBorder"
-        type="button"
+      <HoverableButton
+        hoverContent="Clear the input"
+        style={
+          optionsDisplay === OptionsDisplay.ButtonList
+            ? { padding: '.5em', borderRadius: '0.5em', border: 'none', marginLeft: '0.5em' }
+            : {
+                marginRight: '0em',
+                borderTopLeftRadius: '0px',
+                borderBottomLeftRadius: '0px',
+                borderLeft: 'none',
+              }
+        }
         onClick={() => {
           setImmediateValue('');
           setShowSuggestions(false);
         }}
       >
         <XIcon size="1em" display="block" />
-      </button>
+      </HoverableButton>
     </>
   );
 };

--- a/src/controls/controls.css
+++ b/src/controls/controls.css
@@ -104,12 +104,6 @@
   color: var(--color-text);
 }
 
-.NoLeftBorder {
-  border-top-left-radius: 0px;
-  border-bottom-left-radius: 0px;
-  border-left: none !important;
-}
-
 .selector button:disabled,
 .selector button:disabled:hover {
   color: var(--color-text-secondary);

--- a/src/controls/selectors/LanguageScopeSelector.tsx
+++ b/src/controls/selectors/LanguageScopeSelector.tsx
@@ -16,7 +16,7 @@ const LanguageScopeSelector: React.FC = () => {
 
   return (
     <Selector
-      selectorLabel="Language Scope:"
+      selectorLabel="Language Scope"
       selectorDescription={selectorDescription}
       options={Object.values(LanguageScope)}
       onChange={(scope: LanguageScope) =>

--- a/src/controls/selectors/LimitInput.tsx
+++ b/src/controls/selectors/LimitInput.tsx
@@ -1,24 +1,23 @@
 import React from 'react';
 
 import { View } from '../../types/PageParamTypes';
-import Selector from '../components/SelectorOld';
+import { OptionsDisplay } from '../components/Selector';
+import SelectorLabel from '../components/SelectorLabel';
 import TextInput from '../components/TextInput';
 import { usePageParams } from '../PageParamsContext';
 
 const LimitInput: React.FC = () => {
   const { limit, objectType, updatePageParams, view } = usePageParams();
-  if ([View.About].includes(view)) {
-    // Not supported for this view
-    return <></>;
-  }
 
   return (
-    <Selector
-      selectorLabel="Limit:"
-      selectorDescription={`Limit how many ${objectType.toLowerCase()} ${getLimitableObjectName(view)} are shown.`}
-    >
+    <div className="selector" style={{ display: 'flex', alignItems: 'center' }}>
+      <SelectorLabel
+        description={`Limit how many ${objectType.toLowerCase()} ${getLimitableObjectName(view)} are shown.`}
+        label="Item Limit"
+        optionsDisplay={OptionsDisplay.ButtonList}
+      />
       <TextInput
-        inputStyle={{ width: '3em' }}
+        inputStyle={{ minWidth: '3em' }}
         getSuggestions={async () => [
           { searchString: '8', label: '8' },
           { searchString: '20', label: '20' },
@@ -26,10 +25,11 @@ const LimitInput: React.FC = () => {
           { searchString: '200', label: '200' },
         ]}
         onChange={(limit: string) => updatePageParams({ limit: parseInt(limit) })}
+        optionsDisplay={OptionsDisplay.ButtonList}
         placeholder="∞"
         value={limit < 1 || Number.isNaN(limit) ? '' : limit.toString()}
       />
-    </Selector>
+    </div>
   );
 };
 

--- a/src/controls/selectors/SearchBar.tsx
+++ b/src/controls/selectors/SearchBar.tsx
@@ -2,6 +2,7 @@ import { SearchIcon } from 'lucide-react';
 import React from 'react';
 
 import { SearchableField, View } from '../../types/PageParamTypes';
+import { OptionsDisplay } from '../components/Selector';
 import Selector from '../components/SelectorOld';
 import SingleChoiceOptions from '../components/SingleChoiceOptions';
 import TextInput from '../components/TextInput';
@@ -19,6 +20,7 @@ const SearchBar: React.FC = () => {
         inputStyle={{ minWidth: '20em' }}
         getSuggestions={getSearchSuggestions}
         onChange={(searchString: string) => updatePageParams({ searchString })}
+        optionsDisplay={OptionsDisplay.ButtonGroup}
         placeholder="search"
         showGoToDetailsButton={true}
         showTextInputButton={view !== View.Details}

--- a/src/controls/selectors/TerritoryFilter.tsx
+++ b/src/controls/selectors/TerritoryFilter.tsx
@@ -1,0 +1,54 @@
+import React, { useMemo } from 'react';
+
+import { useDataContext } from '../../data/DataContext';
+import { SearchableField } from '../../types/PageParamTypes';
+import { getSearchableField, HighlightedObjectField } from '../../views/common/ObjectField';
+import { OptionsDisplay } from '../components/Selector';
+import SelectorLabel from '../components/SelectorLabel';
+import TextInput, { Suggestion } from '../components/TextInput';
+import { getScopeFilter } from '../filter';
+import { usePageParams } from '../PageParamsContext';
+
+const TerritoryFilter: React.FC = () => {
+  const { territoryFilter, updatePageParams } = usePageParams();
+  const { territories } = useDataContext();
+  const filterByScope = getScopeFilter();
+
+  const getSuggestions = useMemo(() => {
+    return async (query: string): Promise<Suggestion[]> => {
+      return Object.values(territories)
+        .filter(filterByScope)
+        .map((object) => {
+          const label = (
+            <HighlightedObjectField
+              object={object}
+              field={SearchableField.NameOrCode}
+              query={query}
+            />
+          );
+          const searchString = getSearchableField(object, SearchableField.NameOrCode);
+          return { objectID: object.ID, searchString, label };
+        });
+    };
+  }, [territories, filterByScope]);
+
+  return (
+    <div className="selector" style={{ display: 'flex', alignItems: 'center' }}>
+      <SelectorLabel
+        optionsDisplay={OptionsDisplay.ButtonList}
+        label="Territory"
+        description="Filter results by ones relevant in a territory."
+      />
+      <TextInput
+        inputStyle={{ minWidth: '10em' }}
+        optionsDisplay={OptionsDisplay.ButtonList}
+        getSuggestions={getSuggestions}
+        onChange={(territoryFilter: string) => updatePageParams({ territoryFilter })}
+        placeholder="Filter name or code"
+        value={territoryFilter}
+      />
+    </div>
+  );
+};
+
+export default TerritoryFilter;

--- a/src/controls/selectors/TerritoryScopeSelector.tsx
+++ b/src/controls/selectors/TerritoryScopeSelector.tsx
@@ -17,7 +17,7 @@ const TerritoryScopeSelector: React.FC = () => {
 
   return (
     <Selector
-      selectorLabel="Territory Scope:"
+      selectorLabel="Territory Scope"
       selectorDescription={selectorDescription}
       options={Object.values(TerritoryScope)}
       onChange={(scope: TerritoryScope) =>

--- a/src/controls/selectors/ViewSelector.tsx
+++ b/src/controls/selectors/ViewSelector.tsx
@@ -9,7 +9,7 @@ const ViewSelector: React.FC = () => {
 
   return (
     <Selector
-      selectorLabel="View:"
+      selectorLabel="View"
       getOptionDescription={(option) => <img src={getImageSrc(option)} width={180} />}
       options={Object.values(View)}
       onChange={(view: View) => updatePageParams({ view, objectID: undefined })}

--- a/src/controls/selectors/useSearchSuggestions.tsx
+++ b/src/controls/selectors/useSearchSuggestions.tsx
@@ -16,28 +16,21 @@ export function useSearchSuggestions(): (query: string) => Promise<Suggestion[]>
   const scopeFilter = getScopeFilter();
 
   const objects = useMemo(() => {
-    if (searchBy === SearchableField.Territory) {
-      return Object.values(territories);
-    } else {
-      switch (objectType) {
-        case ObjectType.Language:
-          return Object.values(languages);
-        case ObjectType.Locale:
-          return Object.values(locales);
-        case ObjectType.Territory:
-          return Object.values(territories);
-        case ObjectType.WritingSystem:
-          return Object.values(writingSystems);
-      }
+    switch (objectType) {
+      case ObjectType.Language:
+        return Object.values(languages);
+      case ObjectType.Locale:
+        return Object.values(locales);
+      case ObjectType.Territory:
+        return Object.values(territories);
+      case ObjectType.WritingSystem:
+        return Object.values(writingSystems);
     }
   }, [objectType, languages, locales, territories, writingSystems, searchBy]);
 
   const getSuggestions = useMemo(() => {
     return async (query: string) => {
-      const substringFilter = getSubstringFilterOnQuery(
-        query,
-        searchBy === SearchableField.Territory ? SearchableField.NameOrCode : searchBy,
-      );
+      const substringFilter = getSubstringFilterOnQuery(query, searchBy);
       return uniqueBy(
         (objects || [])
           .filter(scopeFilter)
@@ -45,15 +38,13 @@ export function useSearchSuggestions(): (query: string) => Promise<Suggestion[]>
           .slice(0, SEARCH_RESULTS_LIMIT)
           .map((object) => {
             let label = <HighlightedObjectField object={object} field={searchBy} query={query} />;
-            let searchString = getSearchableField(object, searchBy);
+            const searchString = getSearchableField(object, searchBy);
             if (searchBy === SearchableField.Code) {
               label = (
                 <>
                   {object.nameDisplay} [{label}]
                 </>
               );
-            } else if (searchBy === SearchableField.Territory) {
-              searchString = object.nameDisplay;
             }
             return { objectID: object.ID, searchString, label };
           }),

--- a/src/data/DataContext.tsx
+++ b/src/data/DataContext.tsx
@@ -114,3 +114,5 @@ export const useDataContext = () => {
   if (!context) throw new Error('useDataContext must be used within a DataProvider');
   return context;
 };
+
+export default DataProvider;

--- a/src/generic/HoverableButton.tsx
+++ b/src/generic/HoverableButton.tsx
@@ -28,6 +28,7 @@ const HoverableButton: React.FC<HoverableProps> = ({
           cursor: onClick ? 'pointer' : 'auto',
           ...style,
         }}
+        type="button"
       >
         {children}
       </button>

--- a/src/types/PageParamTypes.tsx
+++ b/src/types/PageParamTypes.tsx
@@ -31,7 +31,6 @@ export enum SearchableField {
   EngName = 'English Name',
   Endonym = 'Endonym',
   AllNames = 'All Names',
-  Territory = 'Territory',
 }
 
 export type LocaleSeparator = '-' | '_';
@@ -47,6 +46,7 @@ export type PageParamKey =
   | 'searchBy'
   | 'searchString'
   | 'sortBy'
+  | 'territoryFilter'
   | 'territoryScopes'
   | 'view';
 
@@ -61,6 +61,7 @@ export type PageParams = {
   searchBy: SearchableField;
   searchString: string;
   sortBy: SortBy;
+  territoryFilter: string;
   territoryScopes: TerritoryScope[];
   view: View;
 };
@@ -76,6 +77,7 @@ export type PageParamsOptional = {
   searchBy?: SearchableField;
   searchString?: string;
   sortBy?: SortBy;
+  territoryFilter?: string;
   territoryScopes?: TerritoryScope[];
   view?: View;
 };

--- a/src/views/Loading.tsx
+++ b/src/views/Loading.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const Loading: React.FC = () => {
+  return (
+    <div style={{ height: '100vh', textAlign: 'center', paddingTop: '20vh' }}>
+      <h2>Loading...</h2>
+      <p>Please wait while the content is being prepared.</p>
+    </div>
+  );
+};
+
+export default Loading;

--- a/src/views/PageBody.tsx
+++ b/src/views/PageBody.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import SearchBar from '../controls/selectors/SearchBar';
+
+import MainViews from './MainViews';
+
+const PageBody: React.FC = () => {
+  return (
+    <main style={{ padding: '1em', flex: 1, overflow: 'auto', width: '100%' }}>
+      <SearchBar />
+      <div
+        style={{
+          maxWidth: '1280px',
+          margin: '0 auto',
+          padding: '1rem 2rem',
+          textAlign: 'center',
+        }}
+      >
+        <MainViews />
+      </div>
+    </main>
+  );
+};
+
+export default PageBody;

--- a/src/views/PageContents.tsx
+++ b/src/views/PageContents.tsx
@@ -1,0 +1,26 @@
+import React, { Suspense } from 'react';
+
+import Loading from './Loading';
+
+const DataProvider = React.lazy(() => import('../data/DataContext'));
+
+const PageBody = React.lazy(() => import('./PageBody'));
+const SidePanel = React.lazy(() => import('../controls/SidePanel'));
+const ViewModal = React.lazy(() => import('./ViewModal'));
+
+const PageContents: React.FC = () => {
+  return (
+    // DataProvider and many other data components have more lines of code so they are loaded lazily
+    <Suspense fallback={<Loading />}>
+      <DataProvider>
+        <div style={{ display: 'flex', minHeight: '100vh' }}>
+          <SidePanel />
+          <PageBody />
+        </div>
+      </DataProvider>
+      <ViewModal />
+    </Suspense>
+  );
+};
+
+export default PageContents;

--- a/src/views/common/CardList.tsx
+++ b/src/views/common/CardList.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
-import { getScopeFilter, getSliceFunction, getSubstringFilter } from '../../controls/filter';
+import {
+  getFilterBySubstring,
+  getFilterByTerritory,
+  getScopeFilter,
+  getSliceFunction,
+} from '../../controls/filter';
 import { getSortFunction } from '../../controls/sort';
 import { ObjectData } from '../../types/DataTypes';
 import ViewCard from '../ViewCard';
@@ -15,14 +20,22 @@ interface Props<T> {
 
 function CardList<T extends ObjectData>({ objects, renderCard }: Props<T>) {
   const sortBy = getSortFunction();
-  const filterBySubstring = getSubstringFilter() || (() => true);
+  const filterBySubstring = getFilterBySubstring();
+  const filterByTerritory = getFilterByTerritory();
   const filterByScope = getScopeFilter();
   const sliceFunction = getSliceFunction<T>();
 
   // Filter results
   const objectsVisible = useMemo(
-    () => sliceFunction(objects.filter(filterByScope).filter(filterBySubstring).sort(sortBy)),
-    [objects, filterByScope, filterBySubstring, sortBy, sliceFunction],
+    () =>
+      sliceFunction(
+        objects
+          .filter(filterByScope)
+          .filter(filterByTerritory)
+          .filter(filterBySubstring)
+          .sort(sortBy),
+      ),
+    [objects, filterByScope, filterByTerritory, filterBySubstring, sortBy, sliceFunction],
   );
 
   return (

--- a/src/views/common/ObjectField.tsx
+++ b/src/views/common/ObjectField.tsx
@@ -71,7 +71,6 @@ export function getSearchableField(object: ObjectData, field: SearchableField, q
     case SearchableField.EngName:
       return object.nameDisplay;
     case SearchableField.NameOrCode:
-    case SearchableField.Territory:
       return object.nameDisplay + ' [' + object.codeDisplay + ']';
   }
 }

--- a/src/views/common/TreeList/TreeListPageBody.tsx
+++ b/src/views/common/TreeList/TreeListPageBody.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
-import { getSubstringFilter } from '../../../controls/filter';
+import { getFilterBySubstring, getFilterByTerritory } from '../../../controls/filter';
 import { usePageParams } from '../../../controls/PageParamsContext';
+import { ObjectData } from '../../../types/DataTypes';
 
 import { filterBranch } from './filterBranch';
 import { TreeNodeData } from './TreeListNode';
 import { TreeListOptionsProvider, TreeListOptionsSelectors } from './TreeListOptions';
 import TreeListRoot from './TreeListRoot';
+
 import './treelist.css';
 
 type Props = {
@@ -16,7 +18,14 @@ type Props = {
 
 const TreeListPageBody: React.FC<Props> = ({ rootNodes, description }) => {
   const { limit } = usePageParams();
-  const substringFilterFunction = getSubstringFilter();
+  const filterBySubstring = getFilterBySubstring();
+  const filterByTerritory = getFilterByTerritory();
+  const filterFunction = useCallback(
+    (object: ObjectData) => {
+      return filterBySubstring(object) && filterByTerritory(object);
+    },
+    [filterBySubstring, filterByTerritory],
+  );
 
   return (
     <div className="TreeListView">
@@ -24,7 +33,7 @@ const TreeListPageBody: React.FC<Props> = ({ rootNodes, description }) => {
         <div style={{ marginBottom: 8 }}>{description}</div>
         <TreeListRoot
           rootNodes={rootNodes
-            .map((node) => filterBranch(node, substringFilterFunction))
+            .map((node) => filterBranch(node, filterFunction))
             .filter((node) => node != null)
             .slice(0, limit > 0 ? limit : undefined)}
         />

--- a/src/views/common/table/ObjectTable.tsx
+++ b/src/views/common/table/ObjectTable.tsx
@@ -1,7 +1,12 @@
 import { ArrowUpDownIcon } from 'lucide-react';
 import React, { Dispatch, SetStateAction, useMemo, useState, useCallback } from 'react';
 
-import { getScopeFilter, getSliceFunction, getSubstringFilter } from '../../../controls/filter';
+import {
+  getFilterBySubstring,
+  getFilterByTerritory,
+  getScopeFilter,
+  getSliceFunction,
+} from '../../../controls/filter';
 import { usePageParams } from '../../../controls/PageParamsContext';
 import { getSortFunction } from '../../../controls/sort';
 import HoverableButton from '../../../generic/HoverableButton';
@@ -30,7 +35,8 @@ interface Props<T> {
  */
 function ObjectTable<T extends ObjectData>({ objects, columns }: Props<T>) {
   const sortBy = getSortFunction();
-  const substringFilter = getSubstringFilter() ?? (() => true);
+  const filterBySubstring = getFilterBySubstring();
+  const filterByTerritory = getFilterByTerritory();
   const scopeFilter = getScopeFilter();
   const [sortDirectionIsNormal, setSortDirectionIsNormal] = useState(true);
 
@@ -52,14 +58,14 @@ function ObjectTable<T extends ObjectData>({ objects, columns }: Props<T>) {
   const sliceFunction = getSliceFunction<T>();
 
   const objectsFilteredAndSorted = useMemo(() => {
-    let result = objects.filter(scopeFilter).filter(substringFilter);
+    let result = objects.filter(scopeFilter).filter(filterByTerritory).filter(filterBySubstring);
     if (sortDirectionIsNormal) {
       result = result.sort(sortBy);
     } else {
       result = result.sort((a, b) => -sortBy(a, b));
     }
     return result;
-  }, [sortBy, objects, substringFilter, scopeFilter, sortDirectionIsNormal]);
+  }, [sortBy, objects, filterBySubstring, filterByTerritory, scopeFilter, sortDirectionIsNormal]);
 
   return (
     <div className="ObjectTableContainer">

--- a/src/views/language/DubiousLanguages.tsx
+++ b/src/views/language/DubiousLanguages.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 
-import { getSliceFunction, getSubstringFilter } from '../../controls/filter';
+import {
+  getFilterBySubstring,
+  getFilterByTerritory,
+  getSliceFunction,
+} from '../../controls/filter';
 import { usePageParams } from '../../controls/PageParamsContext';
 import LimitInput from '../../controls/selectors/LimitInput';
 import PaginationControls from '../../controls/selectors/PaginationControls';
@@ -18,11 +22,13 @@ const DubiousLanguages: React.FC = () => {
     territories,
   } = useDataContext();
   const { page, limit } = usePageParams();
-  const filterFunction = getSubstringFilter() ?? (() => true);
+  const filterBySubstring = getFilterBySubstring();
+  const filterByTerritory = getFilterByTerritory();
   const sortFunction = getSortFunction();
   const sliceFunction = getSliceFunction<LanguageData>();
   const languages = Object.values(Inclusive)
-    .filter(filterFunction)
+    .filter(filterBySubstring)
+    .filter(filterByTerritory)
     .filter((lang) => lang.codeDisplay.match('xx.-|^[0-9]'));
 
   return (

--- a/src/views/language/LanguagesWithIdenticalNames.tsx
+++ b/src/views/language/LanguagesWithIdenticalNames.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 
-import { getSliceFunction, getSubstringFilter } from '../../controls/filter';
+import {
+  getFilterBySubstring,
+  getFilterByTerritory,
+  getSliceFunction,
+} from '../../controls/filter';
 import { usePageParams } from '../../controls/PageParamsContext';
 import LimitInput from '../../controls/selectors/LimitInput';
 import PaginationControls from '../../controls/selectors/PaginationControls';
@@ -19,11 +23,13 @@ const LanguagesWithIdenticalNames: React.FC = () => {
     languagesBySchema: { Inclusive },
   } = useDataContext();
   const { page, limit } = usePageParams();
-  const filterFunction = getSubstringFilter() ?? (() => true);
+  const filterBySubstring = getFilterBySubstring();
+  const filterByTerritory = getFilterByTerritory();
   const sortFunction = getSortFunction();
   const sliceFunction = getSliceFunction<[string, LanguageData[]]>();
   const languagesByName = Object.values(Inclusive)
-    .filter(filterFunction)
+    .filter(filterBySubstring)
+    .filter(filterByTerritory)
     .reduce<Record<string, LanguageData[]>>((languagesByName, lang) => {
       const name = lang.nameDisplay;
       if (languagesByName[name] == null) {

--- a/src/views/locale/PotentialLocales.tsx
+++ b/src/views/locale/PotentialLocales.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 
+import { OptionsDisplay } from '../../controls/components/Selector';
 import Selector from '../../controls/components/SelectorOld';
 import TextInput from '../../controls/components/TextInput';
 import { getScopeFilter } from '../../controls/filter';
@@ -71,6 +72,7 @@ const PotentialLocales: React.FC = () => {
             { searchString: '5', label: '5%' },
             { searchString: '10', label: '10%' },
           ]}
+          optionsDisplay={OptionsDisplay.ButtonGroup}
           onChange={(percent: string) => setPercentThreshold(Number(percent))}
           placeholder=""
           value={Number.isNaN(percentThreshold) ? '' : percentThreshold.toString()}


### PR DESCRIPTION
The search bar had a "territory" option but imho that was overloading the search bar since it was hard to discover.

Now you can use the territory filter separately! While I was here I also changed lazy loading to break up the JS filesize and I improved the rendering of text-input controls in the sidepanel.

|Before|After|
|--|--|
|<img width="1416" height="830" alt="Screenshot 2025-07-25 at 20 16 41" src="https://github.com/user-attachments/assets/422cc882-f470-4dce-be39-7eb522ff2b84" />|<img width="1423" height="828" alt="Screenshot 2025-07-25 at 20 17 17" src="https://github.com/user-attachments/assets/1c675b21-ff15-4a5e-9892-ae90f0fdcde8" />
