### PR TITLE
Navigation: Add initial path breadcrumbs component & add inline-dropdown selector style

### DIFF
--- a/src/controls/components/MultiChoiceOptions.tsx
+++ b/src/controls/components/MultiChoiceOptions.tsx
@@ -47,7 +47,7 @@ function MultiChoiceOptions<T extends React.Key>({
         {selected.length > 1 && 'Multiple selected'} {expanded ? `▼` : `▶`}
       </HoverableButton>
       {expanded && (
-        <div className="SelectorPopupAnchor" ref={popupRef}>
+        <div style={{ position: 'relative' }} ref={popupRef}>
           <div className="SelectorPopup">{contents}</div>
         </div>
       )}

--- a/src/controls/components/Selector.tsx
+++ b/src/controls/components/Selector.tsx
@@ -1,71 +1,55 @@
 import React, { ReactNode, useState } from 'react';
 
 import HoverableButton from '../../generic/HoverableButton';
+import { getPositionInGroup, PositionInGroup } from '../../generic/PositionInGroup';
 import { useClickOutside } from '../../generic/useClickOutside';
 
 import SelectorLabel from './SelectorLabel';
 
 export enum OptionsDisplay {
   Dropdown = 'dropdown', // Formatting is still off for these
+  InlineDropdown = 'inlineDropdown', // Used to be inline with text
   ButtonGroup = 'buttonGroup', // Unsure if we want to keep this
   ButtonList = 'buttonList',
 }
 
 type Props<T extends React.Key> = {
   appearance?: 'rounded' | 'tabs';
-  selectorLabel?: ReactNode;
-  selectorDescription?: ReactNode;
-  size?: 'regular' | 'compact';
   getOptionDescription?: (value: T) => React.ReactNode;
   getOptionLabel?: (value: T) => React.ReactNode; // optional label renderer
-  optionsDisplay?: OptionsDisplay;
   onChange: (value: T) => void;
   options: readonly T[];
+  optionsDisplay?: OptionsDisplay;
   selected: T | T[];
+  selectorDescription?: ReactNode;
+  selectorLabel?: ReactNode;
 };
 
 function Selector<T extends React.Key>({
-  selectorLabel,
-  selectorDescription,
-  size = 'regular',
   getOptionDescription = () => undefined,
   getOptionLabel = (val) => val as string,
-  selected,
-  optionsDisplay = OptionsDisplay.ButtonList,
   onChange,
   options,
+  optionsDisplay = OptionsDisplay.ButtonList,
+  selected,
+  selectorDescription,
+  selectorLabel,
 }: Props<T>) {
   const [expanded, setExpanded] = useState(false);
   const optionsRef = useClickOutside(() => setExpanded(false));
+  // const optionsRef = useClickOutside(() => setExpanded(true));
 
   return (
-    <div
-      className={'selector ' + size + ' ' + optionsDisplay}
-      style={{
-        marginLeft: '0.125em',
-        marginRight: '0.5em',
-        display: 'flex',
-        flexDirection: optionsDisplay === OptionsDisplay.ButtonList ? 'column' : 'row',
-        alignItems: optionsDisplay === OptionsDisplay.ButtonList ? 'start' : 'end',
-        gap: optionsDisplay === OptionsDisplay.ButtonGroup ? '-0.125em' : '0',
-      }}
-    >
-      <SelectorLabel
-        label={selectorLabel}
-        description={selectorDescription}
-        optionsDisplay={optionsDisplay}
-      />
-
-      {optionsDisplay === OptionsDisplay.Dropdown && (
-        <SelectorOption<T>
-          getOptionDescription={getOptionDescription}
-          getOptionLabel={(opt) => `${getOptionLabel(opt)} ${expanded ? `▼` : `▶`}`}
-          onClick={() => setExpanded((prev) => !prev)}
-          option={Array.isArray(selected) ? selected[0] : selected}
+    <SelectorContainer optionsDisplay={optionsDisplay}>
+      {selectorLabel && (
+        <SelectorLabel
+          label={selectorLabel}
+          description={selectorDescription}
           optionsDisplay={optionsDisplay}
-          isSelected={true}
         />
       )}
+
+      {/* The dropdown menu or the button list */}
       <OptionsContainer
         isExpanded={expanded}
         containerRef={optionsRef}
@@ -83,9 +67,53 @@ function Selector<T extends React.Key>({
           selected={selected}
         />
       </OptionsContainer>
-    </div>
+
+      {/* Standalone option to open/close the dropdown menu */}
+      {(optionsDisplay === OptionsDisplay.Dropdown ||
+        optionsDisplay === OptionsDisplay.InlineDropdown) && (
+        <SelectorOption<T>
+          getOptionDescription={getOptionDescription}
+          getOptionLabel={(opt) => `${getOptionLabel(opt)} ${expanded ? `▼` : `▶`}`}
+          onClick={() => setExpanded((prev) => !prev)}
+          option={Array.isArray(selected) ? selected[0] : selected}
+          optionsDisplay={optionsDisplay}
+          isSelected={true}
+        />
+      )}
+    </SelectorContainer>
   );
 }
+
+const SelectorContainer: React.FC<
+  React.PropsWithChildren<{
+    optionsDisplay?: OptionsDisplay;
+  }>
+> = ({ children, optionsDisplay }) => {
+  const style: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'end',
+    marginLeft: '0.125em',
+    marginRight: '0.5em',
+    marginBottom: '0.5em',
+  };
+  if (optionsDisplay === OptionsDisplay.ButtonList) {
+    style.flexDirection = 'column';
+    style.alignItems = 'start';
+  } else if (optionsDisplay === OptionsDisplay.InlineDropdown) {
+    style.marginLeft = '0';
+    style.marginRight = '0';
+    style.marginBottom = '0';
+  } else if (optionsDisplay === OptionsDisplay.ButtonGroup) {
+    style.gap = '-0.125em'; // Overlap the buttons slightly
+  }
+
+  return (
+    <div className={'selector ' + optionsDisplay} style={style}>
+      {children}
+    </div>
+  );
+};
 
 type OptionsContainerProps = {
   isExpanded?: boolean;
@@ -104,7 +132,7 @@ const OptionsContainer: React.FC<React.PropsWithChildren<OptionsContainerProps>>
       return (
         <div
           ref={containerRef}
-          style={{ display: 'flex', flexWrap: 'wrap', gap: '0.25em 0.5em', marginLeft: '1em' }}
+          style={{ display: 'flex', flexWrap: 'wrap', gap: '0.25em 0.25em', marginLeft: '1em' }}
         >
           {children}
         </div>
@@ -112,19 +140,21 @@ const OptionsContainer: React.FC<React.PropsWithChildren<OptionsContainerProps>>
     case OptionsDisplay.ButtonGroup:
       return <>{children}</>;
     case OptionsDisplay.Dropdown:
+    case OptionsDisplay.InlineDropdown:
       if (isExpanded) {
         return (
           <div style={{ position: 'relative' }} ref={containerRef}>
             <div
               className="dropdown"
               style={{
-                alignItems: 'end',
+                alignItems: 'start',
                 position: 'absolute',
                 display: 'flex',
-                right: '0px',
+                left: '0px',
                 flexDirection: 'column',
                 width: 'fit-content',
                 zIndex: 100,
+                marginTop: optionsDisplay === OptionsDisplay.InlineDropdown ? '0.25em' : '0',
               }}
             >
               {children}
@@ -162,13 +192,7 @@ function Options<T extends React.Key>({
       option={option}
       optionsDisplay={optionsDisplay}
       isSelected={Array.isArray(selected) ? selected.includes(option) : selected === option}
-      position={
-        i == 0
-          ? PositionInGroup.First
-          : i == options.length - 1
-            ? PositionInGroup.Last
-            : PositionInGroup.Middle
-      }
+      position={getPositionInGroup(i, options.length)}
     />
   ));
 }
@@ -209,57 +233,68 @@ export function getOptionStyle(
   isSelected: boolean,
   position: PositionInGroup,
 ): React.CSSProperties {
-  let borderRadius: string | undefined = '0px';
-  let border = '0.125em solid var(--color-button-primary)';
-  let width = undefined;
-  let margin = undefined;
+  // Standard option style
+  const style: React.CSSProperties = {
+    border: '0.125em solid var(--color-button-primary)',
+    borderRadius: '0px',
+    cursor: 'pointer',
+    lineHeight: '1em',
+    padding: '0.5em',
+    whiteSpace: 'nowrap',
+  };
+  // Customize based on position and display type
   switch (optionsDisplay) {
     case OptionsDisplay.ButtonGroup:
       if (position === PositionInGroup.Last) {
-        borderRadius = '0 1em 1em 0';
+        style.marginLeft = '-0.125em';
+        style.borderRadius = '0 1em 1em 0';
       } else if (position === PositionInGroup.First) {
-        borderRadius = '1em 0 0 1em';
+        style.borderRadius = '1em 0 0 1em';
+      } else if (position === PositionInGroup.Middle) {
+        style.marginLeft = '-0.125em';
       }
       break;
     case OptionsDisplay.ButtonList:
-      borderRadius = '1em';
-      if (!isSelected) border = '0.125em solid var(--color-button-secondary)';
+      style.borderRadius = '1em';
+      if (!isSelected) style.border = '0.125em solid var(--color-button-secondary)';
       break;
+    case OptionsDisplay.InlineDropdown:
+      // The standalone option should match the regular page text
+      if (position === PositionInGroup.Standalone) {
+        style.backgroundColor = 'transparent';
+        style.color = 'var(--color-text)';
+        style.border = 'none';
+        style.padding = '0';
+        return style;
+      }
+      // otherwise return the Dropdown style
+      return getOptionStyle(OptionsDisplay.Dropdown, isSelected, position);
     case OptionsDisplay.Dropdown:
-      width = '100%';
-      borderRadius = undefined;
+      style.textAlign = 'left';
+      style.width = '100%';
+      style.borderRadius = undefined;
       if (position === PositionInGroup.First) {
-        borderRadius = '1em 1em 0 0';
-        margin = '0 0 -0.125em 0';
+        style.borderRadius = '1em 1em 0 0';
+        style.margin = '0 0 -0.125em 0';
+        style.borderBottom = 'none';
       } else if (position === PositionInGroup.Last) {
-        borderRadius = '0 0 1em 1em';
-        margin = '0';
+        style.borderRadius = '0 0 1em 1em';
+        style.margin = '0';
+        style.borderTop = 'none';
       } else if (position === PositionInGroup.Middle) {
-        margin = '0 0 -0.125em 0';
+        style.margin = '0 0 -0.125em 0';
+        style.borderTop = 'none';
+        style.borderBottom = 'none';
+      } else if (position === PositionInGroup.Only) {
+        style.borderRadius = '1em';
       } else if (position === PositionInGroup.Standalone) {
-        borderRadius = '1em';
-        width = 'fit-content';
+        style.borderRadius = '1em';
+        style.width = 'fit-content';
       }
       break;
   }
 
-  return {
-    border,
-    borderRadius,
-    cursor: 'pointer',
-    lineHeight: '1em',
-    padding: '0.5em',
-    margin,
-    width,
-    whiteSpace: 'nowrap',
-  };
-}
-
-export enum PositionInGroup {
-  Standalone = 'standalone',
-  First = 'first',
-  Last = 'last',
-  Middle = 'middle',
+  return style;
 }
 
 export default Selector;

--- a/src/controls/components/Selector.tsx
+++ b/src/controls/components/Selector.tsx
@@ -37,7 +37,6 @@ function Selector<T extends React.Key>({
 }: Props<T>) {
   const [expanded, setExpanded] = useState(false);
   const optionsRef = useClickOutside(() => setExpanded(false));
-  // const optionsRef = useClickOutside(() => setExpanded(true));
 
   return (
     <SelectorContainer optionsDisplay={optionsDisplay}>

--- a/src/controls/components/SelectorLabel.tsx
+++ b/src/controls/components/SelectorLabel.tsx
@@ -14,24 +14,41 @@ type Props = {
 const SelectorLabel: React.FC<Props> = ({ label, description, optionsDisplay, style }) => {
   if (label == null) return null;
   return (
-    <span
-      style={{
-        marginLeft: optionsDisplay === OptionsDisplay.ButtonGroup ? '-0.125em' : '0',
-        marginRight: optionsDisplay === OptionsDisplay.ButtonGroup ? '-0.125em' : '0',
-        lineHeight: '1em',
-        fontWeight: 'bold',
-        padding: '0.5em',
-        whiteSpace: 'nowrap',
-        borderTopLeftRadius: optionsDisplay === OptionsDisplay.ButtonList ? '0' : '1em',
-        borderBottomLeftRadius: optionsDisplay === OptionsDisplay.ButtonList ? '0' : '1em',
-        ...style,
-      }}
-    >
+    <span style={{ ...getStyle(optionsDisplay), ...style }}>
       <Hoverable hoverContent={description} style={{ textDecoration: 'none' }}>
         {label}
       </Hoverable>
     </span>
   );
 };
+
+function getStyle(optionsDisplay: OptionsDisplay): React.CSSProperties {
+  const style: React.CSSProperties = {
+    lineHeight: '1em',
+    fontWeight: 'bold',
+    padding: '0.5em',
+    whiteSpace: 'nowrap',
+    borderRadius: '1em',
+  };
+
+  switch (optionsDisplay) {
+    case OptionsDisplay.ButtonGroup:
+      style.borderRadius = '1em 0 0 1em';
+      style.marginLeft = '-0.125em'; // This may just be a remnant of the old style
+      style.marginRight = '-0.125em';
+      break;
+    case OptionsDisplay.ButtonList:
+      style.borderRadius = '1em 0 0 1em';
+      break;
+    case OptionsDisplay.InlineDropdown:
+      style.padding = '0 0.5em';
+      break;
+    case OptionsDisplay.Dropdown:
+      // nothing special
+      break;
+  }
+
+  return style;
+}
 
 export default SelectorLabel;

--- a/src/controls/components/SingleChoiceOptions.tsx
+++ b/src/controls/components/SingleChoiceOptions.tsx
@@ -10,6 +10,7 @@ type Props<T extends React.Key> = {
   onChange: (value: T) => void;
   options: readonly T[];
   selected: T;
+  style?: React.CSSProperties;
 };
 
 function SingleChoiceOptions<T extends React.Key>({
@@ -19,6 +20,7 @@ function SingleChoiceOptions<T extends React.Key>({
   onChange,
   options,
   selected,
+  style,
 }: Props<T>) {
   const [expanded, setExpanded] = useState(false);
   const popupRef = useClickOutside(() => setExpanded(false));
@@ -46,11 +48,12 @@ function SingleChoiceOptions<T extends React.Key>({
         hoverContent={getOptionDescription(selected)}
         className="selected LastChild"
         onClick={() => setExpanded((prev) => !prev)}
+        style={style}
       >
         {getOptionLabel(selected)} {expanded ? `▼` : `▶`}
       </HoverableButton>
       {expanded && (
-        <div className="SelectorPopupAnchor" ref={popupRef}>
+        <div style={{ position: 'relative' }} ref={popupRef}>
           <div className="SelectorPopup">{contents}</div>
         </div>
       )}

--- a/src/controls/components/TextInput.tsx
+++ b/src/controls/components/TextInput.tsx
@@ -2,10 +2,11 @@ import { ExternalLinkIcon, XIcon, FilterIcon } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 
 import HoverableButton from '../../generic/HoverableButton';
+import { getPositionInGroup, PositionInGroup } from '../../generic/PositionInGroup';
 import { View } from '../../types/PageParamTypes';
 import { usePageParams } from '../PageParamsContext';
 
-import { getOptionStyle, OptionsDisplay, PositionInGroup } from './Selector';
+import { getOptionStyle, OptionsDisplay } from './Selector';
 
 export type Suggestion = {
   objectID?: string;
@@ -75,6 +76,35 @@ const TextInput: React.FC<Props> = ({
 
   return (
     <>
+      {showSuggestions && suggestions.length > 0 && (
+        <div style={{ position: 'relative' }}>
+          <div
+            className="SelectorPopup"
+            style={{
+              background: 'var(--color-background)',
+              border: 'none',
+              alignItems: 'start',
+              position: 'absolute',
+              display: 'flex',
+              left: '0px',
+              flexDirection: 'column',
+              width: 'fit-content',
+              zIndex: 100,
+            }}
+          >
+            {suggestions.map((s, i) => (
+              <SuggestionRow
+                key={i}
+                position={getPositionInGroup(i, suggestions.length)}
+                setImmediateValue={setImmediateValue}
+                showTextInputButton={showTextInputButton}
+                showGoToDetailsButton={showGoToDetailsButton}
+                suggestion={s}
+              />
+            ))}
+          </div>
+        </div>
+      )}
       <input
         type="text"
         className={immediateValue === '' ? 'empty' : ''}
@@ -103,28 +133,6 @@ const TextInput: React.FC<Props> = ({
       >
         {value || ' '}
       </span>
-      {showSuggestions && suggestions.length > 0 && (
-        <div className="SelectorPopupAnchor">
-          <div className="SelectorPopup" style={{ border: 'none' }}>
-            {suggestions.map((s, i) => (
-              <SuggestionRow
-                key={i}
-                position={
-                  i === 0
-                    ? PositionInGroup.First
-                    : i === suggestions.length - 1
-                      ? PositionInGroup.Last
-                      : PositionInGroup.Middle
-                }
-                setImmediateValue={setImmediateValue}
-                showTextInputButton={showTextInputButton}
-                showGoToDetailsButton={showGoToDetailsButton}
-                suggestion={s}
-              />
-            ))}
-          </div>
-        </div>
-      )}
       <HoverableButton
         hoverContent="Clear the input"
         style={

--- a/src/controls/controls.css
+++ b/src/controls/controls.css
@@ -19,7 +19,6 @@
   background-color: transparent;
 }
 
-
 .selector button,
 .selector input,
 .selector label {

--- a/src/controls/controls.css
+++ b/src/controls/controls.css
@@ -19,20 +19,11 @@
   background-color: transparent;
 }
 
-.selector {
-  margin-left: 0.125em;
-  margin-right: 0.5em;
-  display: flex;
-  align-items: end;
-  margin-bottom: 0.5em;
-}
 
 .selector button,
 .selector input,
 .selector label {
   border: 0.125em solid var(--color-button-primary);
-  margin-left: -0.125em;
-  margin-right: -0.125em;
   line-height: 1em;
   padding: 0.5em 0.5em;
   white-space: nowrap;
@@ -101,10 +92,6 @@
 .selector button:disabled:hover {
   color: var(--color-text-secondary);
   pointer-events: none;
-}
-
-.SelectorPopupAnchor {
-  position: relative;
 }
 
 .SelectorPopup {

--- a/src/controls/pathnav/PathNav.tsx
+++ b/src/controls/pathnav/PathNav.tsx
@@ -1,0 +1,55 @@
+import { SlashIcon } from 'lucide-react';
+import React, { useCallback } from 'react';
+
+import { ObjectType, View } from '../../types/PageParamTypes';
+import Selector, { OptionsDisplay } from '../components/Selector';
+import { usePageParams } from '../PageParamsContext';
+
+const PathNav: React.FC = () => {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '0.5em', flexWrap: 'wrap' }}>
+      <ObjectTypeSelector />
+      <SlashIcon size="1em" />
+      <ViewSelector />
+    </div>
+  );
+};
+
+const ObjectTypeSelector: React.FC = () => {
+  const { objectType, updatePageParams, view } = usePageParams();
+  const goToObjectType = useCallback(
+    (objectType: ObjectType) => {
+      updatePageParams({
+        objectType,
+        view,
+        searchString: undefined,
+        page: 1,
+      });
+    },
+    [updatePageParams, view],
+  );
+
+  return (
+    <Selector
+      optionsDisplay={OptionsDisplay.InlineDropdown}
+      options={Object.values(ObjectType)}
+      onChange={goToObjectType}
+      selected={objectType}
+    />
+  );
+};
+
+const ViewSelector: React.FC = () => {
+  const { view, updatePageParams } = usePageParams();
+
+  return (
+    <Selector
+      optionsDisplay={OptionsDisplay.InlineDropdown}
+      options={Object.values(View)}
+      onChange={(view: View) => updatePageParams({ view, objectID: undefined })}
+      selected={view}
+    />
+  );
+};
+
+export default PathNav;

--- a/src/controls/selectors/ObjectTypeSelector.tsx
+++ b/src/controls/selectors/ObjectTypeSelector.tsx
@@ -3,7 +3,7 @@ import React, { useCallback } from 'react';
 import { toTitleCase } from '../../generic/stringUtils';
 import { ObjectType, View } from '../../types/PageParamTypes';
 import { getObjectTypeLabelPlural } from '../../views/common/getObjectName';
-import Selector, { OptionsDisplay } from '../components/Selector';
+import Selector from '../components/Selector';
 import { usePageParams } from '../PageParamsContext';
 
 const ObjectTypeSelector: React.FC = () => {
@@ -23,7 +23,6 @@ const ObjectTypeSelector: React.FC = () => {
   return (
     <Selector
       selectorLabel="Entity"
-      optionsDisplay={OptionsDisplay.ButtonList}
       options={Object.values(ObjectType)}
       onChange={goToObjectType}
       selected={objectType}

--- a/src/controls/selectors/PaginationControls.tsx
+++ b/src/controls/selectors/PaginationControls.tsx
@@ -16,11 +16,13 @@ const PaginationControls: React.FC<Props> = ({ currentPage, totalPages }) => {
 
   return (
     <>
-      Page:{' '}
+      Page:
       <div
         className="selector compact rounded"
         style={{
           marginBottom: 0,
+          marginLeft: '0.5em',
+          marginRight: '0.5em',
           display: 'inline-flex',
           verticalAlign: 'middle',
           alignItems: 'normal',

--- a/src/controls/selectors/SearchBar.tsx
+++ b/src/controls/selectors/SearchBar.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 
 import { SearchableField, View } from '../../types/PageParamTypes';
 import { OptionsDisplay } from '../components/Selector';
-import Selector from '../components/SelectorOld';
 import SingleChoiceOptions from '../components/SingleChoiceOptions';
 import TextInput from '../components/TextInput';
 import { usePageParams } from '../PageParamsContext';
@@ -13,11 +12,24 @@ import { useSearchSuggestions } from './useSearchSuggestions';
 const SearchBar: React.FC = () => {
   const { searchBy, searchString, updatePageParams, view } = usePageParams();
   const getSearchSuggestions = useSearchSuggestions();
+  const border = '0.125em solid var(--color-button-primary)';
 
   return (
-    <Selector selectorLabel={<SearchIcon size="1em" display="block" />}>
+    <div
+      className="selector"
+      style={{
+        display: 'flex',
+        alignItems: 'end',
+        marginBottom: '0.5em',
+      }}
+    >
+      <div
+        style={{ marginRight: '-0.125em', border, padding: '0.5em', borderRadius: '1em 0 0 1em' }}
+      >
+        <SearchIcon size="1em" display="block" />
+      </div>
       <TextInput
-        inputStyle={{ minWidth: '20em' }}
+        inputStyle={{ minWidth: '20em', marginRight: '-0.125em', borderRight: 'none' }}
         getSuggestions={getSearchSuggestions}
         onChange={(searchString: string) => updatePageParams({ searchString })}
         optionsDisplay={OptionsDisplay.ButtonGroup}
@@ -26,13 +38,24 @@ const SearchBar: React.FC = () => {
         showTextInputButton={view !== View.Details}
         value={searchString}
       />
-      <label className="NoLeftBorder">on</label>
+      <label
+        style={{
+          marginLeft: '-0.125em',
+          marginRight: '-0.125em',
+          border,
+          borderLeft: 'none',
+          padding: '0.5em',
+        }}
+      >
+        on
+      </label>
       <SingleChoiceOptions<SearchableField>
         onChange={(searchBy: SearchableField) => updatePageParams({ searchBy })}
         options={Object.values(SearchableField)}
         selected={searchBy}
+        style={{ borderRadius: '0 1em 1em 0' }}
       />
-    </Selector>
+    </div>
   );
 };
 

--- a/src/generic/PositionInGroup.tsx
+++ b/src/generic/PositionInGroup.tsx
@@ -1,0 +1,15 @@
+export enum PositionInGroup {
+  Standalone = 'standalone', // its not visualized with the group
+  First = 'first',
+  Middle = 'middle',
+  Last = 'last',
+  Only = 'only', // first & last
+}
+
+// 0 indexed
+export function getPositionInGroup(index: number, length: number): PositionInGroup {
+  if (length === 1) return PositionInGroup.Only;
+  if (index === 0) return PositionInGroup.First;
+  if (index === length - 1) return PositionInGroup.Last;
+  return PositionInGroup.Middle;
+}

--- a/src/pages/DataPage.tsx
+++ b/src/pages/DataPage.tsx
@@ -17,7 +17,7 @@ const DataPage: React.FC = () => {
         <HoverCardProvider>
           {/* HoverCardProvider is re-declared so it has access to page parameters, there may be a better way to organize it */}
           <DataProvider>
-            <div style={{ display: 'flex', minHeight: '100vh' }}>
+            <div style={{ display: 'flex', height: '100vh' }}>
               <SidePanel />
               <DataPageBody />
             </div>

--- a/src/views/DataPageBody.tsx
+++ b/src/views/DataPageBody.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import PathNav from '../controls/pathnav/PathNav';
 import SearchBar from '../controls/selectors/SearchBar';
 
 import DataViews from './DataViews';
@@ -8,6 +9,7 @@ const DataPageBody: React.FC = () => {
   return (
     <main style={{ padding: '1em', flex: 1, overflow: 'auto', width: '100%' }}>
       <SearchBar />
+      <PathNav />
       <div
         style={{
           maxWidth: '1280px',

--- a/src/views/styles.css
+++ b/src/views/styles.css
@@ -77,7 +77,7 @@ button.compact {
   padding: 0em 0.25em;
   font-size: 1em;
   font-weight: normal;
-  margin: 0 -.125em
+  margin: 0 -0.125em;
 }
 
 div h1:first-child,

--- a/src/views/styles.css
+++ b/src/views/styles.css
@@ -77,6 +77,7 @@ button.compact {
   padding: 0em 0.25em;
   font-size: 1em;
   font-weight: normal;
+  margin: 0 -.125em
 }
 
 div h1:first-child,


### PR DESCRIPTION
One of the biggest pieces of feedback from recent user interviews was difficult navigating to the right page. A design that I considered was breadcrumbs and after playing around with it I really like how it looks.

This PR starts the concept with the 2 main selectors. While adding the inline-dropdown selector style, I revamped other parts of selector style to abide by some better front-end practices (in particular, I'm now leaning to the school of thought to have inline Styles rather than separate CSS files).

See the new buttons

<img width="986" height="358" alt="Screenshot 2025-08-01 at 12 05 46" src="https://github.com/user-attachments/assets/79145400-a7fb-4750-9ead-407ddca58723" />

<img width="542" height="307" alt="Screenshot 2025-08-01 at 12 06 00" src="https://github.com/user-attachments/assets/8ec2fed9-b693-45ca-8fc8-81901019f77b" />


Finishes #149