### PR TITLE
Variants: Support locales with composite variants

### DIFF
--- a/src/data/DataParsing.tsx
+++ b/src/data/DataParsing.tsx
@@ -32,14 +32,14 @@ export function parseLanguageLine(line: string): LanguageData {
       parentLanguageCode: parentGlottocode,
       childLanguages: [],
     },
-    CLDR: { childLanguages: [] }, // Empty for now
+    CLDR: { childLanguages: [] }, 
   };
   const nameEndonym = parts[3] != '' ? parts[3] : undefined;
 
   return {
     ...getBaseLanguageData(code, nameDisplay),
 
-    scope: undefined, // Added by imports
+    scope: undefined, 
 
     nameCanonical: nameDisplay,
     nameDisplay,
@@ -47,7 +47,7 @@ export function parseLanguageLine(line: string): LanguageData {
     nameEndonym,
     names: [nameDisplay, nameSubtitle, nameEndonym].filter((s) => s != null),
 
-    vitalityISO: undefined, // Added by ISO import
+    vitalityISO: undefined,
     vitalityEth2013: parts[6] != '' ? parts[6] : undefined,
     vitalityEth2025: parts[7] != '' ? parts[7] : undefined,
     digitalSupport: parts[8] != '' ? parts[8] : undefined,
@@ -67,7 +67,11 @@ export function parseLanguageLine(line: string): LanguageData {
 export function parseLocaleLine(line: string): LocaleData {
   const parts = line.split('\t');
   const nameEndonym = parts[2] != '' ? parts[2] : undefined;
-  const variantTagCode = parts[6] != '' ? parts[6].toLowerCase() : undefined;
+
+  const variantTagCodesRaw = parts[6] != '' ? parts[6].toLowerCase() : undefined;
+  const variantTagCodes = variantTagCodesRaw
+    ? variantTagCodesRaw.split('-').filter((v) => v.length > 0)
+    : undefined;
 
   return {
     type: ObjectType.Locale,
@@ -81,12 +85,12 @@ export function parseLocaleLine(line: string): LocaleData {
     languageCode: parts[3],
     territoryCode: parts[4],
     explicitScriptCode: parts[5] != '' ? parts[5] : undefined,
-    variantTagCode,
+    variantTagCodes,
     populationSource: parts[7] as PopulationSourceCategory,
     populationSpeaking: Number.parseInt(parts[8]?.replace(/,/g, '')),
     officialStatus: parts[9] != '' ? (parts[9] as OfficialStatus) : undefined,
 
-    censusRecords: [], // Populated later
+    censusRecords: [],
   };
 }
 
@@ -112,11 +116,9 @@ export function parseWritingSystem(line: string): WritingSystemData {
     parentWritingSystemCode: parts[9] != '' ? parts[9] : null,
     containsWritingSystemsCodes: parts[10] != '' ? parts[10].split(', ') : [],
 
-    // Derived when combining other data
     populationUpperBound: 0,
     populationOfDescendents: 0,
 
-    // References to other objects, filled in with DataAssociations methods
     languages: {},
     localesWhereExplicit: [],
     primaryLanguage: undefined,

--- a/src/data/IANAData.tsx
+++ b/src/data/IANAData.tsx
@@ -129,11 +129,7 @@ export function addIANAVariantLocales(
       }
 
      
-      const idParts: string[] = [iso639_3];
-      if (scriptCode) idParts.push(scriptCode);
-      if (regionCode) idParts.push(regionCode);
-      if (variantSubtags.length > 0) idParts.push(...variantSubtags);
-      const localeCode = idParts.join('_');
+      const localeCode = [iso639_3, scriptCode, regionCode, ...variantSubtags].filter(Boolean).join('_');
 
       
       if (!locales[localeCode]) {

--- a/src/types/DataTypes.tsx
+++ b/src/types/DataTypes.tsx
@@ -1,16 +1,12 @@
-/**
- * This file provides types for the data used in the application.
- */
-
 import { CensusData } from './CensusTypes';
 import { LanguageCode, LanguageData } from './LanguageTypes';
 import { ObjectType } from './PageParamTypes';
 
 export interface ObjectBase {
   readonly type: ObjectType;
-  readonly ID: string; // A stable ID to use with indexing
-  codeDisplay: string; // The code for the object -- may change, like if the language schema changes
-  nameDisplay: string; // The name for the object -- may change with data from different sources
+  readonly ID: string;
+  codeDisplay: string;
+  nameDisplay: string;
   nameEndonym?: string;
   names: string[];
 }
@@ -23,10 +19,9 @@ export type ObjectData =
   | WritingSystemData
   | VariantTagData;
 
-// ISO 3166 territory code OR UN M49 code
 export type TerritoryCode = ISO3166Code | UNM49Code;
-export type ISO3166Code = string; // ISO 3166-1 alpha-2 code, eg. US, CA, etc.
-export type UNM49Code = string; // UN M49 code, eg. 001, 150, 419, etc.
+export type ISO3166Code = string; 
+export type UNM49Code = string;
 
 export enum TerritoryScope {
   World = 'World',
@@ -59,11 +54,9 @@ export interface TerritoryData extends ObjectBase {
   containedUNRegionCode: UNM49Code;
   sovereignCode: ISO3166Code;
 
-  // Supplemental data
   literacyPercent?: number;
   gdp?: number;
 
-  // References to other objects, filled in after loading the TSV
   parentUNRegion?: TerritoryData;
   containsTerritories: TerritoryData[];
   sovereign?: TerritoryData;
@@ -72,7 +65,7 @@ export interface TerritoryData extends ObjectBase {
   censuses: CensusData[];
 }
 
-export type ScriptCode = string; // ISO 15924 script code, eg. Latn, Cyrl, etc.
+export type ScriptCode = string;
 
 export enum WritingSystemScope {
   Group = 'Group',
@@ -85,7 +78,7 @@ export interface WritingSystemData extends ObjectBase {
   type: ObjectType.WritingSystem;
 
   ID: ScriptCode;
-  codeDisplay: ScriptCode; // This should be stable
+  codeDisplay: ScriptCode;
   scope: WritingSystemScope;
 
   nameDisplayOriginal: string;
@@ -99,12 +92,10 @@ export interface WritingSystemData extends ObjectBase {
   parentWritingSystemCode: ScriptCode | null;
   containsWritingSystemsCodes: ScriptCode[];
 
-  // Derived when combining data
   populationUpperBound: number;
   nameDisplay: string;
   populationOfDescendents: number;
 
-  // References to other objects, filled in after loading the TSV
   primaryLanguage?: LanguageData;
   territoryOfOrigin?: TerritoryData;
   languages: Record<LanguageCode, LanguageData>;
@@ -114,9 +105,7 @@ export interface WritingSystemData extends ObjectBase {
   containsWritingSystems: WritingSystemData[];
 }
 
-// BCP-47 Locale	Locale Display Name	Native Locale Name	Language Code	Territory ISO	Explicit Script	Variant IANA Tag	Pop Source	Best Guess	Official Language
-export type BCP47LocaleCode = string; // BCP-47 formatted locale, eg. en_US, fr_CA, etc.
-
+export type BCP47LocaleCode = string; 
 export enum PopulationSourceCategory {
   Census = '1 Census',
   Study = '2 Study',
@@ -147,37 +136,38 @@ export interface LocaleData extends ObjectBase {
   type: ObjectType.Locale;
 
   ID: BCP47LocaleCode;
-  codeDisplay: BCP47LocaleCode; // Changes based on the language schema
-  localeSource: 'regularInput' | 'IANA' | 'census'; // Whether this locale is listed in the the regular locale list or not
+  codeDisplay: BCP47LocaleCode; 
+  localeSource: 'regularInput' | 'IANA' | 'census';
 
   nameDisplay: string;
   nameEndonym?: string;
   languageCode: LanguageCode;
   territoryCode: TerritoryCode;
   explicitScriptCode?: ScriptCode;
-  variantTagCode?: VariantIANATag; // TODO Variant tags can be singular (eg. roh-rumgr) or composite (eg. oc-lengadoc-grclass)
+  
+  variantTagCodes?: VariantIANATag[];
+
+  variantTags?: VariantTagData[];
 
   populationSource: PopulationSourceCategory;
   populationSpeaking: number;
   officialStatus?: OfficialStatus;
 
-  // References to other objects, filled in after loading the TSV
   language?: LanguageData;
   territory?: TerritoryData;
   writingSystem?: WritingSystemData;
-  containedLocales?: LocaleData[]; // Particularly for aggregated regional locales eg. es_419
+  containedLocales?: LocaleData[];
   variantTag?: VariantTagData;
 
-  // Data added up some references
   populationSpeakingPercent?: number;
   literacyPercent?: number;
   populationWriting?: number;
   populationWritingPercent?: number;
-  populationCensus?: CensusData; // The census record that provides the population estimate
-  censusRecords: LocaleInCensus[]; // Maps census ID to population estimate
+  populationCensus?: CensusData;
+  censusRecords: LocaleInCensus[]; 
 }
 
-export type VariantIANATag = string; // IANA tag, eg. valencia in cat-ES-valencia
+export type VariantIANATag = string;
 export interface VariantTagData extends ObjectBase {
   type: ObjectType.VariantTag;
   ID: VariantIANATag;
@@ -186,11 +176,10 @@ export interface VariantTagData extends ObjectBase {
   description?: string;
 
   dateAdded?: Date;
-  prefixes: string[]; // Usually language codes but sometimes composites like zh-Latn or oc-lengadoc
-  languageCodes: LanguageCode[]; // zh, oc, etc.
-  localeCodes: BCP47LocaleCode[]; // would look like zh-Latn-pinyin or oc-lengadoc-grclass
+  prefixes: string[]; 
+  languageCodes: LanguageCode[];
+  localeCodes: BCP47LocaleCode[]; 
 
-  // References to other objects
   languages: LanguageData[];
   locales: LocaleData[];
 }

--- a/src/views/locale/LocaleDetails.tsx
+++ b/src/views/locale/LocaleDetails.tsx
@@ -37,9 +37,10 @@ const LocaleDefinitionSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
     languageCode,
     territory,
     territoryCode,
-    variantTag,
-    variantTagCode,
+    variantTags,
+    variantTagCodes,
     writingSystem,
+    variantTag,
   } = locale;
 
   return (
@@ -73,13 +74,21 @@ const LocaleDefinitionSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
           )}
         </DetailsField>
       )}
-      {variantTagCode && (
+      {variantTagCodes && variantTagCodes.length > 0 && (
         <DetailsField title="Variant Tag:">
-          {variantTag ? (
-            <HoverableObjectName object={variantTag} />
+          {variantTags && variantTags.length > 0 ? (
+            <span>
+              {}
+              {variantTags.map((tag, idx) => (
+                <React.Fragment key={tag.ID}>
+                  {idx > 0 && ', '}
+                  <HoverableObjectName object={tag} />
+                </React.Fragment>
+              ))}
+            </span>
           ) : (
             <span>
-              {variantTagCode} <Deemphasized>[variant not in database]</Deemphasized>
+              {variantTagCodes.join(', ')} <Deemphasized>[variant not in database]</Deemphasized>
             </span>
           )}
         </DetailsField>

--- a/src/views/locale/LocaleDetails.tsx
+++ b/src/views/locale/LocaleDetails.tsx
@@ -77,15 +77,9 @@ const LocaleDefinitionSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
       {variantTagCodes && variantTagCodes.length > 0 && (
         <DetailsField title="Variant Tag:">
           {variantTags && variantTags.length > 0 ? (
-            <span>
-              {}
-              {variantTags.map((tag, idx) => (
-                <React.Fragment key={tag.ID}>
-                  {idx > 0 && ', '}
-                  <HoverableObjectName object={tag} />
-                </React.Fragment>
-              ))}
-            </span>
+            <CommaSeparated>
+              {variantTags.map((tag, i) => <HoverableObjectName object={tag} key={i} />)}
+            </CommaSeparated>
           ) : (
             <span>
               {variantTagCodes.join(', ')} <Deemphasized>[variant not in database]</Deemphasized>

--- a/src/views/locale/LocaleStrings.tsx
+++ b/src/views/locale/LocaleStrings.tsx
@@ -21,17 +21,14 @@ export function getLocaleCode(
   localeSeparator: LocaleSeparator,
   territoryOverride?: ISO3166Code,
 ): string {
-  const components: string[] = [];
- 
-  components.push(locale.language?.codeDisplay ?? locale.languageCode);
-  if (locale.explicitScriptCode) components.push(locale.explicitScriptCode);
-  const territory = territoryOverride ?? locale.territoryCode;
-  if (territory) components.push(territory);
-  // Include all variant subtags
-  if (locale.variantTagCodes && locale.variantTagCodes.length > 0) {
-    components.push(...locale.variantTagCodes);
-  }
-  return components.filter(Boolean).join(localeSeparator);
+ return [
+    locale.language?.codeDisplay ?? locale.languageCode,
+    locale.explicitScriptCode,
+    territoryOverride ?? locale.territoryCode,
+    ...locale.variantTagCodes,
+  ]
+    .filter(Boolean)
+    .join(localeSeparator);
 }
 
 export function getOfficialLabel(officialStatus: OfficialStatus): string {

--- a/src/views/locale/LocaleStrings.tsx
+++ b/src/views/locale/LocaleStrings.tsx
@@ -5,11 +5,15 @@ export function getLocaleName(locale: LocaleData): string {
   const languageName = locale.language?.nameDisplay ?? locale.languageCode;
   const territoryName = locale.territory?.nameDisplay ?? locale.territoryCode;
   const scriptName = locale.writingSystem?.nameDisplay ?? locale.explicitScriptCode;
-  const variantName = locale.variantTag?.nameDisplay ?? locale.variantTagCode;
 
-  return (
-    languageName + ' (' + [territoryName, scriptName, variantName].filter(Boolean).join(', ') + ')'
-  );
+  let variantName: string | undefined = undefined;
+  if (locale.variantTags && locale.variantTags.length > 0) {
+    variantName = locale.variantTags.map((v) => v.nameDisplay).join(', ');
+  } else if (locale.variantTagCodes && locale.variantTagCodes.length > 0) {
+    variantName = locale.variantTagCodes.join(', ');
+  }
+
+  return languageName + ' (' + [territoryName, scriptName, variantName].filter(Boolean).join(', ') + ')';
 }
 
 export function getLocaleCode(
@@ -17,14 +21,17 @@ export function getLocaleCode(
   localeSeparator: LocaleSeparator,
   territoryOverride?: ISO3166Code,
 ): string {
-  return [
-    locale.language?.codeDisplay ?? locale.languageCode,
-    locale.explicitScriptCode,
-    territoryOverride ?? locale.territoryCode,
-    locale.variantTagCode, // TODO a locale could have multiple variant tags
-  ]
-    .filter(Boolean)
-    .join(localeSeparator);
+  const components: string[] = [];
+ 
+  components.push(locale.language?.codeDisplay ?? locale.languageCode);
+  if (locale.explicitScriptCode) components.push(locale.explicitScriptCode);
+  const territory = territoryOverride ?? locale.territoryCode;
+  if (territory) components.push(territory);
+  // Include all variant subtags
+  if (locale.variantTagCodes && locale.variantTagCodes.length > 0) {
+    components.push(...locale.variantTagCodes);
+  }
+  return components.filter(Boolean).join(localeSeparator);
 }
 
 export function getOfficialLabel(officialStatus: OfficialStatus): string {


### PR DESCRIPTION
Adds support for composite variant tags in locales, updates the variant locale script to handle them, and fixes divergence with territory tags to ensure consistency between locales and variant locales.