### PR TITLE
Add variant tag population calculations and displays

### DIFF
--- a/src/data/IANAData.tsx
+++ b/src/data/IANAData.tsx
@@ -156,6 +156,9 @@ export function connectVariantTags(
 ): void {
   // Link variants to languages and link languages back to variants
   Object.values(variantTags).forEach((variant) => {
+    // Ensure population upper bound is initialised
+    variant.populationUpperBound = 0;
+
     // Link languages to variants
     variant.languageCodes.forEach((langCode) => {
       const lang = languages[langCode];
@@ -171,6 +174,17 @@ export function connectVariantTags(
         // console.warn(`Language code ${langCode} not found for variant ${variant.ID}`);
       }
     });
+
+    // Compute an upper bound for the potential population of this variant tag.  This is based on
+    // the populations of all languages that this variant declares as a prefix.  It is not meant to
+    // represent actual speaker counts, but rather the maximum number of people who could conceivably
+    // use this variant if every speaker of the associated languages adopted it.  Languages without
+    // a cited population are treated as zero.
+    if (variant.languages && variant.languages.length > 0) {
+      variant.populationUpperBound = variant.languages.reduce((sum, lang) => {
+        return sum + (lang.populationCited || 0);
+      }, 0);
+    }
   });
 
   // Link locales to variants and vice versa

--- a/src/data/PopulationData.tsx
+++ b/src/data/PopulationData.tsx
@@ -5,6 +5,7 @@ import {
   LocaleData,
   LocaleInCensus,
   TerritoryData,
+  VariantTagData,
 } from '../types/DataTypes';
 
 import { CoreData } from './CoreData';
@@ -116,4 +117,21 @@ export function computeLocaleWritingPopulation(locales: Record<BCP47LocaleCode, 
           (locale.populationSpeakingPercent * locale.literacyPercent) / 100;
       }
     });
+}
+
+/**
+ * Compute the cited population for each variant tag based on locales.  After locale populations have been
+ * determined (e.g. via computeLocalePopulationFromCensuses), this function will iterate through all variant
+ * tags and sum the populationSpeaking from their associated locales.  The result is stored on the
+ * populationCited property of each VariantTagData.  If a variant tag has no associated locales or
+ * none of its locales have population information, the cited population will be set to zero.
+ */
+export function computeVariantTagPopulations(variantTags: Record<string, VariantTagData>): void {
+  Object.values(variantTags).forEach((variant) => {
+    // Sum the populationSpeaking for all locales that reference this variant tag
+    const total = variant.locales?.reduce((sum, locale) => {
+      return sum + (locale.populationSpeaking || 0);
+    }, 0) ?? 0;
+    variant.populationCited = total;
+  });
 }

--- a/src/data/SupplementalData.tsx
+++ b/src/data/SupplementalData.tsx
@@ -3,6 +3,7 @@ import { CoreData } from './CoreData';
 import {
   computeLocalePopulationFromCensuses,
   computeLocaleWritingPopulation,
+  computeVariantTagPopulations,
 } from './PopulationData';
 import { computeContainedTerritoryStats, loadTerritoryGDPLiteracy } from './TerritoryData';
 import { getLanguageCountsFromCLDR, loadCLDRCoverage } from './UnicodeData';
@@ -31,4 +32,7 @@ export async function loadSupplementalData(coreData: CoreData): Promise<void> {
   computeContainedTerritoryStats(coreData.territories['001']);
   computeLocalePopulationFromCensuses(coreData);
   computeLocaleWritingPopulation(coreData.locales);
+
+  // Once locale populations have been computed, update variant tag populations.
+  computeVariantTagPopulations(coreData.variantTags);
 }

--- a/src/types/DataTypes.tsx
+++ b/src/types/DataTypes.tsx
@@ -193,4 +193,19 @@ export interface VariantTagData extends ObjectBase {
   // References to other objects
   languages: LanguageData[];
   locales: LocaleData[];
+
+  /**
+   * A lower bound on the number of speakers explicitly citing this variant tag in a census or locale record.
+   * This value is derived by summing the populationSpeaking field of all locales that reference this variant tag.
+   * It may be zero if no locales explicitly cite this variant tag or if population data has not yet been loaded.
+   */
+  populationCited?: number;
+
+  /**
+   * An upper bound estimate of the potential population that could use this variant.
+   * This is computed as the sum of the cited populations of all languages for which this tag is declared as a prefix.
+   * In other words, it represents how many people might speak a language that could employ this variant,
+   * regardless of whether they actually do so.  It is not meant to be an exact speaker count.
+   */
+  populationUpperBound?: number;
 }

--- a/src/views/varianttag/VariantTagCard.tsx
+++ b/src/views/varianttag/VariantTagCard.tsx
@@ -14,7 +14,10 @@ interface Props {
 
 const VariantTagCard: React.FC<Props> = ({ data }) => {
   const { updatePageParams } = usePageParams();
+  // destructure additional population fields if present on the variant tag
   const { ID, nameDisplay, languages } = data;
+  const populationCited = (data as any).populationCited;
+  const populationUpperBound = (data as any).populationUpperBound;
 
   return (
     <div>
@@ -28,6 +31,20 @@ const VariantTagCard: React.FC<Props> = ({ data }) => {
         <label>Name:</label>
         {nameDisplay}
       </div>
+
+      {/* Show cited and potential populations when available and non-zero */}
+      {typeof populationCited === 'number' && populationCited > 0 && (
+        <div>
+          <label>Cited Population:</label>
+          {populationCited.toLocaleString()}
+        </div>
+      )}
+      {typeof populationUpperBound === 'number' && populationUpperBound > 0 && (
+        <div>
+          <label>Potential Population:</label>
+          {populationUpperBound.toLocaleString()}
+        </div>
+      )}
 
       {languages && Object.values(languages).length > 0 && (
         <div>

--- a/src/views/varianttag/VariantTagDetails.tsx
+++ b/src/views/varianttag/VariantTagDetails.tsx
@@ -11,7 +11,17 @@ type Props = {
 };
 
 const VariantTagDetails: React.FC<Props> = ({ variantTag }) => {
-  const { ID, dateAdded, prefixes, nameDisplay, description, languages, locales } = variantTag;
+  const {
+    ID,
+    dateAdded,
+    prefixes,
+    nameDisplay,
+    description,
+    languages,
+    locales,
+    populationCited,
+    populationUpperBound,
+  } = variantTag as any;
 
   return (
     <div className="Details">
@@ -20,6 +30,12 @@ const VariantTagDetails: React.FC<Props> = ({ variantTag }) => {
         <DetailsField title="Name:">{nameDisplay}</DetailsField>
         {description && <DetailsField title="Description:">{description}</DetailsField>}
         {dateAdded && <DetailsField title="Added:">{dateAdded.toLocaleDateString()}</DetailsField>}
+        {typeof populationCited === 'number' && populationCited > 0 && (
+          <DetailsField title="Cited Population:">{populationCited.toLocaleString()}</DetailsField>
+        )}
+        {typeof populationUpperBound === 'number' && populationUpperBound > 0 && (
+          <DetailsField title="Potential Population:">{populationUpperBound.toLocaleString()}</DetailsField>
+        )}
       </DetailsSection>
 
       <DetailsSection title="Connections">

--- a/src/views/varianttag/VariantTagTable.tsx
+++ b/src/views/varianttag/VariantTagTable.tsx
@@ -6,7 +6,6 @@ import Hoverable from '../../generic/Hoverable';
 import HoverableEnumeration from '../../generic/HoverableEnumeration';
 import { VariantTagData } from '../../types/DataTypes';
 import { SortBy } from '../../types/PageParamTypes';
-import { getObjectPopulation } from '../common/ObjectField';
 import { CodeColumn, NameColumn } from '../common/table/CommonColumns';
 import ObjectTable from '../common/table/ObjectTable';
 
@@ -35,14 +34,41 @@ const VariantTagTable: React.FC = () => {
           sortParam: SortBy.CountOfLanguages,
         },
         {
-          key: 'Potential Population',
+          key: 'Cited Population',
+          label: (
+            <Hoverable
+              hoverContent={
+                <>
+                  <TriangleAlertIcon size="1em" /> This figure is a lower bound based on census
+                  data: it sums the number of speakers recorded for locales that explicitly cite
+                  this variant tag.  In many cases there will be no cited population and this will
+                  be zero.
+                </>
+              }
+            >
+              Cited Population
+            </Hoverable>
+          ),
+          render: (object) => {
+            // Cast to any so we can access the optional property
+            const cited = (object as any).populationCited;
+            return typeof cited === 'number' && cited > 0 ? cited : 0;
+          },
+          isInitiallyVisible: false,
+          isNumeric: true,
+          // Sort by cited population.  Use population sort param here so that the page param
+          // remains stable, but getObjectPopulation will prioritise cited population first.
+          sortParam: SortBy.Population,
+        },
+        {
+          key: 'Upper Bound Population',
           label: (
             <Hoverable
               hoverContent={
                 <>
                   <TriangleAlertIcon size="1em" /> This is not the actual population of this variant
-                  tag, but an estimate based on the language(s) it applies to. If its an
-                  orthographic variant maybe it applies to the full modern population, but if its a
+                  tag, but an upper bound based on the language(s) it applies to.  If this is an
+                  orthographic variant it might apply to the full modern population, but if it is a
                   dialect or historic variation it may only be a small group of people or only found
                   in manuscripts.
                 </>
@@ -51,9 +77,13 @@ const VariantTagTable: React.FC = () => {
               Potential Population
             </Hoverable>
           ),
-          render: (object) => getObjectPopulation(object),
+          render: (object) => {
+            const upper = (object as any).populationUpperBound;
+            return typeof upper === 'number' && upper > 0 ? upper : 0;
+          },
           isInitiallyVisible: false,
           isNumeric: true,
+          // Still sort by the main population param so upper bound works with descending sorts
           sortParam: SortBy.Population,
         },
       ]}


### PR DESCRIPTION
Implemented two figures for each variant: a cited population derived from available locale data, and an upper-bound population estimate based on the total population of the variant’s associated prefix or language (for example, roh_rumgr could have as many users as roh in general). These additions make sorting and comparing variants by population more meaningful even when direct variant-specific population data is missing.