### PR TITLE
Data: Mayotte and Bahamas Census

### DIFF
--- a/public/data/census/data.un.org/bs.tsv
+++ b/public/data/census/data.un.org/bs.tsv
@@ -1,0 +1,11 @@
+#codeDisplay		bs2010
+#nameDisplay		Bahamas 2010
+#isoRegionCode		BS
+#yearCollected		2010
+#datePublished		2013
+#eligiblePopulation		351,461
+#notes		Census - de jure - complete tabulation
+#responsesPerIndividual		1
+#url	https://data.un.org/Data.aspx?d=POP&f=tableCode:27	
+#collectorType	Government	
+eng	English	351,461

--- a/public/data/census/yt.tsv
+++ b/public/data/census/yt.tsv
@@ -1,0 +1,28 @@
+#codeDisplay		yt2007	yt2002write	yt2002speak	yt2006L1	yt2006speak	#yt2006L1raw	#yt2006speakraw
+#nameDisplay		Mayotte 2007	Mayotte 2002 Writing	Mayotte 2002 Spoken	Mayotte 2006 Mothertongue	Mayotte 2006 Spoken	Mayotte 2006 Mothertongue Original	Mayotte 2006 Spoken Original
+#isoRegionCode	YT							
+#yearCollected		2007	2002	2002	2006	2006	2006	2006
+#datePublished		2009						
+#eligiblePopulation		108,187	92738	92738	133053	133053	2743	2743
+#sampleRate					0.02061584481	0.02061584481		
+#modality		Spoken	Written	Spoken	Spoken	Spoken	Spoken	Spoken
+#acquisitionOrder			Any	Any	L1	Any	L1	Any
+#age		14+	15+	15+	9+	9+	9+	9+
+#responsesPerIndividual		1	1+	1+	1+	1+	1+	1+
+#url		https://data.un.org/Data.aspx?d=POP&f=tableCode:27	http://www.insee.fr/fr/insee_regions/mayotte/themes/dossiers/rp/rp2002/for5.xls	https://web.archive.org/web/20150924164057/https://www.insee.fr/fr/insee_regions/mayotte/themes/dossiers/rp/rp2002/for4.xls	https://web.archive.org/web/20070614075940/http://www.ac-mayotte.fr/IMG/pdf/Interv_BARRETEAU_CM2.pdf	https://web.archive.org/web/20070614075940/http://www.ac-mayotte.fr/IMG/pdf/Interv_BARRETEAU_CM2.pdf	https://web.archive.org/web/20070614075940/http://www.ac-mayotte.fr/IMG/pdf/Interv_BARRETEAU_CM2.pdf	https://web.archive.org/web/20070614075940/http://www.ac-mayotte.fr/IMG/pdf/Interv_BARRETEAU_CM2.pdf
+#collectorType		Government	Government	Government	Study			
+#notes		Census - de jure - complete tabulation			Recomputed from a highly sampled sociolinguistic dataset. Targetting "Mothertongue"			
+swb	Mahorais/Shimaore		37840	80140	71789	115009	1480	2371
+fra	French/Français	6,696	50607	54784	1795	74166	37	1529
+fra	#French-Other languages	61,668						
+mul	Local language	39,823						
+wni	Shinsdzwani/Anjouanais				29055	45887	599	946
+buc	Kibushi/Shibushi				17705	37495	365	773
+ara	#Arabe		31065	3199	485	14067	10	290
+mlg	Malgache		7208	23561				
+mul	Dialectes comoriens			23876				
+zdj	Shingazidza				10332	18093	213	373
+mul	Autres			4358	534	1601	11	33
+wlc	Shimwali/Mohélien				1067	3395	22	70
+mul	Dialectes malgaches			2277				
+kian1236	Kiantalaotsi				291	1164	6	24

--- a/public/data/locales.tsv
+++ b/public/data/locales.tsv
@@ -10069,3 +10069,24 @@ vki_NG	Ija-Zuba (Nigeria)		vki	NG			7 Fallback
 wya_US	Wyandot (United States)		wya	US			7 Fallback		
 xrq_AU	Karranga (Australia)		xrq	AU			7 Fallback		
 szd_MY	Seru (Malaysia)		szd	MY			7 Fallback		
+mlg_YT	Malgache (Mayotte)		mlg	YT					
+wni_YT	Shinsdzwani (Mayotte)		wni	YT					
+ara_YT	Arabic (Mayotte)		ara	YT					
+zdj_YT	Shingazidja (Mayotte)		zdj	YT					
+wlc_YT	Shimwali (Mayotte)		wlc	YT					
+emk_GM	Eastern Maninkakan (Gambia)		emk	GM					
+eng_IC	English (Canary Islands)		eng	IC					
+fra_IC	French (Canary Islands)		fra	IC					
+deu_IC	German (Canary Islands)		deu	IC					
+ita_IC	Italian (Canary Islands)		ita	IC					
+bale1256_ES	Balearic (Spain)		bale1256	ES					
+acch1238_NP	Acchami (Nepal)		acch1238	NP					
+thar1284_NP	Tharu (Nepal)		thar1284	NP					
+tama1367_NP	Tamang (Nepal)		tama1367	NP					
+maga1261_NP	Magar (Nepal)		maga1261	NP					
+ara_AU	Arabic (Australia)		ara	AU					
+vie_AU	Vietnamese (Australia)		vie	AU					
+ara_EA	Arabic (Ceuta and Melilla)		ara	EA					
+eng_EA	English (Ceuta and Melilla)		eng	EA					
+fra_EA	French (Ceuta and Melilla)		fra	EA					
+ber_EA	Berber (Ceuta and Melilla)		ber	EA					

--- a/src/data/CensusData.tsx
+++ b/src/data/CensusData.tsx
@@ -1,6 +1,6 @@
 import { toTitleCase } from '../generic/stringUtils';
 import { CensusCollectorType, CensusData } from '../types/CensusTypes';
-import { LanguageCode } from '../types/LanguageTypes';
+import { LanguageCode, LanguageModality } from '../types/LanguageTypes';
 import { ObjectType } from '../types/PageParamTypes';
 
 import { CoreData } from './CoreData';
@@ -13,6 +13,8 @@ const CENSUS_FILENAMES = [
   'data.un.org/au', // Australia Censuses downloaded from UN data portal
   'data.un.org/ru', // Russia 2010 Census downloaded from UN data portal
   'es2021', // Spain 2021 Census
+  'data.un.org/bs', // Bahamas 2010 Census downloaded from UN data portal
+  'yt', // Mayotte Censuses
   // Add more census files here as needed
 ];
 
@@ -97,6 +99,8 @@ function parseCensusImport(fileInput: string, filename: string): CensusImport {
           censuses[index][key] = Number.parseFloat(value);
         } else if (key === 'collectorType') {
           censuses[index][key] = value as CensusCollectorType;
+        } else if (key === 'modality') {
+          censuses[index][key] = value as LanguageModality;
         } else if (
           key === 'languageCount' ||
           key === 'languageEstimates' ||
@@ -226,6 +230,12 @@ export function addCensusData(coreData: CoreData, censusData: CensusImport): voi
   for (const census of censusData.censuses) {
     // Add the census to the core data if its not there yet
     if (coreData.censuses[census.ID] == null) {
+      // Drop census tables which have a "#" in the codeDisplay -- that means they are provided for context
+      // but LangNav doesn't have a good way to show it.
+      if (census.codeDisplay.includes('#')) {
+        continue;
+      }
+
       coreData.censuses[census.ID] = census;
 
       // Add the territory reference to it

--- a/src/types/CensusTypes.tsx
+++ b/src/types/CensusTypes.tsx
@@ -1,5 +1,5 @@
 import { ObjectBase, TerritoryCode, TerritoryData } from './DataTypes';
-import { LanguageCode } from './LanguageTypes';
+import { LanguageCode, LanguageModality } from './LanguageTypes';
 import { ObjectType } from './PageParamTypes';
 
 // Unique identifier for the census or other source of population data
@@ -23,7 +23,7 @@ export interface CensusData extends ObjectBase {
   collectorType: CensusCollectorType; // Type of organization (e.g., Government, CLDR)
 
   // Kind of language data collected
-  modality?: string; // eg. Spoken, Written, Sign
+  modality?: LanguageModality; // eg. Spoken, Written, Sign
   proficiency?: string; // eg. Conversant or Learning, Fluent, Non-Fluent
   acquisitionOrder?: string; // eg. Any, L1, L2, L3
   domain?: string; // eg. Any, Home, School, Work, Community, Unspecified


### PR DESCRIPTION
This adds data from the Mayotte and Bahamas censuses.

While I was here I also added the ability to suppress a census table during import -- this way we can include raw data without adding extraneous data.

See the new Mayotte locales here:
https://translation-commons.github.io//lang-nav/data?territoryFilter=yt&languageScopes=Macrolanguage%2CLanguage%2CDialect&view=Table&objectType=Locale

|Before|After|
|--|--|
|<img width="619" height="152" alt="Screenshot 2025-07-29 at 17 32 30" src="https://github.com/user-attachments/assets/ba73574b-2447-4f2d-92a7-bc3ef6e9f06e" />|<img width="629" height="296" alt="Screenshot 2025-07-29 at 17 32 09" src="https://github.com/user-attachments/assets/7b84fb9f-8e28-4921-8f57-3d127cea558e" />
