### PR TITLE
Reports: List census progress

### DIFF
--- a/src/types/CensusTypes.tsx
+++ b/src/types/CensusTypes.tsx
@@ -4,10 +4,12 @@ import { ObjectType } from './PageParamTypes';
 
 // Unique identifier for the census or other source of population data
 export type CensusID = string; // eg. 'ca2021.2', 'us2013.1'
+
+// Ranked by priority
 export enum CensusCollectorType {
   Government = 'Government',
-  CLDR = 'CLDR',
   Study = 'Study',
+  CLDR = 'CLDR',
 }
 
 export interface CensusData extends ObjectBase {

--- a/src/views/ViewReports.tsx
+++ b/src/views/ViewReports.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { usePageParams } from '../controls/PageParamsContext';
 import { ObjectType } from '../types/PageParamTypes';
 
+import TableOfCountriesWithCensuses from './census/TableOfCountriesWithCensuses';
 import DubiousLanguages from './language/DubiousLanguages';
 import LanguagesWithIdenticalNames from './language/LanguagesWithIdenticalNames';
 import PotentialLocales from './locale/PotentialLocales';
@@ -33,6 +34,7 @@ const ReportsForObjectType: React.FC<{ objectType: ObjectType }> = ({ objectType
         </>
       );
     case ObjectType.Census:
+      return <TableOfCountriesWithCensuses />;
     case ObjectType.Territory:
     case ObjectType.WritingSystem:
       return <div>There are no reports for this object type.</div>;

--- a/src/views/census/TableOfCountriesWithCensuses.tsx
+++ b/src/views/census/TableOfCountriesWithCensuses.tsx
@@ -1,0 +1,63 @@
+import React, { useMemo } from 'react';
+
+import { useDataContext } from '../../data/DataContext';
+import CommaSeparated from '../../generic/CommaSeparated';
+import { CensusCollectorType } from '../../types/CensusTypes';
+import { TerritoryData } from '../../types/DataTypes';
+import { SortBy } from '../../types/PageParamTypes';
+import CollapsibleReport from '../common/CollapsibleReport';
+import HoverableObjectName from '../common/HoverableObjectName';
+import { CodeColumn, NameColumn } from '../common/table/CommonColumns';
+import ObjectTable from '../common/table/ObjectTable';
+
+const TableOfCountriesWithCensuses: React.FC = () => {
+  const { territories } = useDataContext();
+  const territoryArray = useMemo(() => Object.values(territories), [territories]);
+
+  return (
+    <CollapsibleReport title="Countries with Censuses">
+      <ObjectTable<TerritoryData>
+        objects={territoryArray}
+        columns={[
+          CodeColumn,
+          NameColumn,
+          {
+            key: 'Censuses',
+            render: (territory) => territory.censuses.length,
+            isNumeric: true,
+          },
+          ...Object.values(CensusCollectorType).map((collectorType) => ({
+            key: collectorType,
+            render: (territory: TerritoryData) => {
+              return (
+                <div style={{ maxWidth: '10em' }}>
+                  <CommaSeparated limit={1}>
+                    {territory.censuses
+                      .filter((census) => census.collectorType === collectorType)
+                      .map((census) => (
+                        <HoverableObjectName key={census.ID} object={census} />
+                      ))}
+                  </CommaSeparated>
+                </div>
+              );
+            },
+          })),
+          {
+            key: 'Population',
+            render: (territory) => territory.population,
+            isNumeric: true,
+            sortParam: SortBy.Population,
+          },
+          {
+            key: 'Languages',
+            render: (territory) => territory.locales.length,
+            isNumeric: true,
+            sortParam: SortBy.CountOfLanguages,
+          },
+        ]}
+      />
+    </CollapsibleReport>
+  );
+};
+
+export default TableOfCountriesWithCensuses;

--- a/src/views/common/CollapsibleReport.tsx
+++ b/src/views/common/CollapsibleReport.tsx
@@ -1,0 +1,28 @@
+import React, { ReactNode } from 'react';
+
+const CollapsibleReport: React.FC<{
+  children: React.ReactNode;
+  title: ReactNode;
+}> = ({ title, children }) => {
+  return (
+    <details className="collapsible-report">
+      <summary
+        style={{
+          width: '100%',
+          backgroundColor: 'var(--color-button-secondary)',
+          padding: '0.5em',
+          borderRadius: '0.5em',
+          cursor: 'pointer',
+          textAlign: 'left',
+          fontSize: '1.2em',
+          marginBottom: '1em',
+        }}
+      >
+        {title}
+      </summary>
+      {children}
+    </details>
+  );
+};
+
+export default CollapsibleReport;

--- a/src/views/language/DubiousLanguages.tsx
+++ b/src/views/language/DubiousLanguages.tsx
@@ -12,6 +12,7 @@ import { getSortFunction } from '../../controls/sort';
 import { useDataContext } from '../../data/DataContext';
 import Deemphasized from '../../generic/Deemphasized';
 import { LanguageData } from '../../types/LanguageTypes';
+import CollapsibleReport from '../common/CollapsibleReport';
 import HoverableObjectName from '../common/HoverableObjectName';
 import ViewCard from '../ViewCard';
 
@@ -32,8 +33,7 @@ const DubiousLanguages: React.FC = () => {
     .filter((lang) => lang.codeDisplay.match('xx.-|^[0-9]'));
 
   return (
-    <details className="collapsible-report">
-      <summary>Dubious languages ({languages.length})</summary>
+    <CollapsibleReport title={`Dubious languages (${languages.length})`}>
       These languages have strange language codes and maybe should be removed from the list of
       languages. Some possibilities are:
       <ol>
@@ -105,7 +105,7 @@ const DubiousLanguages: React.FC = () => {
           );
         })}
       </div>
-    </details>
+    </CollapsibleReport>
   );
 };
 

--- a/src/views/language/LanguagesWithIdenticalNames.tsx
+++ b/src/views/language/LanguagesWithIdenticalNames.tsx
@@ -13,6 +13,7 @@ import { useDataContext } from '../../data/DataContext';
 import CommaSeparated from '../../generic/CommaSeparated';
 import Deemphasized from '../../generic/Deemphasized';
 import { LanguageData, LanguageSource } from '../../types/LanguageTypes';
+import CollapsibleReport from '../common/CollapsibleReport';
 import TreeListRoot from '../common/TreeList/TreeListRoot';
 import ViewCard from '../ViewCard';
 
@@ -50,8 +51,9 @@ const LanguagesWithIdenticalNames: React.FC = () => {
   );
 
   return (
-    <details className="collapsible-report">
-      <summary>Languages with identical names ({Object.keys(langsWithDupNames).length})</summary>
+    <CollapsibleReport
+      title={`Languages with identical names (${Object.keys(langsWithDupNames).length})`}
+    >
       The following languages have identical names. This can happen when merging data from multiple
       sources. It gets confusing to find the right language when names overlap. To fix this we
       should change names with these possible options:
@@ -138,7 +140,7 @@ const LanguagesWithIdenticalNames: React.FC = () => {
           </div>
         </div>
       ))}
-    </details>
+    </CollapsibleReport>
   );
 };
 

--- a/src/views/locale/PotentialLocales.tsx
+++ b/src/views/locale/PotentialLocales.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../types/DataTypes';
 import { LanguageCode, LanguageData } from '../../types/LanguageTypes';
 import { LocaleSeparator, ObjectType, SortBy } from '../../types/PageParamTypes';
+import CollapsibleReport from '../common/CollapsibleReport';
 import HoverableObjectName from '../common/HoverableObjectName';
 import ObjectTable from '../common/table/ObjectTable';
 
@@ -99,13 +100,10 @@ const SubReport: React.FC<{
 }> = ({ title, children, locales }) => {
   const filterByScope = getScopeFilter();
   return (
-    <details className="collapsible-report">
-      <summary>
-        {title} ({locales.filter(filterByScope).length})
-      </summary>
+    <CollapsibleReport title={`${title} (${locales.filter(filterByScope).length})`}>
       {children}
       <PotentialLocalesTable locales={locales} />
-    </details>
+    </CollapsibleReport>
   );
 };
 


### PR DESCRIPTION
This PR adds a report so that we can see how many census sources we have available for each country so we can track which countries are in need of census data.

https://translation-commons.github.io/lang-nav/data?view=Reports&objectType=Census&sortBy=Count+of+Languages

<img width="1159" height="645" alt="Screenshot 2025-08-13 at 09 36 51" src="https://github.com/user-attachments/assets/cfc7cf30-a176-4f61-98ed-172b0c508534" />
