### PR TITLE
Controls: Add sort direction selector

### DIFF
--- a/src/controls/PageParamsContext.tsx
+++ b/src/controls/PageParamsContext.tsx
@@ -102,6 +102,9 @@ function getParamsFromURL(urlParams: URLSearchParams): PageParamsOptional {
       case 'languageSource':
         params.languageSource = value as LanguageSource;
         break;
+      case 'sortDirection':
+        params.sortDirection = value === 'reverse' ? value : 'normal';
+        break;
 
       // Freeform strings
       case 'objectID':
@@ -159,10 +162,12 @@ function getNewURLSearchParams(
   );
   Array.from(next.entries()).forEach(([key, value]) => {
     const defaultValue = defaults[key as PageParamKey];
-    if (key === 'profile' && value !== ProfileType.LanguageEthusiast) {
-      // "defaults" will always be set to the current profile, so don't clear it
-      return;
-    }
+
+    // Don't remove view or profile because they change on defaults
+    if (key === 'view') return;
+    if (key === 'profile' && value !== ProfileType.LanguageEthusiast) return;
+
+    // If the default is the empty array you can remove it
     if (value === '[]' && Array.isArray(defaultValue) && defaultValue.length === 0) {
       next.delete(key);
       return;

--- a/src/controls/Profiles.tsx
+++ b/src/controls/Profiles.tsx
@@ -22,7 +22,7 @@ export enum ProfileType {
 const GLOBAL_DEFAULTS: PageParams = {
   languageSource: LanguageSource.All,
   languageScopes: [LanguageScope.Macrolanguage, LanguageScope.Language],
-  limit: 8,
+  limit: 12,
   localeSeparator: LocaleSeparator.Underscore,
   objectID: undefined,
   objectType: ObjectType.Language,
@@ -31,6 +31,7 @@ const GLOBAL_DEFAULTS: PageParams = {
   searchBy: SearchableField.AllNames,
   searchString: '',
   sortBy: SortBy.Population,
+  sortDirection: 'normal',
   territoryScopes: [TerritoryScope.Country, TerritoryScope.Dependency],
   territoryFilter: '',
   view: View.CardList,

--- a/src/controls/SidePanel.tsx
+++ b/src/controls/SidePanel.tsx
@@ -11,6 +11,7 @@ import LocaleSeparatorSelector from './selectors/LocaleSeparatorSelector';
 import ObjectTypeSelector from './selectors/ObjectTypeSelector';
 import ProfileSelector from './selectors/ProfileSelector';
 import SortBySelector from './selectors/SortBySelector';
+import SortDirectionSelector from './selectors/SortDirectionSelector';
 import TerritoryFilterSelector from './selectors/TerritoryFilterSelector';
 import TerritoryScopeSelector from './selectors/TerritoryScopeSelector';
 import ViewSelector from './selectors/ViewSelector';
@@ -51,6 +52,7 @@ const SidePanel: React.FC = () => {
         <ViewSelector />
         <LimitInput />
         <SortBySelector />
+        <SortDirectionSelector />
         <LocaleSeparatorSelector />
       </SidePanelSection>
 

--- a/src/controls/selectors/SortDirectionSelector.tsx
+++ b/src/controls/selectors/SortDirectionSelector.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { toTitleCase } from '../../generic/stringUtils';
+import Selector, { OptionsDisplay } from '../components/Selector';
+import { usePageParams } from '../PageParamsContext';
+
+const SortDirectionSelector: React.FC = () => {
+  const { sortDirection, updatePageParams } = usePageParams();
+
+  return (
+    <Selector
+      selectorLabel="Sort Direction"
+      optionsDisplay={OptionsDisplay.ButtonGroup}
+      options={['normal', 'reverse']}
+      getOptionLabel={(direction) => toTitleCase(direction)}
+      getOptionDescription={(direction) =>
+        direction === 'normal'
+          ? 'Sort with high numbers first / first letter in alphabet first.'
+          : 'Sort with low numbers first / last letter in alphabet first.'
+      }
+      onChange={(direction: 'normal' | 'reverse') => updatePageParams({ sortDirection: direction })}
+      selected={sortDirection}
+    />
+  );
+};
+
+export default SortDirectionSelector;

--- a/src/controls/selectors/ViewSelector.tsx
+++ b/src/controls/selectors/ViewSelector.tsx
@@ -1,46 +1,20 @@
 import React from 'react';
 
 import { View } from '../../types/PageParamTypes';
-import Selector, { OptionsDisplay } from '../components/Selector';
+import Selector from '../components/Selector';
 import { usePageParams } from '../PageParamsContext';
 
 const ViewSelector: React.FC = () => {
   const { view, updatePageParams } = usePageParams();
 
   return (
-    <>
-      <Selector
-        selectorLabel="View"
-        getOptionDescription={(option) => <img src={getImageSrc(option)} width={180} />}
-        options={Object.values(View)}
-        onChange={(view: View) => updatePageParams({ view, objectID: undefined })}
-        selected={view}
-      />
-      <Selector
-        selectorLabel="View"
-        getOptionDescription={(option) => <img src={getImageSrc(option)} width={180} />}
-        options={Object.values(View)}
-        optionsDisplay={OptionsDisplay.ButtonGroup}
-        onChange={(view: View) => updatePageParams({ view, objectID: undefined })}
-        selected={view}
-      />
-      <Selector
-        selectorLabel="View"
-        getOptionDescription={(option) => <img src={getImageSrc(option)} width={180} />}
-        options={Object.values(View)}
-        optionsDisplay={OptionsDisplay.Dropdown}
-        onChange={(view: View) => updatePageParams({ view, objectID: undefined })}
-        selected={view}
-      />
-      <Selector
-        selectorLabel="View"
-        getOptionDescription={(option) => <img src={getImageSrc(option)} width={180} />}
-        options={Object.values(View)}
-        optionsDisplay={OptionsDisplay.InlineDropdown}
-        onChange={(view: View) => updatePageParams({ view, objectID: undefined })}
-        selected={view}
-      />
-    </>
+    <Selector
+      selectorLabel="View"
+      getOptionDescription={(option) => <img src={getImageSrc(option)} width={180} />}
+      options={Object.values(View)}
+      onChange={(view: View) => updatePageParams({ view, objectID: undefined })}
+      selected={view}
+    />
   );
 };
 

--- a/src/controls/sort.tsx
+++ b/src/controls/sort.tsx
@@ -12,9 +12,25 @@ export function getSortFunction(
   includeDescendents?: boolean,
   languageSource?: LanguageSource,
 ): SortByFunctionType {
-  const { sortBy, languageSource: languageSourcePageParam } = usePageParams();
+  const { sortBy, languageSource: languageSourcePageParam, sortDirection } = usePageParams();
   const effectiveLanguageSource = languageSource ?? languageSourcePageParam;
 
+  const sortFunction = getSortFunctionParameterized(
+    sortBy,
+    effectiveLanguageSource,
+    includeDescendents ?? false,
+  );
+  if (sortDirection === 'reverse') {
+    return (a, b) => -sortFunction(a, b);
+  }
+  return sortFunction;
+}
+
+function getSortFunctionParameterized(
+  sortBy: SortBy,
+  effectiveLanguageSource: LanguageSource,
+  includeDescendents: boolean,
+): SortByFunctionType {
   switch (sortBy) {
     case SortBy.Code:
       return (a: ObjectData, b: ObjectData) => {

--- a/src/types/PageParamTypes.tsx
+++ b/src/types/PageParamTypes.tsx
@@ -56,6 +56,7 @@ export type PageParamKey =
   | 'searchBy'
   | 'searchString'
   | 'sortBy'
+  | 'sortDirection'
   | 'territoryFilter'
   | 'territoryScopes'
   | 'view';
@@ -72,6 +73,7 @@ export type PageParams = {
   searchBy: SearchableField;
   searchString: string;
   sortBy: SortBy;
+  sortDirection: 'normal' | 'reverse'; // true for normal, false for reverse
   territoryFilter: string;
   territoryScopes: TerritoryScope[];
   view: View;
@@ -89,6 +91,7 @@ export type PageParamsOptional = {
   searchBy?: SearchableField;
   searchString?: string;
   sortBy?: SortBy;
+  sortDirection?: 'normal' | 'reverse';
   territoryFilter?: string;
   territoryScopes?: TerritoryScope[];
   view?: View;

--- a/src/views/common/table/TableSortButton.tsx
+++ b/src/views/common/table/TableSortButton.tsx
@@ -1,0 +1,60 @@
+import { ArrowDown01, ArrowDown10, ArrowDownAZ, ArrowDownZA } from 'lucide-react';
+import React, { useCallback } from 'react';
+
+import { usePageParams } from '../../../controls/PageParamsContext';
+import HoverableButton from '../../../generic/HoverableButton';
+import { SortBy } from '../../../types/PageParamTypes';
+
+type Props = {
+  columnSortBy?: SortBy;
+  isNumeric?: boolean;
+};
+
+const TableSortButton: React.FC<Props> = ({ columnSortBy, isNumeric = false }) => {
+  const { sortBy, updatePageParams, sortDirection } = usePageParams();
+
+  if (!columnSortBy) {
+    return <></>;
+  }
+
+  const onSortButtonClick = useCallback(
+    (newSortBy: SortBy): void => {
+      if (sortBy != newSortBy) {
+        updatePageParams({ sortBy: newSortBy, sortDirection: 'normal' });
+      } else {
+        updatePageParams({ sortDirection: sortDirection === 'normal' ? 'reverse' : 'normal' });
+      }
+    },
+    [sortBy, updatePageParams, sortDirection],
+  );
+
+  return (
+    <HoverableButton
+      className={sortBy === columnSortBy ? 'primary' : ''}
+      style={{
+        display: 'inline-block',
+        margin: 0,
+        marginLeft: '4px',
+        padding: '2px',
+        borderRadius: '2px',
+      }}
+      hoverContent="Click to sort by this column or to toggle the sort direction."
+      onClick={() => onSortButtonClick(columnSortBy)}
+    >
+      <SortButtonIcon isNumeric={isNumeric} sortDirection={sortDirection} />
+    </HoverableButton>
+  );
+};
+
+type SortButtonIconProps = {
+  isNumeric?: boolean;
+  sortDirection?: 'normal' | 'reverse';
+};
+
+function SortButtonIcon({ isNumeric, sortDirection }: SortButtonIconProps) {
+  if (isNumeric && sortDirection === 'reverse') return <ArrowDown01 size="1em" display="block" />;
+  if (isNumeric && sortDirection === 'normal') return <ArrowDown10 size="1em" display="block" />;
+  if (!isNumeric && sortDirection === 'reverse') return <ArrowDownZA size="1em" display="block" />;
+  return <ArrowDownAZ size="1em" display="block" />;
+}
+export default TableSortButton;

--- a/src/views/common/table/tableStyles.css
+++ b/src/views/common/table/tableStyles.css
@@ -24,19 +24,6 @@ thead {
   font-family: Avenir, 'Courier New', monospace;
 }
 
-.sort {
-  display: inline-block;
-  margin: 0;
-  margin-left: 4px;
-  padding: 2px;
-  border-radius: 2px;
-}
-
-.sort.active {
-  background-color: var(--color-button-primary);
-  color: var(--color-background);
-}
-
 summary {
   padding: 4px 8px;
   border-radius: 4px;

--- a/src/views/language/LanguageTable.tsx
+++ b/src/views/language/LanguageTable.tsx
@@ -64,12 +64,14 @@ const LanguageTable: React.FC = () => {
                 .map((lang) => lang.nameDisplay)}
             />
           ),
+          isNumeric: true,
           isInitiallyVisible: false,
           sortParam: SortBy.CountOfLanguages,
         },
         {
           key: 'Territories',
           render: (lang) => <HoverableEnumeration items={getUniqueTerritoriesForLanguage(lang)} />,
+          isNumeric: true,
           sortParam: SortBy.CountOfTerritories,
         },
         InfoButtonColumn,


### PR DESCRIPTION
This does a few things

* Fixes changing the view parameter -- it was being dropped
* Changes the table sort icons to be semantically relevant
* Make Sort Direction a page parameter rather than only in the table view
* Uses sort direction in the core sorting function -- so it should affect all sorts
* Adds sort direction selector to the sidepanel.

<img width="1157" height="800" alt="Screenshot 2025-08-04 at 10 23 54" src="https://github.com/user-attachments/assets/99e5a709-cda1-4b0c-a773-c133e059042f" />
