### PR TITLE
Refactor: Change Language "Schema"/"Definition" to "Source"

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Here's a list of planned functionality. Completed functions are checked off.
   - [ ] Export
 - [ ] Manage data sources
   - [x] Show results based on different definitions of what a language is
-    - [x] ISO, Glottolog, Inclusive
+    - [x] ISO, Glottolog, CLDR, All
     - [x] Highlight language codes in each
   - [ ] Add a better guide for different kinds of users
 - [x] About Page

--- a/src/controls/ControlsBar.tsx
+++ b/src/controls/ControlsBar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import LanguageSchemaSelector from './selectors/LanguageSchemaSelector';
 import LanguageScopeSelector from './selectors/LanguageScopeSelector';
+import LanguageSourceSelector from './selectors/LanguageSourceSelector';
 import LimitInput from './selectors/LimitInput';
 import LocaleSeparatorSelector from './selectors/LocaleSeparatorSelector';
 import SortBySelector from './selectors/SortBySelector';
@@ -12,7 +12,7 @@ import './controls.css';
 const ControlsBar: React.FC = () => {
   return (
     <>
-      <LanguageSchemaSelector />
+      <LanguageSourceSelector />
       <LimitInput />
       <SortBySelector />
       <LanguageScopeSelector />

--- a/src/controls/PageParamsContext.tsx
+++ b/src/controls/PageParamsContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useCallback, useContext, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { TerritoryScope } from '../types/DataTypes';
-import { LanguageSchema, LanguageScope } from '../types/LanguageTypes';
+import { LanguageSource, LanguageScope } from '../types/LanguageTypes';
 import {
   ObjectType,
   PageParamKey,
@@ -39,11 +39,11 @@ const PageParamsProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     const view = getParam('view', DEFAULT_VIEW) as View;
     const defaults = getDefaultParams(objectType, view);
     return {
-      languageSchema: getParam('languageSchema', defaults.languageSchema) as LanguageSchema,
       languageScopes: getParam('languageScopes', defaults.languageScopes.join(','))
         .split(',')
         .map((s) => s as LanguageScope)
         .filter(Boolean),
+      languageSource: getParam('languageSource', defaults.languageSource) as LanguageSource,
       limit: parseInt(getParam('limit', defaults.limit.toString())),
       localeSeparator: getParam('localeSeparator', '') === '-' ? '-' : '_',
       objectID: getParam('objectID', undefined),
@@ -78,7 +78,7 @@ function getDefaultParams(objectType: ObjectType, view: View): PageParams {
   }
 
   return {
-    languageSchema: LanguageSchema.Inclusive,
+    languageSource: LanguageSource.All,
     languageScopes,
     limit: view === View.Table ? 200 : 8,
     localeSeparator: '_',

--- a/src/controls/SidePanel.tsx
+++ b/src/controls/SidePanel.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 
 import HoverableButton from '../generic/HoverableButton';
 
-import LanguageSchemaSelector from './selectors/LanguageSchemaSelector';
 import LanguageScopeSelector from './selectors/LanguageScopeSelector';
+import LanguageListSourceSelector from './selectors/LanguageSourceSelector';
 import LimitInput from './selectors/LimitInput';
 import LocaleSeparatorSelector from './selectors/LocaleSeparatorSelector';
 import ObjectTypeSelector from './selectors/ObjectTypeSelector';
@@ -25,7 +25,7 @@ const SidePanel: React.FC = () => {
       <SidePanelSection>
         <SidePanelSectionTitle>Data</SidePanelSectionTitle>
         <ObjectTypeSelector />
-        <LanguageSchemaSelector />
+        <LanguageListSourceSelector />
       </SidePanelSection>
 
       <SidePanelSection>

--- a/src/controls/selectors/LanguageSourceSelector.tsx
+++ b/src/controls/selectors/LanguageSourceSelector.tsx
@@ -1,41 +1,47 @@
 import React from 'react';
 
-import { LanguageSchema } from '../../types/LanguageTypes';
+import { LanguageSource } from '../../types/LanguageTypes';
 import Selector, { OptionsDisplay } from '../components/Selector';
 import { usePageParams } from '../PageParamsContext';
 
-const LanguageSchemaSelector: React.FC = () => {
-  const { languageSchema, updatePageParams } = usePageParams();
-  const selectorDescription =
-    "Languages have fuzzy boundaries and different authorities categorize potential languages differently. For example, what's a dialect versus a language, or if a language is even attested. Use this option to change what languages appear and what they are considered (family / individual / dialect). This may also change the language code & language name shown.";
+const LanguageListSourceSelector: React.FC = () => {
+  const { languageSource, updatePageParams } = usePageParams();
+  const selectorDescription = (
+    <>
+      Languages have fuzzy boundaries and different sources categorize potential languages
+      differently. For example, what&apos;s a dialect versus a language, or if a language is even
+      attested. Use this option to change what languages appear and what they are considered (family
+      / individual / dialect). This may also change the language codes, names, and parent/child
+      relationships.
+    </>
+  );
 
   return (
     <Selector
-      selectorLabel="Language Definition"
+      selectorLabel="Source of the List of Languages"
       selectorDescription={selectorDescription}
-      options={Object.values(LanguageSchema)}
+      options={Object.values(LanguageSource)}
       optionsDisplay={OptionsDisplay.ButtonList}
-      onChange={(languageSchema: LanguageSchema) => updatePageParams({ languageSchema })}
-      selected={languageSchema}
-      getOptionDescription={(languageSchema) => (
-        <LanguageSchemaDescription languageSchema={languageSchema} />
+      onChange={(languageSource: LanguageSource) => updatePageParams({ languageSource })}
+      selected={languageSource}
+      getOptionDescription={(languageSource) => (
+        <LanguageSourceDescription languageSource={languageSource} />
       )}
     />
   );
 };
 
-const LanguageSchemaDescription: React.FC<{ languageSchema: LanguageSchema }> = ({
-  languageSchema,
+const LanguageSourceDescription: React.FC<{ languageSource: LanguageSource }> = ({
+  languageSource,
 }) => {
-  switch (languageSchema) {
-    case LanguageSchema.Inclusive:
+  switch (languageSource) {
+    case LanguageSource.All:
       return (
         <>
-          <label>Inclusive:</label>Show all languages and dialects, regardless of where it was
-          defined.
+          <label>All:</label>Show all languages and dialects, regardless of where it was defined.
         </>
       );
-    case LanguageSchema.ISO:
+    case LanguageSource.ISO:
       return (
         <>
           <label>International Standards Organization (ISO):</label>The languages and macrolanguages
@@ -45,7 +51,7 @@ const LanguageSchemaDescription: React.FC<{ languageSchema: LanguageSchema }> = 
           languages and macrolanguages or the ISO 639-5 standard for language families.
         </>
       );
-    case LanguageSchema.UNESCO:
+    case LanguageSource.UNESCO:
       return (
         <>
           <label>UNESCO&apos;s World Atlas of Languages (WAL):</label>The languages that have been
@@ -53,14 +59,14 @@ const LanguageSchemaDescription: React.FC<{ languageSchema: LanguageSchema }> = 
           World Atlas of Languages.
         </>
       );
-    case LanguageSchema.Glottolog:
+    case LanguageSource.Glottolog:
       return (
         <>
           <label>Glottolog:</label>The languoids shown in the Glottolog database. This schema will
           include many more language families than ISO.
         </>
       );
-    case LanguageSchema.CLDR:
+    case LanguageSource.CLDR:
       return (
         <>
           <label>CLDR:</label>The languages supported by Unicode&apos;s tooling that is used by most
@@ -75,4 +81,4 @@ const LanguageSchemaDescription: React.FC<{ languageSchema: LanguageSchema }> = 
   }
 };
 
-export default LanguageSchemaSelector;
+export default LanguageListSourceSelector;

--- a/src/controls/sort.tsx
+++ b/src/controls/sort.tsx
@@ -1,14 +1,14 @@
 import { ObjectData } from '../types/DataTypes';
-import { LanguageSchema } from '../types/LanguageTypes';
+import { LanguageSource } from '../types/LanguageTypes';
 import { ObjectType, SortBy, View } from '../types/PageParamTypes';
 
 import { usePageParams } from './PageParamsContext';
 
 export type SortByFunctionType = (a: ObjectData, b: ObjectData) => number;
 
-export function getSortFunction(languageSchema?: LanguageSchema): SortByFunctionType {
-  const { sortBy, view, languageSchema: languageSchemaPageParam } = usePageParams();
-  const effectiveLanguageSchema = languageSchema ?? languageSchemaPageParam;
+export function getSortFunction(languageSource?: LanguageSource): SortByFunctionType {
+  const { sortBy, view, languageSource: languageSourcePageParam } = usePageParams();
+  const effectiveLanguageSource = languageSource ?? languageSourcePageParam;
 
   switch (sortBy) {
     case SortBy.Code:
@@ -31,8 +31,8 @@ export function getSortFunction(languageSchema?: LanguageSchema): SortByFunction
               ? (b.populationCited ?? 0) -
                   (a.populationCited ?? 0) +
                   (view === View.Hierarchy
-                    ? (b.schemaSpecific[effectiveLanguageSchema].populationOfDescendents ?? 0) -
-                      (a.schemaSpecific[effectiveLanguageSchema].populationOfDescendents ?? 0)
+                    ? (b.sourceSpecific[effectiveLanguageSource].populationOfDescendents ?? 0) -
+                      (a.sourceSpecific[effectiveLanguageSource].populationOfDescendents ?? 0)
                     : 0)
               : -1;
           case ObjectType.Locale:

--- a/src/data/CensusData.tsx
+++ b/src/data/CensusData.tsx
@@ -205,7 +205,7 @@ export function addCensusData(coreData: CoreData, censusData: CensusImport): voi
   // Add alternative language names to the language data
   Object.entries(censusData.languageNames).forEach(([languageCode, languageName]) => {
     // Assuming languageCode is using the canonical ID (eg. eng not en or stan1293)
-    const language = coreData.languagesBySchema.Inclusive[languageCode];
+    const language = coreData.languagesBySource.All[languageCode];
     if (language != null) {
       // Split on / since some censuses have multiple names for the same language
       languageName

--- a/src/data/CoreData.tsx
+++ b/src/data/CoreData.tsx
@@ -9,7 +9,7 @@ import {
   TerritoryData,
   WritingSystemData,
 } from '../types/DataTypes';
-import { LanguagesBySchema } from '../types/LanguageTypes';
+import { LanguagesBySource } from '../types/LanguageTypes';
 
 import {
   addISODataToLanguages,
@@ -25,7 +25,7 @@ import {
   connectLanguagesToParent,
   connectLocales,
   connectWritingSystems,
-  groupLanguagesBySchema,
+  groupLanguagesBySource,
 } from './DataAssociations';
 import { loadLanguages, loadLocales, loadWritingSystems } from './DataLoader';
 import {
@@ -43,14 +43,14 @@ import { addCLDRLanguageDetails } from './UnicodeData';
 
 export type CoreData = {
   censuses: Record<CensusID, CensusData>;
-  languagesBySchema: LanguagesBySchema;
+  languagesBySource: LanguagesBySource;
   locales: Record<BCP47LocaleCode, LocaleData>;
   territories: Record<TerritoryCode, TerritoryData>;
   writingSystems: Record<ScriptCode, WritingSystemData>;
 };
 
-export const EMPTY_LANGUAGES_BY_SCHEMA: LanguagesBySchema = {
-  Inclusive: {},
+export const EMPTY_LANGUAGES_BY_SCHEMA: LanguagesBySource = {
+  All: {},
   ISO: {},
   Glottolog: {},
   UNESCO: {},
@@ -65,8 +65,8 @@ export function useCoreData(): {
   loadCoreData: () => Promise<void>;
   coreData: CoreData;
 } {
-  const [languagesBySchema, setLanguagesBySchema] =
-    useState<LanguagesBySchema>(EMPTY_LANGUAGES_BY_SCHEMA);
+  const [languagesBySource, setLanguagesBySource] =
+    useState<LanguagesBySource>(EMPTY_LANGUAGES_BY_SCHEMA);
   const [locales, setLocales] = useState<Record<BCP47LocaleCode, LocaleData>>({});
   const [territories, setTerritories] = useState<Record<TerritoryCode, TerritoryData>>({});
   const [writingSystems, setWritingSystems] = useState<Record<ScriptCode, WritingSystemData>>({});
@@ -108,21 +108,21 @@ export function useCoreData(): {
     }
 
     addISODataToLanguages(initialLangs, isoLangs || []);
-    const languagesBySchema = groupLanguagesBySchema(initialLangs);
-    addISOLanguageFamilyData(languagesBySchema, langFamilies || [], isoLangsToFamilies || {});
-    addISOMacrolanguageData(languagesBySchema.ISO, macroLangs || []);
-    addGlottologLanguages(languagesBySchema, glottologImport || [], manualGlottocodeToISO || {});
-    addCLDRLanguageDetails(languagesBySchema);
-    addIANAVariantLocales(languagesBySchema, locales, ianaVariants);
+    const languagesBySource = groupLanguagesBySource(initialLangs);
+    addISOLanguageFamilyData(languagesBySource, langFamilies || [], isoLangsToFamilies || {});
+    addISOMacrolanguageData(languagesBySource.ISO, macroLangs || []);
+    addGlottologLanguages(languagesBySource, glottologImport || [], manualGlottocodeToISO || {});
+    addCLDRLanguageDetails(languagesBySource);
+    addIANAVariantLocales(languagesBySource, locales, ianaVariants);
 
-    connectLanguagesToParent(languagesBySchema);
+    connectLanguagesToParent(languagesBySource);
     connectTerritoriesToParent(territories);
-    connectWritingSystems(languagesBySchema.Inclusive, territories, writingSystems);
-    connectLocales(languagesBySchema.Inclusive, territories, writingSystems, locales);
+    connectWritingSystems(languagesBySource.All, territories, writingSystems);
+    connectLocales(languagesBySource.All, territories, writingSystems, locales);
     createRegionalLocales(territories, locales); // create them after connecting them
-    computeOtherPopulationStatistics(languagesBySchema, writingSystems);
+    computeOtherPopulationStatistics(languagesBySource, writingSystems);
 
-    setLanguagesBySchema(languagesBySchema);
+    setLanguagesBySource(languagesBySource);
     setTerritories(territories);
     setLocales(locales);
     setWritingSystems(writingSystems);
@@ -132,7 +132,7 @@ export function useCoreData(): {
     loadCoreData,
     coreData: {
       censuses,
-      languagesBySchema,
+      languagesBySource,
       locales,
       territories,
       writingSystems,

--- a/src/data/DataParsing.tsx
+++ b/src/data/DataParsing.tsx
@@ -22,8 +22,8 @@ export function parseLanguageLine(line: string): LanguageData {
   const parentLanguageCode = parts[11] != '' ? parts[11] : undefined;
   const parentISOCode = parts[11] != '' && parts[11].length <= 3 ? parts[11] : undefined;
   const parentGlottocode = parts[12] != '' ? parts[12] : undefined;
-  const schemaSpecific = {
-    Inclusive: { code, name: nameDisplay, parentLanguageCode, childLanguages: [] },
+  const sourceSpecific = {
+    All: { code, name: nameDisplay, parentLanguageCode, childLanguages: [] },
     ISO: { code, parentLanguageCode: parentISOCode, childLanguages: [] },
     UNESCO: { code, name: nameDisplay, parentLanguageCode: parentISOCode, childLanguages: [] },
     Glottolog: {
@@ -62,7 +62,7 @@ export function parseLanguageLine(line: string): LanguageData {
     primaryScriptCode: parts[5] != '' ? parts[5] : undefined,
 
     // References to other objects, filled in with DataAssociations methods
-    schemaSpecific,
+    sourceSpecific,
     locales: [],
     primaryWritingSystem: undefined,
     writingSystems: {},

--- a/src/data/GlottologData.tsx
+++ b/src/data/GlottologData.tsx
@@ -2,7 +2,7 @@ import {
   Glottocode,
   LanguageCode,
   LanguageData,
-  LanguagesBySchema,
+  LanguagesBySource,
   LanguageScope,
 } from '../types/LanguageTypes';
 import { ObjectType } from '../types/PageParamTypes';
@@ -71,38 +71,38 @@ export async function loadManualGlottocodeToISO(): Promise<Record<
 
 /**
  *
- * languagesBySchema.Glottolog is updated with new entries
+ * languagesBySource.Glottolog is updated with new entries
  */
 export function addGlottologLanguages(
-  languagesBySchema: LanguagesBySchema,
+  languagesBySource: LanguagesBySource,
   glottologImport: GlottologData[],
   manualGlottocodeToISO: Record<Glottocode, LanguageCode>,
 ): void {
-  // Add the entries from the manualGlottocodeToISO to languagesBySchema.Glottolog
+  // Add the entries from the manualGlottocodeToISO to languagesBySource.Glottolog
   Object.entries(manualGlottocodeToISO).forEach(([glottoCode, isoCode]) => {
     if (glottoCode === '' || glottoCode[0] === '<') {
       return; // Skip empty or invalid glottocodes
     }
 
-    const glottolang = languagesBySchema.Glottolog[glottoCode];
-    const isoLang = languagesBySchema.ISO[isoCode];
+    const glottolang = languagesBySource.Glottolog[glottoCode];
+    const isoLang = languagesBySource.ISO[isoCode];
     if (glottolang == null && isoLang != null) {
-      isoLang.schemaSpecific.Glottolog.code = glottoCode;
-      languagesBySchema.Glottolog[glottoCode] = isoLang;
+      isoLang.sourceSpecific.Glottolog.code = glottoCode;
+      languagesBySource.Glottolog[glottoCode] = isoLang;
     }
   });
 
   // Add new glottocodes from the import
   glottologImport.forEach((importedLanguage) => {
     const { glottoCode, parentGlottocode, scope, name } = importedLanguage;
-    const lang = languagesBySchema.Glottolog[glottoCode];
+    const lang = languagesBySource.Glottolog[glottoCode];
     const parentLanguageCode =
-      parentGlottocode != null ? languagesBySchema.Glottolog[parentGlottocode]?.ID : undefined;
+      parentGlottocode != null ? languagesBySource.Glottolog[parentGlottocode]?.ID : undefined;
 
     if (lang == null) {
       // Create new LanguageData
-      const schemaSpecific = {
-        Inclusive: {
+      const sourceSpecific = {
+        All: {
           code: glottoCode,
           scope,
           parentLanguageCode: parentLanguageCode ?? parentGlottocode,
@@ -129,21 +129,21 @@ export function addGlottologLanguages(
         scope,
         viabilityConfidence: 'No',
         viabilityExplanation: 'Glottolog entry not found in ISO',
-        schemaSpecific,
+        sourceSpecific,
         writingSystems: {},
         locales: [],
         childLanguages: [],
       };
-      languagesBySchema.Inclusive[glottoCode] = newLang;
-      languagesBySchema.Glottolog[glottoCode] = newLang;
+      languagesBySource.All[glottoCode] = newLang;
+      languagesBySource.Glottolog[glottoCode] = newLang;
     } else {
       // Fill in missing data
       if (parentGlottocode != null) {
-        lang.schemaSpecific.Inclusive.parentLanguageCode = parentLanguageCode ?? parentGlottocode; // Prefer original parentage
-        lang.schemaSpecific.Glottolog.parentLanguageCode = parentGlottocode;
+        lang.sourceSpecific.All.parentLanguageCode = parentLanguageCode ?? parentGlottocode; // Prefer original parentage
+        lang.sourceSpecific.Glottolog.parentLanguageCode = parentGlottocode;
       }
-      lang.schemaSpecific.Glottolog.scope = scope;
-      lang.schemaSpecific.Glottolog.name = name;
+      lang.sourceSpecific.Glottolog.scope = scope;
+      lang.sourceSpecific.Glottolog.name = name;
       if (lang.scope == null) {
         lang.scope = scope;
       } else if (DEBUG && scope != lang.scope) {

--- a/src/data/IANAData.tsx
+++ b/src/data/IANAData.tsx
@@ -1,5 +1,5 @@
 import { LocaleData, PopulationSourceCategory } from '../types/DataTypes';
-import { LanguagesBySchema } from '../types/LanguageTypes';
+import { LanguagesBySource } from '../types/LanguageTypes';
 import { ObjectType } from '../types/PageParamTypes';
 
 export interface IANAVariantData {
@@ -44,7 +44,7 @@ export function parseIANAVariants(input: string): IANAVariantData[] {
 }
 
 export function addIANAVariantLocales(
-  languagesBySchema: LanguagesBySchema,
+  languagesBySource: LanguagesBySource,
   locales: Record<string, LocaleData>,
   variants: IANAVariantData[] | void,
 ): void {
@@ -52,7 +52,7 @@ export function addIANAVariantLocales(
 
   for (const variant of variants) {
     for (const prefix of variant.prefixes) {
-      const cldrLang = languagesBySchema.CLDR[prefix];
+      const cldrLang = languagesBySource.CLDR[prefix];
       if (!cldrLang) continue;
 
       const iso639_3 = cldrLang.ID;

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -2,7 +2,7 @@ import React, { PropsWithChildren, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 
 import { getNewURL } from '../controls/PageParamsContext';
-import { LanguageSchema } from '../types/LanguageTypes';
+import { LanguageSource } from '../types/LanguageTypes';
 import { PageParamsOptional } from '../types/PageParamTypes';
 
 import CreativeCommonsLicense from './CreativeCommonsLicense';
@@ -48,17 +48,17 @@ const AboutPage: React.FC = () => {
             The Language Navigator highlights not only widely spoken languages but also those
             recognized by specific communities, even if they lack global consensus. Where data is
             disputed or incomplete, we aim for transparency. Users can see{' '}
-            <DataPageLink params={{ languageSchema: LanguageSchema.Inclusive }}>
+            <DataPageLink params={{ languageSource: LanguageSource.All }}>
               all attested languages
             </DataPageLink>{' '}
             or choose to follow specific standards like{' '}
-            <DataPageLink params={{ languageSchema: LanguageSchema.ISO }}>ISO 639-3/5</DataPageLink>
+            <DataPageLink params={{ languageSource: LanguageSource.ISO }}>ISO 639-3/5</DataPageLink>
             ,{' '}
-            <DataPageLink params={{ languageSchema: LanguageSchema.Glottolog }}>
+            <DataPageLink params={{ languageSource: LanguageSource.Glottolog }}>
               Glottolog
             </DataPageLink>
-            , <DataPageLink params={{ languageSchema: LanguageSchema.UNESCO }}>UNESCO</DataPageLink>
-            , or <DataPageLink params={{ languageSchema: LanguageSchema.CLDR }}>CLDR</DataPageLink>.
+            , <DataPageLink params={{ languageSource: LanguageSource.UNESCO }}>UNESCO</DataPageLink>
+            , or <DataPageLink params={{ languageSource: LanguageSource.CLDR }}>CLDR</DataPageLink>.
           </DictionaryEntry>
         </dl>
       </Section>
@@ -229,15 +229,15 @@ const AboutPage: React.FC = () => {
             their respective original database (ISO, Glottolog, CLDR). When an object has multiple
             identities, it has been manually matched by the Language Navigator team to a single
             entity. For instance, English is represented in CLDR by the ISO 639-1 code{' '}
-            <DataPageLink params={{ languageSchema: LanguageSchema.CLDR, objectID: 'eng' }}>
+            <DataPageLink params={{ languageSource: LanguageSource.CLDR, objectID: 'eng' }}>
               en
             </DataPageLink>
             , the ISO 639-3 code{' '}
-            <DataPageLink params={{ languageSchema: LanguageSchema.ISO, objectID: 'eng' }}>
+            <DataPageLink params={{ languageSource: LanguageSource.ISO, objectID: 'eng' }}>
               eng
             </DataPageLink>
             , and the Glottocode{' '}
-            <DataPageLink params={{ languageSchema: LanguageSchema.Glottolog, objectID: 'eng' }}>
+            <DataPageLink params={{ languageSource: LanguageSource.Glottolog, objectID: 'eng' }}>
               stan1293
             </DataPageLink>
             .

--- a/src/types/LanguageTypes.tsx
+++ b/src/types/LanguageTypes.tsx
@@ -15,10 +15,10 @@ import { LocaleData, ObjectBase, ScriptCode, WritingSystemData } from './DataTyp
 import { ObjectType } from './PageParamTypes';
 
 export type LanguageDictionary = Record<LanguageCode, LanguageData>;
-export type LanguagesBySchema = Record<LanguageSchema, LanguageDictionary>;
+export type LanguagesBySource = Record<LanguageSource, LanguageDictionary>;
 
-export enum LanguageSchema {
-  Inclusive = 'Inclusive',
+export enum LanguageSource {
+  All = 'All',
   ISO = 'ISO',
   UNESCO = 'UNESCO',
   Glottolog = 'Glottolog',
@@ -58,12 +58,12 @@ export interface LanguageData extends ObjectBase {
 
   // Provided by the TSV files
   ID: LanguageCode; // Stable ID, favors ISO
-  codeDisplay: LanguageCode; // Changes with different language schema
+  codeDisplay: LanguageCode; // Changes with different language source
   codeISO6391?: LanguageCode;
   scope?: LanguageScope;
 
-  nameCanonical: string; // Stays the same with different language schema
-  nameDisplay: string; // May update if a language schema has a different name
+  nameCanonical: string; // Stays the same with different language source
+  nameDisplay: string; // May update if a language source has a different name
   nameSubtitle?: string;
   nameEndonym?: string;
 
@@ -82,7 +82,7 @@ export interface LanguageData extends ObjectBase {
   modality?: LanguageModality;
   primaryScriptCode?: ScriptCode;
 
-  schemaSpecific: Record<LanguageSchema, LanguageDataInSchema>;
+  sourceSpecific: Record<LanguageSource, LanguageDataInSource>;
   cldrCoverage?: CLDRCoverageData;
   cldrDataProvider?: LanguageData | LocaleData;
 
@@ -94,8 +94,8 @@ export interface LanguageData extends ObjectBase {
   childLanguages: LanguageData[];
 }
 
-// Since languages can be categorized by ISO, Glottolog, or other schema, these values will vary based on the language schema
-type LanguageDataInSchema = {
+// Since languages can be categorized by ISO, Glottolog, or other source, these values will vary based on the language source
+type LanguageDataInSource = {
   code?: LanguageCode;
   name?: string;
   scope?: LanguageScope;

--- a/src/types/PageParamTypes.tsx
+++ b/src/types/PageParamTypes.tsx
@@ -1,5 +1,5 @@
 import { TerritoryScope } from './DataTypes';
-import { LanguageSchema, LanguageScope } from './LanguageTypes';
+import { LanguageSource, LanguageScope } from './LanguageTypes';
 
 export enum ObjectType {
   Language = 'Language',
@@ -35,7 +35,7 @@ export enum SearchableField {
 export type LocaleSeparator = '-' | '_';
 
 export type PageParamKey =
-  | 'languageSchema'
+  | 'languageSource'
   | 'languageScopes'
   | 'limit'
   | 'localeSeparator'
@@ -50,8 +50,8 @@ export type PageParamKey =
   | 'view';
 
 export type PageParams = {
-  languageSchema: LanguageSchema;
   languageScopes: LanguageScope[];
+  languageSource: LanguageSource;
   limit: number; // < 1 means show all
   localeSeparator: LocaleSeparator;
   objectID?: string;
@@ -66,8 +66,8 @@ export type PageParams = {
 };
 
 export type PageParamsOptional = {
-  languageSchema?: LanguageSchema;
   languageScopes?: LanguageScope[];
+  languageSource?: LanguageSource;
   limit?: number;
   localeSeparator?: string;
   objectID?: string;

--- a/src/views/census/TableOfLanguagesInCensus.tsx
+++ b/src/views/census/TableOfLanguagesInCensus.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
   const {
-    languagesBySchema: { Inclusive: langObjects },
+    languagesBySource: { All: langObjects },
     locales,
   } = useDataContext();
   const { localeSeparator } = usePageParams();

--- a/src/views/common/CLDRCoverageInfo.tsx
+++ b/src/views/common/CLDRCoverageInfo.tsx
@@ -20,7 +20,7 @@ export const CLDRCoverageInfo: React.FC<Props> = ({ object, parentNotes }) => {
   const {
     cldrCoverage,
     cldrDataProvider,
-    schemaSpecific: { CLDR },
+    sourceSpecific: { CLDR },
   } = object;
 
   if (cldrCoverage == null) {

--- a/src/views/common/ObjectDetails.tsx
+++ b/src/views/common/ObjectDetails.tsx
@@ -37,15 +37,15 @@ const ObjectDetails: React.FC<Props> = ({ object, objectID }) => {
 
 export function getObjectFromID(inputObjectID?: string): ObjectData | undefined {
   const { objectID: pageObjectID } = usePageParams();
-  const { censuses, languagesBySchema, territories, writingSystems, locales } = useDataContext();
+  const { censuses, languagesBySource, territories, writingSystems, locales } = useDataContext();
   const objectID = inputObjectID ?? pageObjectID;
 
   if (objectID == null) return undefined;
 
   return (
     censuses[objectID] ??
-    languagesBySchema.Inclusive[objectID] ??
-    languagesBySchema.Glottolog[objectID] ?? // The Glottolog lookup should no longer be necessary since objects have a stable ID field, but keep just in case
+    languagesBySource.All[objectID] ??
+    languagesBySource.Glottolog[objectID] ?? // The Glottolog lookup should no longer be necessary since objects have a stable ID field, but keep just in case
     territories[objectID] ??
     locales[objectID] ??
     writingSystems[objectID]

--- a/src/views/common/ObjectField.tsx
+++ b/src/views/common/ObjectField.tsx
@@ -4,7 +4,7 @@ import { usePageParams } from '../../controls/PageParamsContext';
 import Highlightable from '../../generic/Highlightable';
 import { anyWordStartsWith } from '../../generic/stringUtils';
 import { ObjectData } from '../../types/DataTypes';
-import { LanguageSchema } from '../../types/LanguageTypes';
+import { LanguageSource } from '../../types/LanguageTypes';
 import { ObjectType, SearchableField } from '../../types/PageParamTypes';
 
 interface Props {
@@ -78,14 +78,14 @@ export function getSearchableField(object: ObjectData, field: SearchableField, q
 export function getObjectPopulation(
   object: ObjectData,
   includeDescendents?: boolean,
-  languageSchema?: LanguageSchema,
+  languageSource?: LanguageSource,
 ): number {
   switch (object.type) {
     case ObjectType.Language:
       return (
         (object.populationCited ?? 0) +
-        (includeDescendents && languageSchema
-          ? (object.schemaSpecific[languageSchema].populationOfDescendents ?? 0)
+        (includeDescendents && languageSource
+          ? (object.sourceSpecific[languageSource].populationOfDescendents ?? 0)
           : 0)
       );
     case ObjectType.Locale:

--- a/src/views/language/DubiousLanguages.tsx
+++ b/src/views/language/DubiousLanguages.tsx
@@ -17,7 +17,7 @@ import ViewCard from '../ViewCard';
 
 const DubiousLanguages: React.FC = () => {
   const {
-    languagesBySchema: { Inclusive, CLDR },
+    languagesBySource: { All, CLDR },
     writingSystems,
     territories,
   } = useDataContext();
@@ -26,7 +26,7 @@ const DubiousLanguages: React.FC = () => {
   const filterByTerritory = getFilterByTerritory();
   const sortFunction = getSortFunction();
   const sliceFunction = getSliceFunction<LanguageData>();
-  const languages = Object.values(Inclusive)
+  const languages = Object.values(All)
     .filter(filterBySubstring)
     .filter(filterByTerritory)
     .filter((lang) => lang.codeDisplay.match('xx.-|^[0-9]'));
@@ -65,7 +65,7 @@ const DubiousLanguages: React.FC = () => {
           const relatedObjects = codePieces
             .map(
               (partialCode) =>
-                Inclusive[partialCode] ??
+                All[partialCode] ??
                 CLDR[partialCode] ??
                 territories[partialCode] ??
                 writingSystems[partialCode],

--- a/src/views/language/LanguageDetails.tsx
+++ b/src/views/language/LanguageDetails.tsx
@@ -28,8 +28,8 @@ const LanguageDetails: React.FC<Props> = ({ lang }) => {
 };
 
 const LanguageIdentification: React.FC<{ lang: LanguageData }> = ({ lang }) => {
-  const { codeISO6391, nameDisplay, nameEndonym, schemaSpecific } = lang;
-  const { Glottolog, ISO, CLDR } = schemaSpecific;
+  const { codeISO6391, nameDisplay, nameEndonym, sourceSpecific } = lang;
+  const { Glottolog, ISO, CLDR } = sourceSpecific;
 
   // nameDisplay and nameEndonym should already be shown in the title for this
   const otherNames = useMemo(
@@ -188,11 +188,11 @@ const LanguageVitalityAndViability: React.FC<{ lang: LanguageData }> = ({ lang }
 };
 
 const LanguageConnections: React.FC<{ lang: LanguageData }> = ({ lang }) => {
-  const { languageSchema } = usePageParams();
+  const { languageSource } = usePageParams();
   const sortFunction = getSortFunction();
   const {
     childLanguages,
-    schemaSpecific: { ISO, Glottolog },
+    sourceSpecific: { ISO, Glottolog },
   } = lang;
 
   return (
@@ -214,7 +214,7 @@ const LanguageConnections: React.FC<{ lang: LanguageData }> = ({ lang }) => {
         <div>
           <label>Descendent Languages:</label>
           {childLanguages.length > 0 ? (
-            <TreeListRoot rootNodes={getLanguageTreeNodes([lang], languageSchema, sortFunction)} />
+            <TreeListRoot rootNodes={getLanguageTreeNodes([lang], languageSource, sortFunction)} />
           ) : (
             <div>
               <span className="unsupported">No languages come from this language.</span>

--- a/src/views/language/LanguageHierarchy.tsx
+++ b/src/views/language/LanguageHierarchy.tsx
@@ -5,13 +5,13 @@ import { usePageParams } from '../../controls/PageParamsContext';
 import { getSortFunction } from '../../controls/sort';
 import { useDataContext } from '../../data/DataContext';
 import { ObjectData } from '../../types/DataTypes';
-import { LanguageData, LanguageSchema, LanguageScope } from '../../types/LanguageTypes';
+import { LanguageData, LanguageSource, LanguageScope } from '../../types/LanguageTypes';
 import { ObjectType } from '../../types/PageParamTypes';
 import { TreeNodeData } from '../common/TreeList/TreeListNode';
 import TreeListPageBody from '../common/TreeList/TreeListPageBody';
 
 export const LanguageHierarchy: React.FC = () => {
-  const { languageSchema } = usePageParams();
+  const { languageSource } = usePageParams();
   const { languages } = useDataContext();
   const sortFunction = getSortFunction();
   const filterByScope = getScopeFilter();
@@ -20,7 +20,7 @@ export const LanguageHierarchy: React.FC = () => {
     Object.values(languages).filter(
       (lang) => lang.parentLanguage == null || !filterByScope(lang.parentLanguage),
     ),
-    languageSchema,
+    languageSource,
     sortFunction,
     filterByScope,
   );
@@ -40,20 +40,20 @@ export const LanguageHierarchy: React.FC = () => {
 
 export function getLanguageTreeNodes(
   languages: LanguageData[],
-  languageSchema: LanguageSchema,
+  languageSource: LanguageSource,
   sortFunction: (a: ObjectData, b: ObjectData) => number,
   filterFunction: (a: ObjectData) => boolean = () => true,
 ): TreeNodeData[] {
   return languages
     .filter(filterFunction)
     .sort(sortFunction)
-    .map((lang) => getLanguageTreeNode(lang, languageSchema, sortFunction, filterFunction))
+    .map((lang) => getLanguageTreeNode(lang, languageSource, sortFunction, filterFunction))
     .filter((node) => node != null);
 }
 
 function getLanguageTreeNode(
   lang: LanguageData,
-  languageSchema: LanguageSchema,
+  languageSource: LanguageSource,
   sortFunction: (a: ObjectData, b: ObjectData) => number,
   filterFunction: (a: ObjectData) => boolean,
 ): TreeNodeData {
@@ -61,8 +61,8 @@ function getLanguageTreeNode(
     type: ObjectType.Language,
     object: lang,
     children: getLanguageTreeNodes(
-      lang.schemaSpecific[languageSchema].childLanguages,
-      languageSchema,
+      lang.sourceSpecific[languageSource].childLanguages,
+      languageSource,
       sortFunction,
       filterFunction,
     ),

--- a/src/views/language/LanguageSuggestions.tsx
+++ b/src/views/language/LanguageSuggestions.tsx
@@ -4,14 +4,14 @@ import { useDataContext } from '../../data/DataContext';
 import HoverableObjectName from '../common/HoverableObjectName';
 
 const LanguageSuggestions: React.FC = () => {
-  const { languagesBySchema } = useDataContext();
+  const { languagesBySource } = useDataContext();
 
   return (
     <div className="separatedButtonList">
       {['eng', 'spa', 'fra', 'deu', 'zho', 'ara'].map(
         (code) =>
-          languagesBySchema.ISO[code] != null && (
-            <HoverableObjectName key={code} object={languagesBySchema.ISO[code]} format="button" />
+          languagesBySource.ISO[code] != null && (
+            <HoverableObjectName key={code} object={languagesBySource.ISO[code]} format="button" />
           ),
       )}
     </div>

--- a/src/views/language/LanguagesWithIdenticalNames.tsx
+++ b/src/views/language/LanguagesWithIdenticalNames.tsx
@@ -12,7 +12,7 @@ import { getSortFunction } from '../../controls/sort';
 import { useDataContext } from '../../data/DataContext';
 import CommaSeparated from '../../generic/CommaSeparated';
 import Deemphasized from '../../generic/Deemphasized';
-import { LanguageData, LanguageSchema } from '../../types/LanguageTypes';
+import { LanguageData, LanguageSource } from '../../types/LanguageTypes';
 import TreeListRoot from '../common/TreeList/TreeListRoot';
 import ViewCard from '../ViewCard';
 
@@ -20,14 +20,14 @@ import { getLanguageTreeNodes } from './LanguageHierarchy';
 
 const LanguagesWithIdenticalNames: React.FC = () => {
   const {
-    languagesBySchema: { Inclusive },
+    languagesBySource: { All },
   } = useDataContext();
   const { page, limit } = usePageParams();
   const filterBySubstring = getFilterBySubstring();
   const filterByTerritory = getFilterByTerritory();
   const sortFunction = getSortFunction();
   const sliceFunction = getSliceFunction<[string, LanguageData[]]>();
-  const languagesByName = Object.values(Inclusive)
+  const languagesByName = Object.values(All)
     .filter(filterBySubstring)
     .filter(filterByTerritory)
     .reduce<Record<string, LanguageData[]>>((languagesByName, lang) => {
@@ -88,7 +88,7 @@ const LanguagesWithIdenticalNames: React.FC = () => {
           <h3 style={{ marginBottom: 0 }}>{name}</h3>
           <div className="CardList">
             {langs.map((lang) => {
-              const { ISO, Glottolog } = lang.schemaSpecific;
+              const { ISO, Glottolog } = lang.sourceSpecific;
               const otherNames = lang.names.filter(
                 (name) => name !== lang.nameDisplay && name !== lang.nameEndonym,
               );
@@ -116,7 +116,7 @@ const LanguagesWithIdenticalNames: React.FC = () => {
                     <div>
                       ISO Hierarchy:{' '}
                       <TreeListRoot
-                        rootNodes={getLanguageTreeNodes([lang], LanguageSchema.ISO, sortFunction)}
+                        rootNodes={getLanguageTreeNodes([lang], LanguageSource.ISO, sortFunction)}
                       />
                     </div>
                   )}
@@ -126,7 +126,7 @@ const LanguagesWithIdenticalNames: React.FC = () => {
                       <TreeListRoot
                         rootNodes={getLanguageTreeNodes(
                           [lang],
-                          LanguageSchema.Glottolog,
+                          LanguageSource.Glottolog,
                           sortFunction,
                         )}
                       />

--- a/src/views/locale/LocaleTable.tsx
+++ b/src/views/locale/LocaleTable.tsx
@@ -11,12 +11,12 @@ import LocaleCensusCitation from './LocaleCensusCitation';
 
 const LocaleTable: React.FC = () => {
   const { locales } = useDataContext();
-  const { languageSchema } = usePageParams();
+  const { languageSource } = usePageParams();
 
   return (
     <ObjectTable<LocaleData>
       objects={Object.values(locales).filter(
-        (locale) => locale.language?.schemaSpecific[languageSchema].code != null,
+        (locale) => locale.language?.sourceSpecific[languageSource].code != null,
       )}
       columns={[
         CodeColumn,

--- a/src/views/locale/PotentialLocales.tsx
+++ b/src/views/locale/PotentialLocales.tsx
@@ -34,7 +34,7 @@ const PotentialLocales: React.FC = () => {
   const {
     locales,
     censuses,
-    languagesBySchema: { Inclusive: languages },
+    languagesBySource: { All: languages },
   } = useDataContext();
   const { localeSeparator } = usePageParams();
   const [percentThreshold, setPercentThreshold] = React.useState(0.05);


### PR DESCRIPTION
@jeannettestewart  gave us great feedback that the language "definition" selector wasn't qutie right. She recommended calling it the "Language List Source" -- I went a bit further and called it "Source of the List of Languages" and renamed the variables to languageSource. She also recommended making the inclusive category "all". While I think inclusive is more correct -- it's jargony. "All" is better.

|Before|After|
|--|--|
|<img width="479" height="344" alt="Screenshot 2025-07-29 at 17 20 43" src="https://github.com/user-attachments/assets/8acebcb1-83dd-4139-9615-8c88bdc57e28" />|<img width="464" height="357" alt="Screenshot 2025-07-29 at 17 22 44" src="https://github.com/user-attachments/assets/78975709-6ec6-4608-b962-c7c420ac54b0" />
