### PR TITLE
Search: Misc improvements with Census languages

### DIFF
--- a/src/controls/selectors/TerritoryScopeSelector.tsx
+++ b/src/controls/selectors/TerritoryScopeSelector.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
 
 import { TerritoryScope } from '../../types/DataTypes';
-import { ObjectType } from '../../types/PageParamTypes';
+import { ObjectType, View } from '../../types/PageParamTypes';
 import Selector from '../components/Selector';
 import { usePageParams } from '../PageParamsContext';
 
 const TerritoryScopeSelector: React.FC = () => {
-  const { territoryScopes, updatePageParams, objectType } = usePageParams();
+  const { territoryScopes, updatePageParams, objectType, view } = usePageParams();
 
-  if (![ObjectType.Territory, ObjectType.Locale].includes(objectType)) {
+  if (
+    ![ObjectType.Territory, ObjectType.Locale].includes(objectType) &&
+    !(view === View.Reports && objectType === ObjectType.Census)
+  ) {
     return null; // Only applicable for territory and locale objects
   }
 

--- a/src/pages/CommonObjectives.tsx
+++ b/src/pages/CommonObjectives.tsx
@@ -46,23 +46,34 @@ const Objective: React.FC<ObjectiveProps> = ({
   return (
     <li>
       {label}
-      {inputParam && (
-        <input
-          style={{ padding: '0.25em 0.5em', marginLeft: '0.5em' }}
-          placeholder={inputPlaceholder}
-          value={inputText}
-          onChange={(e) => setInputText(e.target.value)}
-        />
-      )}
-      <GoButton params={params} />
+
+      <form
+        style={{ display: 'inline' }}
+        onSubmit={(e) => {
+          e.preventDefault();
+          window.location.href = `data${getNewURL(params)}`;
+        }}
+      >
+        {inputParam && (
+          <input
+            style={{ padding: '0.25em 0.5em', marginLeft: '0.5em' }}
+            placeholder={inputPlaceholder}
+            value={inputText}
+            onChange={(e) => setInputText(e.target.value)}
+          />
+        )}
+        <GoButton params={params} />
+      </form>
     </li>
   );
 };
 
 const GoButton: React.FC<{ params: PageParamsOptional }> = ({ params }) => {
   return (
-    <a href={`data${getNewURL(params)}`}>
-      <button style={{ padding: '0.25em 0.5em', marginLeft: '0.5em' }}>GO</button>
+    <a href={`data${getNewURL(params)}`} style={{ marginLeft: '0.5em' }}>
+      <button style={{ padding: '0.25em 0.5em' }} type="submit">
+        GO
+      </button>
     </a>
   );
 };

--- a/src/views/VisibleItemsMeter.tsx
+++ b/src/views/VisibleItemsMeter.tsx
@@ -9,11 +9,12 @@ import { ObjectData } from '../types/DataTypes';
 
 interface Props {
   objects: ObjectData[];
+  shouldFilterUsingSearchBar?: boolean;
 }
 
-const VisibleItemsMeter: React.FC<Props> = ({ objects }) => {
+const VisibleItemsMeter: React.FC<Props> = ({ objects, shouldFilterUsingSearchBar = true }) => {
   const { page, limit, territoryFilter } = usePageParams();
-  const filterBySubstring = getFilterBySubstring();
+  const filterBySubstring = shouldFilterUsingSearchBar ? getFilterBySubstring() : () => true;
   const filterByTerritory = getFilterByTerritory();
   const filterByScope = getScopeFilter();
 

--- a/src/views/census/TableOfLanguagesInCensus.tsx
+++ b/src/views/census/TableOfLanguagesInCensus.tsx
@@ -85,6 +85,7 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
       )}
       <ObjectTable<LocaleData>
         objects={languagesInCensus}
+        shouldFilterUsingSearchBar={false}
         columns={[
           CodeColumn,
           {

--- a/src/views/common/table/ObjectTable.tsx
+++ b/src/views/common/table/ObjectTable.tsx
@@ -30,12 +30,17 @@ export interface TableColumn<T> {
 interface Props<T> {
   objects: T[];
   columns: TableColumn<T>[];
+  shouldFilterUsingSearchBar?: boolean;
 }
 
-function ObjectTable<T extends ObjectData>({ objects, columns }: Props<T>) {
+function ObjectTable<T extends ObjectData>({
+  objects,
+  columns,
+  shouldFilterUsingSearchBar = true,
+}: Props<T>) {
   const { sortBy } = usePageParams();
   const sortFunction = getSortFunction();
-  const filterBySubstring = getFilterBySubstring();
+  const filterBySubstring = shouldFilterUsingSearchBar ? getFilterBySubstring() : () => true;
   const filterByTerritory = getFilterByTerritory();
   const scopeFilter = getScopeFilter();
 
@@ -67,7 +72,10 @@ function ObjectTable<T extends ObjectData>({ objects, columns }: Props<T>) {
 
   return (
     <div className="ObjectTableContainer">
-      <VisibleItemsMeter objects={objects} />
+      <VisibleItemsMeter
+        objects={objects}
+        shouldFilterUsingSearchBar={shouldFilterUsingSearchBar}
+      />
       <details style={{ margin: '.5em 0 1em 0', gap: '.5em 1em' }}>
         <summary style={{ cursor: 'pointer' }}>
           {currentlyVisibleColumns.length}/{columns.length} columns visible, click here to toggle.


### PR DESCRIPTION
Some improvements to search so it reduces conflicts. In particular, you may search for a particular census by name but then when you open up the details on the census it shows 0 results in the language table. Since that table works on a different kind of object, we shouldn't use the page search on it.

This change also adds the territory scope filter when in census reports since that filter can be used.

|Before|After|
|--|--|
|<img width="784" height="578" alt="Screenshot 2025-08-19 at 18 59 44" src="https://github.com/user-attachments/assets/98bb3595-72a7-479d-a1b0-529da88d7371" />|<img width="781" height="644" alt="Screenshot 2025-08-19 at 18 59 37" src="https://github.com/user-attachments/assets/48e66fed-781a-4512-a8c9-9c33ceed6df4" />

