### PR TITLE
Table: Split 'Internet Technologies' column into two.

### DIFF
--- a/src/views/common/CLDRCoverageInfo.tsx
+++ b/src/views/common/CLDRCoverageInfo.tsx
@@ -8,14 +8,12 @@ import { LocaleData } from '../../types/DataTypes';
 import { LanguageData } from '../../types/LanguageTypes';
 import { ObjectType } from '../../types/PageParamTypes';
 
-type Props = {
+export const CLDRCoverageText: React.FC<{
   object: LanguageData | LocaleData;
-  parentNotes?: React.ReactNode; // Notes from something referencing this cldr coverage.
-};
-
-export const CLDRCoverageInfo: React.FC<Props> = ({ object, parentNotes }) => {
+  parentNotes?: React.ReactNode;
+}> = ({ object, parentNotes }) => {
   if (object.type !== ObjectType.Language) {
-    return 'TODO: CLDRCoverageInfo for LocaleData';
+    return null;
   }
 
   const {
@@ -27,7 +25,7 @@ export const CLDRCoverageInfo: React.FC<Props> = ({ object, parentNotes }) => {
   if (cldrCoverage == null) {
     if (cldrDataProvider != null) {
       return (
-        <CLDRCoverageInfo
+        <CLDRCoverageText
           object={cldrDataProvider}
           parentNotes={[parentNotes, CLDR.notes].filter((n) => n != null)}
         />
@@ -36,20 +34,43 @@ export const CLDRCoverageInfo: React.FC<Props> = ({ object, parentNotes }) => {
     return (
       <>
         <NotesIcon warningNotes={parentNotes} infoNotes={CLDR.notes} />
-        <Deemphasized>Not supported by CLDR or ICU.</Deemphasized>
+        <Deemphasized>Not supported by CLDR.</Deemphasized>
       </>
     );
   }
 
+  const coverageLevel = cldrCoverage.actualCoverageLevel;
+  const capitalizedLevel = coverageLevel.charAt(0).toUpperCase() + coverageLevel.slice(1);
+
   return (
     <>
-      <NotesIcon warningNotes={parentNotes} infoNotes={CLDR.notes} />
-      CLDR:{' '}
+      <NotesIcon warningNotes={parentNotes} infoNotes={CLDR.notes} />{' '}
       <span style={{ color: getCLDRCoverageColor(cldrCoverage.actualCoverageLevel) }}>
-        {cldrCoverage.actualCoverageLevel}
+        {capitalizedLevel}
       </span>{' '}
       coverage by {cldrCoverage.countOfCLDRLocales} locale
-      {cldrCoverage.countOfCLDRLocales > 1 && 's'}. ICU:{' '}
+      {cldrCoverage.countOfCLDRLocales > 1 && 's'}.
+    </>
+  );
+};
+
+export const ICUSupportStatus: React.FC<{ object: LanguageData | LocaleData }> = ({ object }) => {
+  if (object.type !== ObjectType.Language) {
+    return null;
+  }
+
+  const { cldrCoverage, cldrDataProvider } = object;
+
+  if (cldrCoverage == null) {
+    if (cldrDataProvider != null) {
+      return <ICUSupportStatus object={cldrDataProvider} />;
+    }
+    return <Deemphasized>N/A</Deemphasized>;
+  }
+
+  return (
+    <>
+      {' '}
       {cldrCoverage.inICU ? (
         <CheckCircle2Icon
           style={{ color: 'var(--color-text-green)', verticalAlign: 'middle' }}

--- a/src/views/language/LanguageDetails.tsx
+++ b/src/views/language/LanguageDetails.tsx
@@ -6,7 +6,7 @@ import CommaSeparated from '../../generic/CommaSeparated';
 import Deemphasized from '../../generic/Deemphasized';
 import LinkButton from '../../generic/LinkButton';
 import { LanguageData } from '../../types/LanguageTypes';
-import { CLDRCoverageInfo } from '../common/CLDRCoverageInfo';
+import { CLDRCoverageText, ICUSupportStatus } from '../common/CLDRCoverageInfo';
 import HoverableObjectName from '../common/HoverableObjectName';
 import TreeListRoot from '../common/TreeList/TreeListRoot';
 import { getLocaleTreeNodes } from '../locale/LocaleHierarchy';
@@ -181,8 +181,12 @@ const LanguageVitalityAndViability: React.FC<{ lang: LanguageData }> = ({ lang }
         {viabilityConfidence} ... {viabilityExplanation}
       </div>
       <div>
-        <label>Internet Technologies:</label>
-        <CLDRCoverageInfo object={lang} />
+        <label>CLDR Coverage:</label>
+        <CLDRCoverageText object={lang} />
+      </div>
+      <div>
+        <label>ICU Support:</label>
+        <ICUSupportStatus object={lang} />
       </div>
     </div>
   );

--- a/src/views/language/LanguageTable.tsx
+++ b/src/views/language/LanguageTable.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useDataContext } from '../../data/DataContext';
 import { LanguageData } from '../../types/LanguageTypes';
 import { SortBy } from '../../types/PageParamTypes';
-import { CLDRCoverageInfo } from '../common/CLDRCoverageInfo';
+import { CLDRCoverageText, ICUSupportStatus } from '../common/CLDRCoverageInfo';
 import {
   CodeColumn,
   EndonymColumn,
@@ -34,8 +34,15 @@ const LanguageTable: React.FC = () => {
           sortParam: SortBy.Population,
         },
         {
-          key: 'Internet Technologies',
-          render: (lang) => <CLDRCoverageInfo object={lang} />,
+          key: 'CLDRCoverage',
+          label: 'CLDR Coverage',
+          render: (lang) => <CLDRCoverageText object={lang} />,
+          isInitiallyVisible: false,
+        },
+        {
+          key: 'ICUSupport',
+          label: 'ICU Support',
+          render: (lang) => <ICUSupportStatus object={lang} />,
           isInitiallyVisible: false,
         },
         InfoButtonColumn,

--- a/src/views/language/LanguageTable.tsx
+++ b/src/views/language/LanguageTable.tsx
@@ -34,13 +34,13 @@ const LanguageTable: React.FC = () => {
           sortParam: SortBy.Population,
         },
         {
-          key: 'CLDRCoverage',
+          key: 'CLDR Coverage',
           label: 'CLDR Coverage',
           render: (lang) => <CLDRCoverageText object={lang} />,
           isInitiallyVisible: false,
         },
         {
-          key: 'ICUSupport',
+          key: 'ICU Support',
           label: 'ICU Support',
           render: (lang) => <ICUSupportStatus object={lang} />,
           isInitiallyVisible: false,


### PR DESCRIPTION
This pull request resolves issue #119 by splitting the "Internet Technologies" column into two separate, more specific columns: "CLDR Coverage" and "ICU Support."

### Key Changes

-   **Refactored `CLDRCoverageInfo.tsx`:** Broke down the original component `CLDRCoverageInfo` into two new, reusable components:
    -   `CLDRCoverageText`: Renders only the CLDR information.
    -   `ICUSupportStatus`: Renders only the ICU support status icon.
-   **Updated `LanguageTable.tsx`:** Replaced the single "Internet Technologies" column with the two new, more focused columns, each using one of the new components.
-   **Updated `LanguageDetails.tsx`:** Aligned the language details page with the new table structure by displaying "CLDR Coverage" and "ICU Support" as separate fields.

|Link|Before|After|
|--|--|--|
|[Table](https://translation-commons.github.io/lang-nav/data?view=Table) |<img width="906" height="604" alt="image" src="https://github.com/user-attachments/assets/55a3bb0d-78a9-49af-9cff-70eec828e56b" />|<img width="798" height="556" alt="image" src="https://github.com/user-attachments/assets/d80030c5-30fd-48c7-87fc-d2c9d92de66f" />
|[Language](https://translation-commons.github.io/lang-nav/data?view=Details&objectID=zho&searchString=Chinese)|<img width="846" height="176" alt="image" src="https://github.com/user-attachments/assets/9afa53e6-a722-4f63-b2ee-f3bd7e593165" />|<img width="857" height="206" alt="image" src="https://github.com/user-attachments/assets/ceb6b230-8049-47ce-a2b4-745dd7a4b0d8" />|





Fixes #119 
