### PR TITLE
Added date sort for censuses

### DIFF
--- a/src/controls/sort.tsx
+++ b/src/controls/sort.tsx
@@ -1,4 +1,5 @@
 import { uniqueBy } from '../generic/setUtils';
+import { CensusData } from '../types/CensusTypes';
 import { ObjectData } from '../types/DataTypes';
 import { LanguageData, LanguageSource } from '../types/LanguageTypes';
 import { ObjectType, SortBy, View } from '../types/PageParamTypes';
@@ -151,6 +152,18 @@ export function getSortFunction(languageSource?: LanguageSource): SortByFunction
               : -1;
         }
       };
+
+    case SortBy.Date:
+      return (a, b) => {
+        const dateA = (a as CensusData).yearCollected || 0;
+
+        const dateB = (b as CensusData).yearCollected || 0;
+
+        return dateB - dateA; // Sorts descending (newest first)
+      };
+
+    default:
+      return () => 0;
   }
 }
 
@@ -186,7 +199,7 @@ export function getSortBysApplicableToObjectType(objectType: ObjectType): SortBy
         SortBy.CountOfLanguages,
       ];
     case ObjectType.Census:
-      return [SortBy.Code, SortBy.Name, SortBy.Population, SortBy.CountOfLanguages];
+      return [SortBy.Date, SortBy.Code, SortBy.Name, SortBy.Population, SortBy.CountOfLanguages];
     case ObjectType.WritingSystem:
       return [
         SortBy.Code,

--- a/src/types/PageParamTypes.tsx
+++ b/src/types/PageParamTypes.tsx
@@ -27,6 +27,7 @@ export enum SortBy {
   CountOfTerritories = 'Count of Territories',
   RelativePopulation = 'Relative Population',
   Literacy = 'Literacy',
+  Date = 'Date',
 }
 
 export enum SearchableField {


### PR DESCRIPTION
This pull request implements the ability to sort census data by date, as requested in issue #154.

### Key Changes

-   **Added `Date` Sort Option:** A new `Date` value was added to the `SortBy` enum in `PageParamTypes.tsx`.
-   **Implemented Sort Logic:** The main sort function in `sort.tsx` was updated to handle the new `Date` option.
-   **Updated UI:** The "Date" sort button is now available in the "View Options" when viewing the Censuses table.

|Before|After|
|--|--|
|<img width="1463" height="801" alt="image" src="https://github.com/user-attachments/assets/6e9c8fcd-9aa6-4266-b311-751a04f29520" /> | <img width="1464" height="680" alt="image" src="https://github.com/user-attachments/assets/4d8f5eb1-aa4d-4a9d-a149-e1440e66e4d6" />|

Fixes #154 