### PR TITLE
Variant Tags: Add table & hierarchy views

### DIFF
--- a/src/controls/components/TextInput.tsx
+++ b/src/controls/components/TextInput.tsx
@@ -25,6 +25,11 @@ type Props = {
   value: string;
 };
 
+/*
+ * Known issues: This component uses useEffect to debounce inputs and to update the field
+ * if it is updated in another place -- but there still seems to be an issue and it may
+ * cause the history to be reset. Adding 2 TextInputs on the same page may freeze the page.
+ */
 const TextInput: React.FC<Props> = ({
   getSuggestions = () => [],
   inputStyle,

--- a/src/controls/pathnav/PathNav.tsx
+++ b/src/controls/pathnav/PathNav.tsx
@@ -1,6 +1,7 @@
 import { SlashIcon } from 'lucide-react';
 import React, { useCallback } from 'react';
 
+import ObjectTypeDescription from '../../strings/ObjectTypeDescription';
 import { ObjectType, View } from '../../types/PageParamTypes';
 import Selector, { OptionsDisplay } from '../components/Selector';
 import { usePageParams } from '../PageParamsContext';
@@ -39,6 +40,7 @@ const ObjectTypeSelector: React.FC = () => {
       options={Object.values(ObjectType)}
       onChange={goToObjectType}
       selected={objectType}
+      getOptionDescription={(objectType) => <ObjectTypeDescription objectType={objectType} />}
     />
   );
 };

--- a/src/controls/selectors/ObjectTypeSelector.tsx
+++ b/src/controls/selectors/ObjectTypeSelector.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 
 import { toTitleCase } from '../../generic/stringUtils';
+import ObjectTypeDescription from '../../strings/ObjectTypeDescription';
 import { ObjectType, View } from '../../types/PageParamTypes';
 import { getObjectTypeLabelPlural } from '../../views/common/getObjectName';
 import Selector from '../components/Selector';
@@ -31,58 +32,11 @@ const ObjectTypeSelector: React.FC = () => {
       getOptionDescription={(objectType) => (
         <>
           <div style={{ marginBottom: 8 }}>Click here to change the kind of entity viewed.</div>
-          <OptionDescription objectType={objectType} />
+          <ObjectTypeDescription objectType={objectType} />
         </>
       )}
     />
   );
-};
-
-const OptionDescription: React.FC<{ objectType: ObjectType }> = ({ objectType }) => {
-  switch (objectType) {
-    case ObjectType.Census:
-      return (
-        <>
-          <label>Census:</label> A count of people in a given area -- for this site this is
-          typically the count of people that speak or understand a language.
-        </>
-      );
-    case ObjectType.Language:
-      return (
-        <>
-          <label>Language (Languoid):</label>A verbal communication system used by multiple people.
-          Languages should be mutually intelligible, whereas a dialect is a subset of a language
-          defined by differences in lexicon and pronunciation. Since languages families, contested
-          languages, and dialects are included it is more precise to consider these
-          &quot;Languoids&quot;.
-        </>
-      );
-    case ObjectType.Locale:
-      return (
-        <>
-          <label>Locale:</label>The combination of a language and territory -- used to express how
-          many people speak a language in a given area or if a language is officially supported.
-          Some locales specify a particular writing system and/or variation information (dialect,
-          orthography...).
-        </>
-      );
-    case ObjectType.Territory:
-      return (
-        <>
-          <label>Territory:</label>A geographical unit. Some may not have universal recognition.
-          Currently showing both countries as well as dependencies (eg. Hong Kong) that have
-          separate ISO codes.
-        </>
-      );
-    case ObjectType.WritingSystem:
-      return (
-        <>
-          <label>Writing System:</label>A system for writing a language to a persistent visual
-          media. For instance Latin alphabet, Han characters, cursive Arabic script. Some systems
-          may contain other systems.
-        </>
-      );
-  }
 };
 
 export default ObjectTypeSelector;

--- a/src/data/IANAData.tsx
+++ b/src/data/IANAData.tsx
@@ -92,7 +92,7 @@ export function parseIANAVariants(input: string): VariantTagDictionary {
     // Prefixes are usually language codes but can be composites like zh-Latn-pinyin or oc-lengadoc-grclass
     const languageCodes = unique(data.Prefix.map((l) => l.split(/\W/)[0]));
     const localeCodes = data.Prefix.map((l) => l + '-' + ianaTag);
-    const added = data.Added[0] ? new Date(data.Added[0]) : undefined;
+    const dateAdded = data.Added[0] ? new Date(data.Added[0]) : undefined;
 
     if (ianaTag && name) {
       variants[ianaTag] = {
@@ -101,7 +101,7 @@ export function parseIANAVariants(input: string): VariantTagDictionary {
         codeDisplay: ianaTag,
         nameDisplay: name,
         description: data.Comments.join(' '), // It's called comments but its functionally a description
-        added,
+        dateAdded,
         prefixes: data.Prefix,
         languageCodes: languageCodes,
         localeCodes: localeCodes,

--- a/src/strings/ObjectTypeDescription.tsx
+++ b/src/strings/ObjectTypeDescription.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { ObjectType } from '../types/PageParamTypes';
+
+const ObjectTypeDescription: React.FC<{ objectType: ObjectType }> = ({ objectType }) => {
+  switch (objectType) {
+    case ObjectType.Census:
+      return (
+        <>
+          <label>Census:</label> A count of people in a given area -- for this site this is
+          typically the count of people that speak or understand a language.
+        </>
+      );
+    case ObjectType.Language:
+      return (
+        <>
+          <label>Language (Languoid):</label>A verbal communication system used by multiple people.
+          Languages should be mutually intelligible, whereas a dialect is a subset of a language
+          defined by differences in lexicon and pronunciation. Since languages families, contested
+          languages, and dialects are included it is more precise to consider these
+          &quot;Languoids&quot;.
+        </>
+      );
+    case ObjectType.Locale:
+      return (
+        <>
+          <label>Locale:</label>The combination of a language and territory -- used to express how
+          many people speak a language in a given area or if a language is officially supported.
+          Some locales specify a particular writing system and/or variation information (dialect,
+          orthography...).
+        </>
+      );
+    case ObjectType.Territory:
+      return (
+        <>
+          <label>Territory:</label>A geographical unit. Some may not have universal recognition.
+          Currently showing both countries as well as dependencies (eg. Hong Kong) that have
+          separate ISO codes.
+        </>
+      );
+    case ObjectType.WritingSystem:
+      return (
+        <>
+          <label>Writing System:</label>A system for writing a language to a persistent visual
+          media. For instance Latin alphabet, Han characters, cursive Arabic script. Some systems
+          may contain other systems.
+        </>
+      );
+    case ObjectType.VariantTag:
+      return (
+        <>
+          <label>Variant Tag:</label>The Internet Assigned Numbers Authority (IANA) maintains an
+          enumeration of language tags in common usage. The &quot;variant&quot; tags are used in
+          composite locales in the form <code>ca_valencia</code> or <code>ca-u-va-valencia</code>.
+          These are typically used to specify a particular orthography or dialect.
+        </>
+      );
+  }
+};
+
+export default ObjectTypeDescription;

--- a/src/types/DataTypes.tsx
+++ b/src/types/DataTypes.tsx
@@ -185,8 +185,7 @@ export interface VariantTagData extends ObjectBase {
   nameDisplay: string;
   description?: string;
 
-  dateAdded?: string;
-  added?: Date;
+  dateAdded?: Date;
   prefixes: string[]; // Usually language codes but sometimes composites like zh-Latn or oc-lengadoc
   languageCodes: LanguageCode[]; // zh, oc, etc.
   localeCodes: BCP47LocaleCode[]; // would look like zh-Latn-pinyin or oc-lengadoc-grclass

--- a/src/views/DataViews.tsx
+++ b/src/views/DataViews.tsx
@@ -15,10 +15,13 @@ import TerritoryCardList from './territory/TerritoryCardList';
 import { TerritoryHierarchy } from './territory/TerritoryHierarchy';
 import TerritoryTable from './territory/TerritoryTable';
 import VariantTagCardList from './varianttag/VariantTagCardList';
+import { VariantTagHierarchy } from './varianttag/VariantTagHierarchy';
+import VariantTagTable from './varianttag/VariantTagTable';
 import ViewReports from './ViewReports';
 import WritingSystemCardList from './writingsystem/WritingSystemCardList';
 import { WritingSystemHierarchy } from './writingsystem/WritingSystemHierarchy';
 import WritingSystemTable from './writingsystem/WritingSystemTable';
+
 import './styles.css';
 
 function MainViews() {
@@ -56,7 +59,7 @@ function MainViews() {
         case ObjectType.WritingSystem:
           return <WritingSystemHierarchy />;
         case ObjectType.VariantTag:
-          return <>Not yet Implemented</>;
+          return <VariantTagHierarchy />;
       }
     // eslint-disable-next-line no-fallthrough
     case View.Table:
@@ -72,7 +75,7 @@ function MainViews() {
         case ObjectType.WritingSystem:
           return <WritingSystemTable />;
         case ObjectType.VariantTag:
-          return <>Not yet Implemented</>;
+          return <VariantTagTable />;
       }
     // eslint-disable-next-line no-fallthrough
     case View.Reports:

--- a/src/views/census/CensusHierarchy.tsx
+++ b/src/views/census/CensusHierarchy.tsx
@@ -16,7 +16,17 @@ export const CensusHierarchy: React.FC = () => {
 
   const rootNodes = getCensusTreeNodes(Object.values(territories), sortFunction, filterByScope);
 
-  return <TreeListPageBody rootNodes={rootNodes} description={<>Censuses</>} />;
+  return (
+    <TreeListPageBody
+      rootNodes={rootNodes}
+      description={
+        <>
+          This view shows censuses and census tables, organized by the country they were collected
+          for.
+        </>
+      }
+    />
+  );
 };
 
 export function getCensusTreeNodes(

--- a/src/views/census/TableOfAllCensuses.tsx
+++ b/src/views/census/TableOfAllCensuses.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { useDataContext } from '../../data/DataContext';
+import Deemphasized from '../../generic/Deemphasized';
 import HoverableEnumeration from '../../generic/HoverableEnumeration';
 import { CensusData } from '../../types/CensusTypes';
 import { SortBy } from '../../types/PageParamTypes';
@@ -28,7 +29,6 @@ const TableOfAllCensuses: React.FC = () => {
           isNumeric: true,
           sortParam: SortBy.CountOfLanguages,
         },
-
         {
           key: 'Eligible Population',
           render: (census) =>
@@ -37,6 +37,20 @@ const TableOfAllCensuses: React.FC = () => {
               : 'Unknown',
           isNumeric: true,
           sortParam: SortBy.Population,
+        },
+        {
+          key: 'Year Collected',
+          render: (census) =>
+            census.collectorType !== 'CLDR' ? (
+              new Date(census.yearCollected + '-07-01').toLocaleDateString(undefined, {
+                year: 'numeric',
+              })
+            ) : (
+              <Deemphasized>multiple</Deemphasized>
+            ),
+          isInitiallyVisible: false,
+          isNumeric: true,
+          sortParam: SortBy.Date,
         },
         InfoButtonColumn,
       ]}

--- a/src/views/census/TableOfLanguagesInCensus.tsx
+++ b/src/views/census/TableOfLanguagesInCensus.tsx
@@ -110,6 +110,7 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
                 ? numberToFixedUnlessSmall(loc.populationSpeakingPercent) + '%'
                 : 'N/A',
             isNumeric: true,
+            sortParam: SortBy.RelativePopulation,
           },
           {
             key: 'Scope',
@@ -150,10 +151,8 @@ const ActualLocaleInfoButton: React.FC<{ actualLocale?: LocaleData }> = ({ actua
     );
   }
   return (
-    <HoverableObject object={actualLocale}>
-      <button className="InfoButton">
-        <InfoIcon size="1em" />
-      </button>
+    <HoverableObject object={actualLocale} style={{ verticalAlign: 'middle' }}>
+      <InfoIcon size="1em" display="block" />
     </HoverableObject>
   );
 };

--- a/src/views/common/HoverableObject.tsx
+++ b/src/views/common/HoverableObject.tsx
@@ -14,9 +14,10 @@ import WritingSystemCard from '../writingsystem/WritingSystemCard';
 type Props = {
   object?: ObjectData;
   children: React.ReactNode;
+  style?: React.CSSProperties;
 };
 
-const HoverableObject: React.FC<Props> = ({ object, children }) => {
+const HoverableObject: React.FC<Props> = ({ object, children, style }) => {
   const { view, updatePageParams } = usePageParams();
   if (object == null) {
     return <>{children}</>;
@@ -59,6 +60,7 @@ const HoverableObject: React.FC<Props> = ({ object, children }) => {
           objectID: object.ID,
         })
       }
+      style={style}
     >
       {children}
     </Hoverable>

--- a/src/views/common/ObjectField.tsx
+++ b/src/views/common/ObjectField.tsx
@@ -75,6 +75,7 @@ export function getSearchableField(object: ObjectData, field: SearchableField, q
   }
 }
 
+// TODO make better upperbound/lowerbound population estimates when we don't have exact numbers
 export function getObjectPopulation(
   object: ObjectData,
   includeDescendents?: boolean,
@@ -99,6 +100,6 @@ export function getObjectPopulation(
     case ObjectType.Territory:
       return object.population;
     case ObjectType.VariantTag:
-      return 0; // Variant tags don't have a population
+      return object.languages.reduce((sum, lang) => sum + (lang.populationCited || 0), 0);
   }
 }

--- a/src/views/common/TreeList/TreeListNode.tsx
+++ b/src/views/common/TreeList/TreeListNode.tsx
@@ -77,10 +77,8 @@ const TreeListNode: React.FC<Props> = ({ nodeData, isExpandedInitially = false }
           </>
         )}
         {showInfoButton && (
-          <HoverableObject object={object}>
-            <button className="InfoButton">
-              <InfoIcon size="1em" display="block" />
-            </button>
+          <HoverableObject object={object} style={{ marginLeft: '0.125em' }}>
+            <InfoIcon size="1em" />
           </HoverableObject>
         )}
         {showPopulation && population > 0 && (

--- a/src/views/common/TreeList/TreeListPageBody.tsx
+++ b/src/views/common/TreeList/TreeListPageBody.tsx
@@ -30,7 +30,17 @@ const TreeListPageBody: React.FC<Props> = ({ rootNodes, description }) => {
   return (
     <div className="TreeListView">
       <TreeListOptionsProvider>
-        <div style={{ marginBottom: 8 }}>{description}</div>
+        <div style={{ marginBottom: 8 }}>
+          {description}
+          {limit < rootNodes.length && (
+            <>
+              {' '}
+              {limit} of {rootNodes.length} root nodes are shown. Update the item limit in the
+              options panel to see more.
+            </>
+          )}
+        </div>
+
         <TreeListRoot
           rootNodes={rootNodes
             .map((node) => filterBranch(node, filterFunction))

--- a/src/views/common/getObjectFromID.tsx
+++ b/src/views/common/getObjectFromID.tsx
@@ -13,6 +13,7 @@ export default function getObjectFromID(inputObjectID?: string): ObjectData | un
   return (
     censuses[objectID] ??
     languagesBySource.All[objectID] ??
+    languagesBySource.BCP[objectID] ??
     languagesBySource.Glottolog[objectID] ?? // The Glottolog lookup should no longer be necessary since objects have a stable ID field, but keep just in case
     territories[objectID] ??
     locales[objectID] ??

--- a/src/views/common/table/CommonColumns.tsx
+++ b/src/views/common/table/CommonColumns.tsx
@@ -35,10 +35,8 @@ export const EndonymColumn: TableColumn<ObjectData> = {
 export const InfoButtonColumn: TableColumn<ObjectData> = {
   key: 'Info',
   render: (object) => (
-    <HoverableObject object={object}>
-      <button className="InfoButton">
-        <InfoIcon size="1em" display="block" style={{ verticalAlign: 'middle' }} />
-      </button>
+    <HoverableObject object={object} style={{ verticalAlign: 'middle' }}>
+      <InfoIcon size="1em" display="block" />
     </HoverableObject>
   ),
 };

--- a/src/views/styles.css
+++ b/src/views/styles.css
@@ -57,12 +57,6 @@ a:hover {
   margin-top: 1em;
 }
 
-.InfoButton {
-  background-color: var(--color-background);
-  color: var(--color-button-primary);
-  padding: 0 4px;
-}
-
 .LinkButton {
   margin-left: 1em;
   margin-bottom: 0.5em;

--- a/src/views/varianttag/VariantTagDetails.tsx
+++ b/src/views/varianttag/VariantTagDetails.tsx
@@ -9,7 +9,7 @@ type Props = {
 };
 
 const VariantTagDetails: React.FC<Props> = ({ variantTag }) => {
-  const { ID, added, prefixes, nameDisplay, description, languages, locales } = variantTag;
+  const { ID, dateAdded, prefixes, nameDisplay, description, languages, locales } = variantTag;
 
   return (
     <div className="Details">
@@ -29,10 +29,10 @@ const VariantTagDetails: React.FC<Props> = ({ variantTag }) => {
             {description}
           </div>
         )}
-        {added && (
+        {dateAdded && (
           <div>
             <label>Added: </label>
-            {added.toLocaleDateString()}
+            {dateAdded.toLocaleDateString()}
           </div>
         )}
       </div>

--- a/src/views/varianttag/VariantTagHierarchy.tsx
+++ b/src/views/varianttag/VariantTagHierarchy.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+import { getSortFunction } from '../../controls/sort';
+import { useDataContext } from '../../data/DataContext';
+import { ObjectData, VariantTagData } from '../../types/DataTypes';
+import { ObjectType } from '../../types/PageParamTypes';
+import getObjectFromID from '../common/getObjectFromID';
+import { TreeNodeData } from '../common/TreeList/TreeListNode';
+import TreeListPageBody from '../common/TreeList/TreeListPageBody';
+
+export const VariantTagHierarchy: React.FC = () => {
+  const { variantTags } = useDataContext();
+  const sortFunction = getSortFunction();
+
+  const nodeHierarchy = getNodeHierarchy(Object.values(variantTags));
+  const rootNodes: TreeNodeData[] = getTreeNodes(nodeHierarchy, sortFunction);
+
+  return (
+    <TreeListPageBody
+      rootNodes={rootNodes}
+      description={
+        <>
+          Variant tags are associated with different &quot;prefixes&quot; (entities in bold) --
+          usually but not always language codes. This view organizes variant tags by the prefixes
+          they apply to.
+        </>
+      }
+    />
+  );
+};
+
+type VariantTagBranch = {
+  key: string;
+  variantTag?: VariantTagData;
+  branches: Record<string, VariantTagBranch>;
+};
+
+export function getNodeHierarchy(variantTags: VariantTagData[]): Record<string, VariantTagBranch> {
+  return variantTags.reduce<Record<string, VariantTagBranch>>((rootNodes, variantTag) => {
+    const prefixes = variantTag.prefixes;
+
+    prefixes.forEach((prefix) => {
+      // Follow the full path of the pieces of the locale code, from prefix to the variant tag ID
+      const parts = [...prefix.split('-'), variantTag.ID];
+
+      parts.reduce<Record<string, VariantTagBranch>>((parentNode, part, index) => {
+        // Fetch the node or initialize it if it doesn't exist
+        const node = parentNode[part] || { key: part, branches: {} };
+        if (!parentNode[part]) parentNode[part] = node;
+
+        // Add the variant tag as a leaf if we are at the end
+        if (index === parts.length - 1) {
+          node.variantTag = variantTag;
+        }
+        // Otherwise, continue down the branches
+        return node.branches;
+      }, rootNodes);
+
+      return rootNodes;
+    });
+
+    return rootNodes;
+  }, {});
+}
+
+export function getTreeNodes(
+  nodeHierarchy: Record<string, VariantTagBranch>,
+  sortFunction: (a: ObjectData, b: ObjectData) => number,
+): TreeNodeData[] {
+  return Object.values(nodeHierarchy)
+    .map(getVariantTagTreeNode)
+    .filter((node) => node != null)
+    .sort((a, b) => sortFunction(a.object, b.object));
+}
+
+export function getVariantTagTreeNode(VariantTagBranch: VariantTagBranch): TreeNodeData | null {
+  const object = getObjectFromID(VariantTagBranch.key);
+  if (object == null) return null;
+  return {
+    type: object?.type ?? ObjectType.VariantTag,
+    object: VariantTagBranch.variantTag ?? object,
+    children: getTreeNodes(VariantTagBranch.branches, getSortFunction()),
+    labelStyle: { fontWeight: object?.type === ObjectType.VariantTag ? 'normal' : 'bold' },
+  };
+}

--- a/src/views/varianttag/VariantTagTable.tsx
+++ b/src/views/varianttag/VariantTagTable.tsx
@@ -1,0 +1,65 @@
+import { TriangleAlertIcon } from 'lucide-react';
+import React from 'react';
+
+import { useDataContext } from '../../data/DataContext';
+import Hoverable from '../../generic/Hoverable';
+import HoverableEnumeration from '../../generic/HoverableEnumeration';
+import { VariantTagData } from '../../types/DataTypes';
+import { SortBy } from '../../types/PageParamTypes';
+import { getObjectPopulation } from '../common/ObjectField';
+import { CodeColumn, InfoButtonColumn, NameColumn } from '../common/table/CommonColumns';
+import ObjectTable from '../common/table/ObjectTable';
+
+const VariantTagTable: React.FC = () => {
+  const { variantTags } = useDataContext();
+
+  return (
+    <ObjectTable<VariantTagData>
+      objects={Object.values(variantTags)}
+      columns={[
+        CodeColumn,
+        NameColumn,
+        {
+          key: 'Date Added',
+          render: (object) => object.dateAdded?.toLocaleDateString(),
+          isInitiallyVisible: false,
+          isNumeric: true,
+          sortParam: SortBy.Date,
+        },
+        {
+          key: 'Languages',
+          render: (object) => (
+            <HoverableEnumeration items={object.languages.map((lang) => lang.nameDisplay)} />
+          ),
+          isNumeric: true,
+          sortParam: SortBy.CountOfLanguages,
+        },
+        {
+          key: 'Potential Population',
+          label: (
+            <Hoverable
+              hoverContent={
+                <>
+                  <TriangleAlertIcon size="1em" /> This is not the actual population of this variant
+                  tag, but an estimate based on the language(s) it applies to. If its an
+                  orthographic variant maybe it applies to the full modern population, but if its a
+                  dialect or historic variation it may only be a small group of people or only found
+                  in manuscripts.
+                </>
+              }
+            >
+              Potential Population
+            </Hoverable>
+          ),
+          render: (object) => getObjectPopulation(object),
+          isInitiallyVisible: false,
+          isNumeric: true,
+          sortParam: SortBy.Population,
+        },
+        InfoButtonColumn,
+      ]}
+    />
+  );
+};
+
+export default VariantTagTable;


### PR DESCRIPTION
This adds visuals for the hierarchy & tabulation of variant tags. There are some minor updates too (see the copilot summary for them).

|Hierarchy View|Table View|
|--|--|
|<img width="653" height="827" alt="Screenshot 2025-08-07 at 11 53 07" src="https://github.com/user-attachments/assets/461a01b7-8d21-4f6e-9781-269309ebf261" />|<img width="899" height="1096" alt="Screenshot 2025-08-07 at 11 53 55" src="https://github.com/user-attachments/assets/858a0ed8-1db4-4c19-b031-ae87b0609bcf" />
