### PR TITLE
Add filters to page path

### DIFF
--- a/src/controls/components/SelectorDisplay.tsx
+++ b/src/controls/components/SelectorDisplay.tsx
@@ -1,0 +1,6 @@
+export enum SelectorDisplay {
+  Dropdown = 'dropdown', // Formatting is still off for these
+  InlineDropdown = 'inlineDropdown', // Used to be inline with text
+  ButtonGroup = 'buttonGroup', // Unsure if we want to keep this
+  ButtonList = 'buttonList',
+}

--- a/src/controls/components/SelectorLabel.tsx
+++ b/src/controls/components/SelectorLabel.tsx
@@ -3,18 +3,18 @@ import React, { ReactNode } from 'react';
 
 import Hoverable from '../../generic/Hoverable';
 
-import { OptionsDisplay } from './Selector';
+import { SelectorDisplay } from './SelectorDisplay';
 
 type Props = {
   label?: ReactNode;
   description?: ReactNode;
-  optionsDisplay: OptionsDisplay;
+  display: SelectorDisplay;
 };
 
-const SelectorLabel: React.FC<Props> = ({ label, description, optionsDisplay }) => {
+const SelectorLabel: React.FC<Props> = ({ label, description, display }) => {
   if (label == null) return null;
   return (
-    <span style={getStyle(optionsDisplay)}>
+    <span style={getStyle(display)}>
       <div>{label}</div>
       {description && (
         <Hoverable hoverContent={description}>
@@ -25,7 +25,7 @@ const SelectorLabel: React.FC<Props> = ({ label, description, optionsDisplay }) 
   );
 };
 
-function getStyle(optionsDisplay: OptionsDisplay): React.CSSProperties {
+function getStyle(display: SelectorDisplay): React.CSSProperties {
   const style: React.CSSProperties = {
     display: 'flex',
     gap: '0.25em',
@@ -38,19 +38,19 @@ function getStyle(optionsDisplay: OptionsDisplay): React.CSSProperties {
     borderRadius: '1em',
   };
 
-  switch (optionsDisplay) {
-    case OptionsDisplay.ButtonGroup:
+  switch (display) {
+    case SelectorDisplay.ButtonGroup:
       style.borderRadius = '1em 0 0 1em';
       style.marginLeft = '-0.125em'; // This may just be a remnant of the old style
       style.marginRight = '-0.125em';
       break;
-    case OptionsDisplay.ButtonList:
+    case SelectorDisplay.ButtonList:
       style.borderRadius = '1em 0 0 1em';
       break;
-    case OptionsDisplay.InlineDropdown:
+    case SelectorDisplay.InlineDropdown:
       style.padding = '0 0.5em';
       break;
-    case OptionsDisplay.Dropdown:
+    case SelectorDisplay.Dropdown:
       // nothing special
       break;
   }

--- a/src/controls/components/SelectorOption.tsx
+++ b/src/controls/components/SelectorOption.tsx
@@ -1,0 +1,123 @@
+import React, { ReactNode } from 'react';
+
+import HoverableButton from '../../generic/HoverableButton';
+import { PositionInGroup } from '../../generic/PositionInGroup';
+
+import { SelectorDisplay } from './SelectorDisplay';
+
+type OptionProps<T extends React.Key> = {
+  display: SelectorDisplay;
+  getOptionDescription?: (value: T) => React.ReactNode;
+  getOptionLabel?: (value: T) => React.ReactNode; // optional label renderer
+  isSelected: boolean;
+  labelSuffix?: ReactNode; // Appeals after the label
+  onClick: (value: T) => void;
+  option: T | T[];
+  position?: PositionInGroup; // used for styling
+};
+
+function SelectorOption<T extends React.Key>({
+  display,
+  getOptionDescription,
+  getOptionLabel = (val) => val as string,
+  isSelected,
+  labelSuffix,
+  onClick,
+  option,
+  position = PositionInGroup.Standalone,
+}: OptionProps<T>) {
+  let className = 'selectorOption';
+  if (isSelected) className += ' selected';
+  if (!isSelected) className += ' unselected';
+  if (display === SelectorDisplay.InlineDropdown && position === PositionInGroup.Standalone)
+    className += ' hoverableText';
+  return (
+    <HoverableButton
+      className={className}
+      hoverContent={
+        getOptionDescription
+          ? Array.isArray(option)
+            ? option.map(getOptionDescription).join('\n')
+            : getOptionDescription(option)
+          : null
+      }
+      onClick={() => onClick(Array.isArray(option) ? option[0] : option)}
+      style={getOptionStyle(display, isSelected, position)}
+    >
+      {Array.isArray(option) ? option.map(getOptionLabel).join(' or ') : getOptionLabel(option)}
+      {labelSuffix}
+    </HoverableButton>
+  );
+}
+
+export function getOptionStyle(
+  display: SelectorDisplay,
+  isSelected: boolean,
+  position: PositionInGroup,
+): React.CSSProperties {
+  // Standard option style
+  const style: React.CSSProperties = {
+    border: '0.125em solid var(--color-button-primary)',
+    borderRadius: '0px',
+    cursor: 'pointer',
+    lineHeight: '1em',
+    padding: '0.5em',
+    whiteSpace: 'nowrap',
+  };
+  // Customize based on position and display type
+  switch (display) {
+    case SelectorDisplay.ButtonGroup:
+      if (position === PositionInGroup.Last) {
+        style.marginLeft = '-0.125em';
+        style.borderRadius = '0 1em 1em 0';
+      } else if (position === PositionInGroup.First) {
+        style.borderRadius = '1em 0 0 1em';
+      } else if (position === PositionInGroup.Middle) {
+        style.marginLeft = '-0.125em';
+      }
+      break;
+    case SelectorDisplay.ButtonList:
+      style.borderRadius = '1em';
+      if (!isSelected) style.border = '0.125em solid var(--color-button-secondary)';
+      break;
+    case SelectorDisplay.InlineDropdown:
+      // The standalone option should match the regular page text
+      if (position === PositionInGroup.Standalone) {
+        style.margin = '-0.25em';
+        style.border = 'none';
+        style.borderRadius = '.5em';
+        style.padding = '0.25em';
+        return style;
+      }
+      // otherwise return the Dropdown style
+      return getOptionStyle(SelectorDisplay.Dropdown, isSelected, position);
+    case SelectorDisplay.Dropdown:
+      style.textAlign = 'left';
+      style.width = '100%';
+      style.borderRadius = undefined;
+      if (position === PositionInGroup.First) {
+        style.borderRadius = '1em 1em 0 0';
+        style.margin = '0 0 -0.125em 0';
+        style.borderBottom = 'none';
+      } else if (position === PositionInGroup.Last) {
+        style.borderRadius = '0 0 1em 1em';
+        style.margin = '0';
+        style.borderTop = 'none';
+      } else if (position === PositionInGroup.Middle) {
+        style.margin = '0 0 -0.125em 0';
+        style.borderRadius = '0';
+        style.borderTop = 'none';
+        style.borderBottom = 'none';
+      } else if (position === PositionInGroup.Only) {
+        style.borderRadius = '1em';
+      } else if (position === PositionInGroup.Standalone) {
+        style.borderRadius = '1em';
+        style.width = 'fit-content';
+      }
+      break;
+  }
+
+  return style;
+}
+
+export default SelectorOption;

--- a/src/controls/components/TextInput.tsx
+++ b/src/controls/components/TextInput.tsx
@@ -7,8 +7,9 @@ import { useAutoAdjustedWidth } from '../../generic/useAutoAdjustedWidth';
 import { PageParamKey, View } from '../../types/PageParamTypes';
 import { usePageParams } from '../PageParamsContext';
 
-import { getOptionStyle, OptionsDisplay } from './Selector';
+import { SelectorDisplay } from './SelectorDisplay';
 import { SelectorDropdown } from './SelectorDropdown';
+import { getOptionStyle } from './SelectorOption';
 
 export type Suggestion = {
   objectID?: string;
@@ -20,7 +21,7 @@ type Props = {
   getSuggestions?: (query: string) => Promise<Suggestion[]>;
   inputStyle?: React.CSSProperties;
   onChange: (value: string) => void;
-  optionsDisplay: OptionsDisplay;
+  display: SelectorDisplay;
   pageParameter?: PageParamKey;
   placeholder?: string;
   value: string;
@@ -35,7 +36,7 @@ const TextInput: React.FC<Props> = ({
   getSuggestions = () => [],
   inputStyle,
   onChange,
-  optionsDisplay,
+  display,
   pageParameter,
   placeholder,
   value,
@@ -98,7 +99,7 @@ const TextInput: React.FC<Props> = ({
         onFocus={() => setShowSuggestions(true)}
         placeholder={placeholder}
         style={{
-          borderRadius: optionsDisplay === OptionsDisplay.ButtonList ? '0.5em' : undefined,
+          borderRadius: display === SelectorDisplay.ButtonList ? '0.5em' : undefined,
           padding: '0.5em',
           lineHeight: '1.5em',
           ...inputStyle,
@@ -111,7 +112,7 @@ const TextInput: React.FC<Props> = ({
           setImmediateValue('');
           setShowSuggestions(false);
         }}
-        optionsDisplay={optionsDisplay}
+        display={display}
       />
     </>
   );
@@ -140,7 +141,7 @@ const SuggestionRow: React.FC<SuggestionRowProps> = ({
     updatePageParams({ objectID, view: View.Details, searchString });
   };
   const style = getOptionStyle(
-    OptionsDisplay.Dropdown,
+    SelectorDisplay.Dropdown,
     false, // isSelected is always false here
     position,
   );
@@ -166,13 +167,13 @@ const SuggestionRow: React.FC<SuggestionRowProps> = ({
 
 const ClearButton: React.FC<{
   onClick: () => void;
-  optionsDisplay: OptionsDisplay;
-}> = ({ onClick, optionsDisplay }) => {
+  display: SelectorDisplay;
+}> = ({ onClick, display }) => {
   return (
     <HoverableButton
       hoverContent="Clear the input"
       style={{
-        ...(optionsDisplay === OptionsDisplay.ButtonList
+        ...(display === SelectorDisplay.ButtonList
           ? { borderRadius: '0.5em', border: 'none' }
           : { marginRight: '0em', borderRadius: '0 1em 1em 0', borderLeft: 'none' }),
         padding: '0.5em',

--- a/src/controls/pathnav/FilterPath.tsx
+++ b/src/controls/pathnav/FilterPath.tsx
@@ -1,0 +1,111 @@
+import { SlashIcon, XIcon } from 'lucide-react';
+import React, { Fragment } from 'react';
+
+import Deemphasized from '../../generic/Deemphasized';
+import HoverableButton from '../../generic/HoverableButton';
+import { areArraysIdentical } from '../../generic/setUtils';
+import { TerritoryScope } from '../../types/DataTypes';
+import { LanguageScope } from '../../types/LanguageTypes';
+import { SearchableField, View } from '../../types/PageParamTypes';
+import Selector from '../components/Selector';
+import { SelectorDisplay } from '../components/SelectorDisplay';
+import { usePageParams } from '../PageParamsContext';
+import { getDefaultParams } from '../Profiles';
+
+const FilterPath: React.FC = () => {
+  const {
+    languageScopes,
+    searchBy,
+    searchString,
+    territoryFilter,
+    territoryScopes,
+    updatePageParams,
+    view,
+  } = usePageParams();
+  const defaultParams = getDefaultParams();
+
+  const filters = [
+    !areArraysIdentical(languageScopes, defaultParams.languageScopes) && (
+      <Selector
+        selectorStyle={{ marginLeft: '0' }}
+        options={Object.values(LanguageScope)}
+        display={SelectorDisplay.InlineDropdown}
+        onChange={(scope: LanguageScope) =>
+          languageScopes.includes(scope)
+            ? updatePageParams({ languageScopes: languageScopes.filter((s) => s != scope) })
+            : updatePageParams({ languageScopes: [...languageScopes, scope] })
+        }
+        selected={languageScopes}
+      />
+    ),
+    !areArraysIdentical(territoryScopes, defaultParams.territoryScopes) && (
+      <Selector
+        selectorStyle={{ marginLeft: '0' }}
+        options={Object.values(TerritoryScope)}
+        display={SelectorDisplay.InlineDropdown}
+        onChange={(scope: TerritoryScope) =>
+          territoryScopes.includes(scope)
+            ? updatePageParams({ territoryScopes: territoryScopes.filter((s) => s != scope) })
+            : updatePageParams({ territoryScopes: [...territoryScopes, scope] })
+        }
+        selected={territoryScopes}
+      />
+    ),
+    territoryFilter !== '' && (
+      <>
+        In &quot;{territoryFilter}&quot;
+        <HoverableButton
+          onClick={() => updatePageParams({ territoryFilter: '' })}
+          style={{ padding: '0.25em' }}
+        >
+          <XIcon size="1em" display="block" />
+        </HoverableButton>
+      </>
+    ),
+    searchString !== '' && (
+      <>
+        <Selector
+          options={Object.values(SearchableField)}
+          display={SelectorDisplay.InlineDropdown}
+          onChange={(searchBy) => updatePageParams({ searchBy })}
+          selected={searchBy}
+        />{' '}
+        contains &quot;{searchString}&quot;
+        <HoverableButton
+          onClick={() => updatePageParams({ searchString: '' })}
+          style={{ padding: '0.25em' }}
+        >
+          <XIcon size="1em" display="block" />
+        </HoverableButton>
+      </>
+    ),
+  ];
+
+  if (view === View.Details) {
+    return <></>;
+  }
+  if (filters.filter((f) => f).length === 0) {
+    return (
+      <>
+        <SlashIcon size="1em" />
+        <Deemphasized>No filters applied</Deemphasized>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <SlashIcon size="1em" />
+      {filters
+        .filter((f) => f)
+        .map((filter, i) => (
+          <Fragment key={i}>
+            {i !== 0 && <SlashIcon size="1em" />}
+            {filter}
+          </Fragment>
+        ))}
+    </>
+  );
+};
+
+export default FilterPath;

--- a/src/controls/pathnav/ObjectPathChildren.tsx
+++ b/src/controls/pathnav/ObjectPathChildren.tsx
@@ -2,7 +2,8 @@ import { SlashIcon } from 'lucide-react';
 import React from 'react';
 
 import { ObjectData } from '../../types/DataTypes';
-import Selector, { OptionsDisplay } from '../components/Selector';
+import Selector from '../components/Selector';
+import { SelectorDisplay } from '../components/SelectorDisplay';
 import { usePageParams } from '../PageParamsContext';
 import { getSortFunction } from '../sort';
 
@@ -34,7 +35,7 @@ const ObjectPathChildren: React.FC<{ object?: ObjectData }> = ({ object }) => {
       <Selector<string>
         onChange={(childID) => updatePageParams({ objectID: childID, objectType: object.type })}
         selected={children.length + ' ' + descendantsName}
-        optionsDisplay={OptionsDisplay.InlineDropdown}
+        display={SelectorDisplay.InlineDropdown}
         options={childIDs}
         getOptionLabel={(childID) => {
           const child = children.find((c) => c.ID === childID);

--- a/src/controls/pathnav/PathNav.tsx
+++ b/src/controls/pathnav/PathNav.tsx
@@ -3,9 +3,11 @@ import React, { useCallback } from 'react';
 
 import ObjectTypeDescription from '../../strings/ObjectTypeDescription';
 import { ObjectType, View } from '../../types/PageParamTypes';
-import Selector, { OptionsDisplay } from '../components/Selector';
+import Selector from '../components/Selector';
+import { SelectorDisplay } from '../components/SelectorDisplay';
 import { usePageParams } from '../PageParamsContext';
 
+import FilterPath from './FilterPath';
 import ObjectPath from './ObjectPath';
 
 const PathNav: React.FC = () => {
@@ -14,6 +16,7 @@ const PathNav: React.FC = () => {
       <ObjectTypeSelector />
       <SlashIcon size="1em" />
       <ViewSelector />
+      <FilterPath />
       <ObjectPath />
     </PathContainer>
   );
@@ -36,7 +39,7 @@ const ObjectTypeSelector: React.FC = () => {
 
   return (
     <Selector
-      optionsDisplay={OptionsDisplay.InlineDropdown}
+      display={SelectorDisplay.InlineDropdown}
       options={Object.values(ObjectType)}
       onChange={goToObjectType}
       selected={objectType}
@@ -50,7 +53,7 @@ const ViewSelector: React.FC = () => {
 
   return (
     <Selector
-      optionsDisplay={OptionsDisplay.InlineDropdown}
+      display={SelectorDisplay.InlineDropdown}
       options={Object.values(View)}
       onChange={(view: View) => updatePageParams({ view, objectID: undefined })}
       selected={view}

--- a/src/controls/selectors/LanguageSourceSelector.tsx
+++ b/src/controls/selectors/LanguageSourceSelector.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import { LanguageSource } from '../../types/LanguageTypes';
-import Selector, { OptionsDisplay } from '../components/Selector';
+import Selector from '../components/Selector';
+import { SelectorDisplay } from '../components/SelectorDisplay';
 import { usePageParams } from '../PageParamsContext';
 
 const LanguageListSourceSelector: React.FC = () => {
@@ -21,7 +22,7 @@ const LanguageListSourceSelector: React.FC = () => {
       selectorLabel="Source of the List of Languages"
       selectorDescription={selectorDescription}
       options={Object.values(LanguageSource)}
-      optionsDisplay={OptionsDisplay.ButtonList}
+      display={SelectorDisplay.ButtonList}
       onChange={(languageSource: LanguageSource) => updatePageParams({ languageSource })}
       selected={languageSource}
       getOptionDescription={(languageSource) => (

--- a/src/controls/selectors/LimitInput.tsx
+++ b/src/controls/selectors/LimitInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { OptionsDisplay } from '../components/Selector';
+import { SelectorDisplay } from '../components/SelectorDisplay';
 import SelectorLabel from '../components/SelectorLabel';
 import TextInput from '../components/TextInput';
 import { usePageParams } from '../PageParamsContext';
@@ -13,7 +13,7 @@ const LimitInput: React.FC = () => {
       <SelectorLabel
         description={`Limit how many results are shown.`}
         label="Item Limit"
-        optionsDisplay={OptionsDisplay.ButtonList}
+        display={SelectorDisplay.ButtonList}
       />
       <TextInput
         inputStyle={{ minWidth: '3em' }}
@@ -24,7 +24,7 @@ const LimitInput: React.FC = () => {
           { searchString: '200', label: '200' },
         ]}
         onChange={(limit: string) => updatePageParams({ limit: parseInt(limit) })}
-        optionsDisplay={OptionsDisplay.ButtonList}
+        display={SelectorDisplay.ButtonList}
         placeholder="∞"
         value={limit < 1 || Number.isNaN(limit) ? '' : limit.toString()}
       />

--- a/src/controls/selectors/LocaleSeparatorSelector.tsx
+++ b/src/controls/selectors/LocaleSeparatorSelector.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import { LocaleSeparator } from '../../types/PageParamTypes';
-import Selector, { OptionsDisplay } from '../components/Selector';
+import Selector from '../components/Selector';
+import { SelectorDisplay } from '../components/SelectorDisplay';
 import { usePageParams } from '../PageParamsContext';
 
 const LocaleSeparatorSelector: React.FC = () => {
@@ -12,7 +13,7 @@ const LocaleSeparatorSelector: React.FC = () => {
       selectorLabel="Locale Separator"
       selectorDescription="Choose the separator in locale codes, eg. 'ar-EG' or 'ar_EG'"
       options={Object.values(LocaleSeparator)}
-      optionsDisplay={OptionsDisplay.ButtonGroup}
+      display={SelectorDisplay.ButtonGroup}
       onChange={(localeSeparator: LocaleSeparator) => updatePageParams({ localeSeparator })}
       selected={localeSeparator}
     />

--- a/src/controls/selectors/ProfileSelector.tsx
+++ b/src/controls/selectors/ProfileSelector.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { OptionsDisplay } from '../components/Selector';
 import Selector from '../components/Selector';
+import { SelectorDisplay } from '../components/SelectorDisplay';
 import { usePageParams } from '../PageParamsContext';
 import { ProfileType } from '../Profiles';
 
@@ -15,7 +15,7 @@ const ProfileSelector: React.FC = () => {
       options={Object.values(ProfileType)}
       onChange={(profile: ProfileType) => updatePageParams({ profile })}
       selected={profile}
-      optionsDisplay={OptionsDisplay.Dropdown}
+      display={SelectorDisplay.Dropdown}
     />
   );
 };

--- a/src/controls/selectors/SearchBar.tsx
+++ b/src/controls/selectors/SearchBar.tsx
@@ -2,7 +2,7 @@ import { SearchIcon } from 'lucide-react';
 import React from 'react';
 
 import { PageParamKey } from '../../types/PageParamTypes';
-import { OptionsDisplay } from '../components/Selector';
+import { SelectorDisplay } from '../components/SelectorDisplay';
 import TextInput from '../components/TextInput';
 import { usePageParams } from '../PageParamsContext';
 
@@ -28,7 +28,7 @@ const SearchBar: React.FC = () => {
         inputStyle={{ minWidth: '20em', marginRight: '-0.125em', borderRight: 'none' }}
         getSuggestions={getSearchSuggestions}
         onChange={(searchString: string) => updatePageParams({ searchString })}
-        optionsDisplay={OptionsDisplay.ButtonGroup}
+        display={SelectorDisplay.ButtonGroup}
         placeholder="search"
         pageParameter={PageParamKey.searchString}
         value={searchString}

--- a/src/controls/selectors/SearchBySelector.tsx
+++ b/src/controls/selectors/SearchBySelector.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import { SearchableField } from '../../types/PageParamTypes';
-import Selector, { OptionsDisplay } from '../components/Selector';
+import Selector from '../components/Selector';
+import { SelectorDisplay } from '../components/SelectorDisplay';
 import { usePageParams } from '../PageParamsContext';
 
 const SearchBySelector: React.FC = () => {
@@ -11,7 +12,7 @@ const SearchBySelector: React.FC = () => {
     <Selector
       selectorLabel="Search by"
       options={Object.values(SearchableField)}
-      optionsDisplay={OptionsDisplay.Dropdown}
+      display={SelectorDisplay.Dropdown}
       onChange={(searchBy) => updatePageParams({ searchBy })}
       selected={searchBy}
       selectorStyle={{ marginLeft: '1em', marginBottom: '0em' }}

--- a/src/controls/selectors/SortBySelector.tsx
+++ b/src/controls/selectors/SortBySelector.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import { SortBy } from '../../types/PageParamTypes';
-import Selector, { OptionsDisplay } from '../components/Selector';
+import Selector from '../components/Selector';
+import { SelectorDisplay } from '../components/SelectorDisplay';
 import { usePageParams } from '../PageParamsContext';
 import { getSortBysApplicableToObjectType } from '../sort';
 
@@ -16,7 +17,7 @@ const SortBySelector: React.FC = () => {
       options={Object.values(SortBy).filter((sb) => applicableSortBys.includes(sb))}
       onChange={(sortBy: SortBy) => updatePageParams({ sortBy })}
       selected={sortBy}
-      optionsDisplay={OptionsDisplay.ButtonList}
+      display={SelectorDisplay.ButtonList}
     />
   );
 };

--- a/src/controls/selectors/SortDirectionSelector.tsx
+++ b/src/controls/selectors/SortDirectionSelector.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import { toTitleCase } from '../../generic/stringUtils';
-import Selector, { OptionsDisplay } from '../components/Selector';
+import Selector from '../components/Selector';
+import { SelectorDisplay } from '../components/SelectorDisplay';
 import { usePageParams } from '../PageParamsContext';
 
 const SortDirectionSelector: React.FC = () => {
@@ -10,7 +11,7 @@ const SortDirectionSelector: React.FC = () => {
   return (
     <Selector
       selectorLabel="Sort Direction"
-      optionsDisplay={OptionsDisplay.ButtonGroup}
+      display={SelectorDisplay.ButtonGroup}
       options={['normal', 'reverse']}
       getOptionLabel={(direction) => toTitleCase(direction)}
       getOptionDescription={(direction) =>

--- a/src/controls/selectors/TerritoryFilterSelector.tsx
+++ b/src/controls/selectors/TerritoryFilterSelector.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 import { useDataContext } from '../../data/DataContext';
 import { SearchableField } from '../../types/PageParamTypes';
 import { getSearchableField, HighlightedObjectField } from '../../views/common/ObjectField';
-import { OptionsDisplay } from '../components/Selector';
+import { SelectorDisplay } from '../components/SelectorDisplay';
 import SelectorLabel from '../components/SelectorLabel';
 import TextInput, { Suggestion } from '../components/TextInput';
 import { getScopeFilter } from '../filter';
@@ -42,13 +42,13 @@ const TerritoryFilterSelector: React.FC = () => {
   return (
     <div className="selector" style={{ display: 'flex', alignItems: 'center' }}>
       <SelectorLabel
-        optionsDisplay={OptionsDisplay.ButtonList}
+        display={SelectorDisplay.ButtonList}
         label="Territory Filter"
         description="Filter results by ones relevant in a territory."
       />
       <TextInput
         inputStyle={{ minWidth: '5em' }}
-        optionsDisplay={OptionsDisplay.ButtonList}
+        display={SelectorDisplay.ButtonList}
         getSuggestions={getSuggestions}
         onChange={(territoryFilter: string) => updatePageParams({ territoryFilter })}
         placeholder="Filter name or code"

--- a/src/generic/setUtils.tsx
+++ b/src/generic/setUtils.tsx
@@ -13,3 +13,11 @@ export function uniqueBy<T>(items: T[], keyFn: (item: T) => string | number): T[
 export function unique<T extends string | number>(items: T[]): T[] {
   return uniqueBy(items, (item) => item);
 }
+
+export function areArraysIdentical<T>(a: T[], b: T[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  const setB = new Set(b);
+  return a.every((item) => setB.has(item));
+}

--- a/src/views/locale/PotentialLocaleThreshold.tsx
+++ b/src/views/locale/PotentialLocaleThreshold.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 
-import { OptionsDisplay } from '../../controls/components/Selector';
+import { SelectorDisplay } from '../../controls/components/SelectorDisplay';
 import SelectorLabel from '../../controls/components/SelectorLabel';
 import TextInput from '../../controls/components/TextInput';
 
@@ -13,7 +13,7 @@ export function usePotentialLocaleThreshold(): {
   const percentThresholdSelector = (
     <div className="selector" style={{ display: 'flex', alignItems: 'end', marginBottom: '0.5em' }}>
       <SelectorLabel
-        optionsDisplay={OptionsDisplay.ButtonGroup}
+        display={SelectorDisplay.ButtonGroup}
         label="Percent Threshold:"
         description={`Limit results by the minimum percent population in a territory that uses the language.`}
       />
@@ -30,7 +30,7 @@ export function usePotentialLocaleThreshold(): {
           { searchString: '5', label: '5%' },
           { searchString: '10', label: '10%' },
         ]}
-        optionsDisplay={OptionsDisplay.ButtonGroup}
+        display={SelectorDisplay.ButtonGroup}
         onChange={(percent: string) => setPercentThreshold(Number(percent))}
         placeholder=""
         value={Number.isNaN(percentThreshold) ? '' : percentThreshold.toString()}


### PR DESCRIPTION
This change extends the path description at the top of the page to include the active filters. See the new information below the search bar.

While I was here I also moved some more elements out of Selector.tsx into their own files.

https://translation-commons.github.io/lang-nav/data?languageScopes=Family%2CMacrolanguage%2CLanguage&territoryFilter=Ira&territoryScopes=Country%2CDependency%2CSub-continent&view=Hierarchy&objectType=Locale&searchString=kurd

<img width="1068" height="847" alt="Screenshot 2025-08-19 at 07 56 18" src="https://github.com/user-attachments/assets/d3b3032e-0d55-47cc-88e3-65f1c14ce65c" />
