### PR TITLE
Data: Add wikipedia availability

### DIFF
--- a/public/data/locales.tsv
+++ b/public/data/locales.tsv
@@ -10107,3 +10107,4 @@ rar_AU	Rarotongan (Australia)		rar	AU
 epo_US	Esperanto (United States)		epo	US					
 coc_US	Cocopa (United States)		coc	US					
 mfz_US	Mabaan (United States)		mfz	US					
+eng_basiceng	English (Simple)		eng			basiceng			

--- a/public/data/wikipedias.tsv
+++ b/public/data/wikipedias.tsv
@@ -1,0 +1,791 @@
+Title	Local Title	Status	Language	Script (ISO 15924 code)	WP code	Locale Code	Articles	Active users	URL
+English Wikipedia	English Wikipedia	Active	English	Latn	en	eng	7,042,227	107,458	https://en.wikipedia.org
+Cebuano Wikipedia	Wikipedya sa Sinugboanon	Active	Cebuano	Latn	ceb	ceb	6,116,183	154	https://ceb.wikipedia.org
+German Wikipedia	Deutschsprachige Wikipedia	Active	German	Latn	de	deu	3,042,824	38,598	https://de.wikipedia.org
+French Wikipedia	Wikipédia en français	Active	French	Latn	fr	fra	2,703,458	38,502	https://fr.wikipedia.org
+Swedish Wikipedia	Svenskspråkiga Wikipedia	Active	Swedish	Latn	sv	swe	2,614,956	1,751	https://sv.wikipedia.org
+Dutch Wikipedia	Nederlandstalige Wikipedia	Active	Dutch	Latn	nl	nld	2,194,905	8,164	https://nl.wikipedia.org
+Russian Wikipedia	Русская Википедия (Russkaya Vikipediya)	Active	Russian	Cyrl	ru	rus	2,059,836	7,687	https://ru.wikipedia.org
+Spanish Wikipedia	Wikipedia en español	Active	Spanish	Latn	es	spa	2,055,650	11,768	https://es.wikipedia.org
+Italian Wikipedia	Wikipedia in italiano	Active	Italian	Latn	it	ita	1,931,317	6,642	https://it.wikipedia.org
+Polish Wikipedia	Polskojęzyczna Wikipedia	Active	Polish	Latn	pl	pol	1,666,418	10,848	https://pl.wikipedia.org
+Egyptian Arabic Wikipedia	ويكيپيديا مصرى (Wīkībīdiyā maṣri)	Active	Egyptian Arabic	Arab	arz	arz	1,628,630	199	https://arz.wikipedia.org
+Chinese Wikipedia	Traditional Chinese: 中文維基百科, simplified Chinese: 中文维基百科 (pinyin: Zhōngwén wéijī bǎikē)	Active	Chinese (written vernacular Chinese)	Hans/Hant	zh	zho	1,495,415	17,522	https://zh.wikipedia.org
+Japanese Wikipedia	ウィキペディア日本語版 (Wikipedia nihongo-ban)	Active	Japanese	Jpan	ja	jpn	1,470,256	28,667	https://ja.wikipedia.org
+Ukrainian Wikipedia	Українська Вікіпедія (Ukrainska Vikipediia)	Active	Ukrainian	Cyrl	uk	ukr	1,388,371	6,586	https://uk.wikipedia.org
+Vietnamese Wikipedia	Wikipedia tiếng Việt	Active	Vietnamese	Latn	vi	vie	1,295,883	3,047	https://vi.wikipedia.org
+Arabic Wikipedia	ويكيبيديا العربية (Wīkībīdiyā al-ʿarabiyya)	Active	Arabic	Arab	ar	ara	1,276,505	7,628	https://ar.wikipedia.org
+Waray Wikipedia	Waray Wikipedia	Active	Waray	Latn	war	war	1,266,757	62	https://war.wikipedia.org
+Portuguese Wikipedia	Wikipédia em português	Active	Portuguese	Latn	pt	por	1,152,946	7,782	https://pt.wikipedia.org
+Persian Wikipedia	ویکی‌پدیای فارسی (Vikipediā-ye Fārsi)	Active	Persian	Arab	fa	fas	1,050,564	11,164	https://fa.wikipedia.org
+Catalan Wikipedia	Viquipèdia en català	Active	Catalan	Latn	ca	cat	779,627	938	https://ca.wikipedia.org
+Indonesian Wikipedia	Wikipedia bahasa Indonesia	Active	Indonesian	Latn	id	ind	739,436	6,843	https://id.wikipedia.org
+Korean Wikipedia	한국어 위키백과 (Hangugeo wikibaekgwa)	Active	Korean	Hang	ko	kor	719,092	7,729	https://ko.wikipedia.org
+Serbian Wikipedia	Википедија на српском језику (Vikipedija na srpskom jeziku)	Active	Serbian	Cyrl/Latn	sr	srp	709,848	2,155	https://sr.wikipedia.org
+Norwegian Wikipedia (Bokmål)	Norsk Wikipedia	Active	Norwegian (Bokmål)	Latn	no	nor	654,743	2,105	https://no.wikipedia.org
+Turkish Wikipedia	Türkçe Vikipedi	Active	Turkish	Latn	tr	tur	644,636	5,459	https://tr.wikipedia.org
+Chechen Wikipedia	Нохчийн Википеди (Noxçiyn Wikipedi)	Active	Chechen	Cyrl	ce	che	602,280	60	https://ce.wikipedia.org
+Finnish Wikipedia	Suomenkielinen Wikipedia	Active	Finnish	Latn	fi	fin	600,648	1,358	https://fi.wikipedia.org
+Czech Wikipedia	Česká Wikipedie	Active	Czech	Latn	cs	ces	575,239	4,577	https://cs.wikipedia.org
+Hungarian Wikipedia	Magyar Wikipédia	Active	Hungarian	Latn	hu	hun	560,053	1,273	https://hu.wikipedia.org
+Romanian Wikipedia	Wikipedia în limba română	Active	Romanian	Latn	ro	ron	516,035	2,090	https://ro.wikipedia.org
+Tatar Wikipedia	Татар Википедиясе (Tatar Wikipediäse)	Active	Tatar	Cyrl	tt	tat	503,010	72	https://tt.wikipedia.org
+Basque Wikipedia	Euskarazko Wikipedia	Active	Basque	Latn	eu	eus	470,195	284	https://eu.wikipedia.org
+Serbo-Croatian Wikipedia	Srpskohrvatska Wikipedija (Српскохрватска Википедија)	Active	Serbo-Croatian	Latn/Cyrl	sh	hbs	461,003	385	https://sh.wikipedia.org
+Southern Min Wikipedia	Pe̍h-ōe-jī: Holopedia or Wikipedia Bân-lâm-gú	Active	Southern Min	Latn	zh-min-nan	nan	433,764	77	https://zh-min-nan.wikipedia.org
+Malay Wikipedia	Wikipedia Bahasa Melayu (ويکيڤيديا بهاس ملايو)	Active	Malay	Latn	ms	zsm	431,820	626	https://ms.wikipedia.org
+Hebrew Wikipedia	ויקיפדיה העברית (Vikipedya ha-ivrit)	Active	Hebrew	Hebr	he	heb	381,169	8,337	https://he.wikipedia.org
+Esperanto Wikipedia	Vikipedio en Esperanto	Active	Esperanto	Latn	eo	epo	374,107	305	https://eo.wikipedia.org
+Armenian Wikipedia	Հայերեն Վիքիպեդիա (Hayeren Vikʿipedia)	Active	Armenian	Armn	hy	hye	321,982	406	https://hy.wikipedia.org
+Danish Wikipedia	Dansk Wikipedia	Active	Danish	Latn	da	dan	310,215	1,718	https://da.wikipedia.org
+Bulgarian Wikipedia	Българоезична Уикипедия (Bǎlgaroezična Uikipediya)	Active	Bulgarian	Cyrl	bg	bul	305,410	589	https://bg.wikipedia.org
+Uzbek Wikipedia	Oʻzbekcha Vikipediya (Ўзбекча Википедия)	Active	Uzbek	Latn/Cyrl	uz	uzb	297,361	320	https://uz.wikipedia.org
+Welsh Wikipedia	Wicipedia Cymraeg	Active	Welsh	Latn	cy	cym	282,360	127	https://cy.wikipedia.org
+Simple English Wikipedia	Simple English Wikipedia	Active	Simple English	Latn	simple	eng_basiceng	272,321	1,336	https://simple.wikipedia.org
+Greek Wikipedia	Ελληνική Βικιπαίδεια (Ellinikí Vikipaídeia)	Active	Greek	Grek	el	ell	257,190	836	https://el.wikipedia.org
+Belarusian Wikipedia	Беларуская Вікіпедыя (Bielaruskaja Vikipiedyja)	Active	Belarusian (official Narkamaŭka orthography)	Cyrl	be	bel	255,412	252	https://be.wikipedia.org
+Slovak Wikipedia	Slovenská Wikipedia	Active	Slovak	Latn	sk	slk	255,222	437	https://sk.wikipedia.org
+Estonian Wikipedia	Eestikeelne Vikipeedia	Active	Estonian	Latn	et	est	254,311	425	https://et.wikipedia.org
+South Azerbaijani Wikipedia	تورکجه ویکی‌پدیا (Azərbaycanca Vikipediya)	Active	South Azerbaijani	Arab	azb	azb	244,240	94	https://azb.wikipedia.org
+Kazakh Wikipedia	Қазақша Уикипедия (Qazaqşa Wïkïpedïya) (قازاقشا ۋىيكىيپەدىييا)	Active	Kazakh	Cyrl	kk	kaz	239,947	213	https://kk.wikipedia.org
+Urdu Wikipedia	اردو ویکیپیڈیا (Urdū vikipīḍiyā)	Active	Urdu	Arab	ur	urd	231,134	238	https://ur.wikipedia.org
+Minangkabau Wikipedia	Wikipedia Minangkabau	Active	Minangkabau	Latn	min	min	228,487	47	https://min.wikipedia.org
+Croatian Wikipedia	Hrvatska Wikipedija	Active	Croatian	Latn	hr	hrv	227,168	424	https://hr.wikipedia.org
+Galician Wikipedia	Galipedia or Wikipedia en galego	Active	Galician	Latn	gl	glg	226,017	251	https://gl.wikipedia.org
+Lithuanian Wikipedia	Lietuviškoji Vikipedija	Active	Lithuanian	Latn	lt	lit	223,373	301	https://lt.wikipedia.org
+Azerbaijani Wikipedia	Azərbaycanca Vikipediya	Active	Azerbaijani	Latn	az	aze	206,861	902	https://az.wikipedia.org
+Slovene Wikipedia	Slovenska Wikipedija	Active	Slovene	Latn	sl	slv	194,554	287	https://sl.wikipedia.org
+Georgian Wikipedia	ქართული ვიკიპედია (Kartuli vik’ip’edia)	Active	Georgian	Geor	ka	kat	184,593	249	https://ka.wikipedia.org
+Ladin Wikipedia	Wikipedia per ladin	Active	Ladin	Latn	lld	lld	180,801	38	https://lld.wikipedia.org
+Tamil Wikipedia	தமிழ் விக்கிபீடியா (Tamiḻ vikkippīṭiyā)	Active	Tamil	Taml	ta	tam	175,915	249	https://ta.wikipedia.org
+Thai Wikipedia	วิกิพีเดียภาษาไทย (Wi-ki-phi-dia pha-sa thai)	Active	Thai	Thai	th	tha	175,705	1,268	https://th.wikipedia.org
+Norwegian Wikipedia (Nynorsk)	Norsk (Nynorsk) Wikipedia	Active	Norwegian (Nynorsk)	Latn	nn	nno	175,243	133	https://nn.wikipedia.org
+Bengali Wikipedia	বাংলা উইকিপিডিয়া (Bangla uikipiḍiẏa)	Active	Bengali	Beng	bn	ben	174,781	1,008	https://bn.wikipedia.org
+Hindi Wikipedia	हिन्दी विकिपीडिया (Hindī vikipīḍiyā)	Active	Hindi	Deva	hi	hin	166,191	1,666	https://hi.wikipedia.org
+Macedonian Wikipedia	Македонска Википедија (Makedonska Vikipedija)	Active	Macedonian	Cyrl	mk	mkd	154,434	185	https://mk.wikipedia.org
+Cantonese Wikipedia	Traditional Chinese: 粵文維基百科 (Jyutping: jyut6 man4 wai4 gei1 baak3 fo1)	Active	Cantonese	Hant	zh-yue	yue	145,574	1,027	https://zh-yue.wikipedia.org
+Latin Wikipedia	Vicipaedia Latina	Active	Latin	Latn	la	lat	140,425	135	https://la.wikipedia.org
+Asturian Wikipedia	Wikipedia n'asturianu	Active	Asturian	Latn	ast	ast	137,556	121	https://ast.wikipedia.org
+Latvian Wikipedia	Vikipēdija latviešu valodā	Active	Latvian	Latn	lv	lav	137,067	289	https://lv.wikipedia.org
+Afrikaans Wikipedia	Afrikaanse Wikipedia	Active	Afrikaans	Latn	af	afr	126,060	179	https://af.wikipedia.org
+Tajik Wikipedia	Википедияи Тоҷикӣ (Vikipedijai Toçikī)	Active	Tajik	Cyrl/Latn	tg	tgk	115,767	74	https://tg.wikipedia.org
+Telugu Wikipedia	తెలుగు వికీపీడియా (Telugu vikīpīḍiyā)	Active	Telugu	Telu	te	tel	115,123	185	https://te.wikipedia.org
+Burmese Wikipedia	မြန်မာဝီကီပီးဒီးယား (Mranma wikipi:di:ya:)	Active	Burmese	Mymr	my	mya	109,496	141	https://my.wikipedia.org
+Albanian Wikipedia	Wikipedia shqip	Active	Albanian	Latn	sq	sqi	103,870	234	https://sq.wikipedia.org
+Swahili Wikipedia	Wikipedia ya Kiswahili	Active	Swahili	Latn	sw	swa	100,832	541	https://sw.wikipedia.org
+Malagasy Wikipedia	Wikipedia amin'ny teny malagasy	Active	Malagasy	Latn	mg	mlg	100,776	57	https://mg.wikipedia.org
+Marathi Wikipedia	मराठी विकिपीडिया (Marāṭhī vikipīḍiyā)	Active	Marathi	Deva	mr	mar	100,229	146	https://mr.wikipedia.org
+Bosnian Wikipedia	Wikipedia na bosanskom jeziku	Active	Bosnian	Latn	bs	bos	95,640	162	https://bs.wikipedia.org
+Kurdish Wikipedia	Wîkîpediya kurdî (ویکیپەدیا کوردی)	Active	Kurdish (Kurmanji)	Latn/Arab	ku	kur	90,538	82	https://ku.wikipedia.org
+Occitan Wikipedia	Wikipèdia en occitan	Active	Occitan	Latn	oc	oci	90,008	77	https://oc.wikipedia.org
+Belarusian Wikipedia (Classical)	Беларуская Вікіпэдыя (Bielaruskaja Vikipiedyja)	Active	Belarusian (Taraškievica orthography)	Cyrl	be-tarask	bel_tarask	89,532	113	https://be-tarask.wikipedia.org
+Breton Wikipedia	Wikipedia e brezhoneg	Active	Breton	Latn	br	bre	89,082	82	https://br.wikipedia.org
+Malayalam Wikipedia	മലയാളം വിക്കിപീഡിയ (Malayāḷaṃ vikkipīḍiya)	Active	Malayalam	Mlym	ml	mal	87,167	216	https://ml.wikipedia.org
+Low German Wikipedia	Plattdüütsche Wikipedia	Active	Low German	Latn	nds	nds	85,688	45	https://nds.wikipedia.org
+Lombard Wikipedia	Wikipedia in lombard	Active	Lombard	Latn	lmo	lmo	78,615	50	https://lmo.wikipedia.org
+Sorani Kurdish Wikipedia	ویکیپیدیای کوردیی سۆرانی (Wîkîpîdiyay Kurdî Soranî)	Active	Kurdish (Sorani)	Arab	ckb	ckb	78,033	129	https://ckb.wikipedia.org
+Kyrgyz Wikipedia	Кыргыз Википедиясы (Kyrgyz Wikipediyasy)	Active	Kyrgyz	Cyrl	ky	kir	76,034	81	https://ky.wikipedia.org
+Javanese Wikipedia	Wikipedia basa Jawa (ꦮꦶꦏꦶꦥꦺꦝꦶꦪꦃꦧꦱꦗꦮ)	Active	Javanese	Latn/Java	jv	jav	74,621	118	https://jv.wikipedia.org
+Western Punjabi Wikipedia	پنجابی وکیپیڈیا (Pañjābī vikīpīḍīā)	Active	Western Punjabi	Arab	pnb	pnb	74,348	67	https://pnb.wikipedia.org
+Newar Wikipedia	𑐣𑐾𑐥𑐵𑐮𑐨𑐵𑐲𑐵 𑐰𑐶𑐎𑐶𑐥𑐶𑐡𑐶𑐫𑐵 (Nepālabhāshā vikipiḍiyā)	Active	Newar	Deva/Newa	new	new	72,580	23	https://new.wikipedia.org
+Haitian Creole Wikipedia	Wikipedya kreyòl ayisyen	Active	Haitian Creole	Latn	ht	hat	71,054	46	https://ht.wikipedia.org
+Piedmontese Wikipedia	Wikipedia an piemontèisa	Active	Piedmontese	Latn	pms	pms	70,492	32	https://pms.wikipedia.org
+Venetian Wikipedia	Wikipedia en łéngoa vèneta	Active	Venetian	Latn	vec	vec	69,444	36	https://vec.wikipedia.org
+Hausa Wikipedia	Wikipedia Hausa	Active	Hausa	Latn	ha	hau	68,704	201	https://ha.wikipedia.org
+Luxembourgish Wikipedia	Wikipedia op Lëtzebuergesch	Active	Luxembourgish	Latn	lb	ltz	65,585	97	https://lb.wikipedia.org
+Mazanderani Wikipedia	مازرونی ویکی‌پدیا (Mazandarani vikipedi)	Active	Mazanderani	Arab	mzn	mzn	64,135	42	https://mzn.wikipedia.org
+Bashkir Wikipedia	Башҡорт Википедияһы (Başķort Vikipediya)	Active	Bashkir	Cyrl	ba	bak	63,889	71	https://ba.wikipedia.org
+Irish Wikipedia	Vicipéid na Gaeilge	Active	Irish	Latn	ga	gle	62,194	81	https://ga.wikipedia.org
+Sundanese Wikipedia	Wikipédia basa Sunda	Active	Sundanese	Latn	su	sun	62,056	54	https://su.wikipedia.org
+Icelandic Wikipedia	Íslenska Wikipedia	Active	Icelandic	Latn	is	isl	60,442	163	https://is.wikipedia.org
+Silesian Wikipedia	Ślůnsko Wikipedyjo	Active	Silesian	Latn	szl	szl	59,100	43	https://szl.wikipedia.org
+Punjabi Wikipedia	ਪੰਜਾਬੀ ਵਿਕੀਪੀਡੀਆ (Pañjābī vikīpīḍīā)	Active	Punjabi	Guru	pa	pan	58,944	99	https://pa.wikipedia.org
+Chuvash Wikipedia	Чăваш Википедийĕ (Russian-based: Căvaš Vikipedijĕ, Turkish-based: Çovaş Vikipyediyö)	Active	Chuvash	Cyrl	cv	chv	57,851	44	https://cv.wikipedia.org
+West Frisian Wikipedia	Frysktalige Wikipedy	Active	West Frisian	Latn	fy	fry	57,667	73	https://fy.wikipedia.org
+Ido Wikipedia	Wikipedio en Ido	Active	Ido	Latn	io	ido	57,287	63	https://io.wikipedia.org
+Aragonese Wikipedia	Biquipedia en aragonés	Active	Aragonese	Latn	an	arg	49,746	67	https://an.wikipedia.org
+Tagalog Wikipedia	Wikipediang Tagalog	Active	Tagalog	Latn	tl	tgl	48,787	163	https://tl.wikipedia.org
+Gilaki Wikipedia	گیلکی ویکیپدیاٰ (Gilɵki vikipɵdiya)	Active	Gilaki	Arab	glk	glk	48,159	16	https://glk.wikipedia.org
+Wu Wikipedia	Traditional Chinese: 吳語維基百科, simplified Chinese: 吴语维基百科 (Romanized: Wu-nyu Vi-ci-pah-khu)	Active	Wu Chinese	Hans/Hant	wuu	wuu	46,252	67	https://wuu.wikipedia.org
+Volapük Wikipedia	Vükiped Volapükik	Active	Volapük	Latn	vo	vol	44,252	34	https://vo.wikipedia.org
+Igbo Wikipedia	Wikipedia Igbo	Active	Igbo	Latn	ig	ibo	43,297	118	https://ig.wikipedia.org
+Zazaki Wikipedia	Wikipediyay Zazaki	Active	Zaza	Latn	diq	diq	42,324	36	https://diq.wikipedia.org
+Yoruba Wikipedia	Wikipéédíà Yorùbá	Active	Yoruba	Latn	yo	yor	35,633	58	https://yo.wikipedia.org
+Scots Wikipedia	Scots Wikipædia	Active	Scots	Latn	sco	sco	34,339	88	https://sco.wikipedia.org
+Kannada Wikipedia	ಕನ್ನಡ ವಿಕಿಪೀಡಿಯ (Kannaḍa vikipīḍiya)	Active	Kannada	Knda	kn	kan	33,917	134	https://kn.wikipedia.org
+Balinese Wikipedia	Wikipédia Basa Bali (ᬯᬶᬓᬶᬧᬾᬤᬶᬬ ᬩᬲᬩᬮᬶ)	Active	Balinese	Latn	ban	ban	32,099	66	https://ban.wikipedia.org
+Alemannic Wikipedia	Alemannische Wikipedia	Active	Alemannic German	Latn	als	als	31,255	68	https://als.wikipedia.org
+Gujarati Wikipedia	ગુજરાતી વિકિપીડિયા (Gujrātī vikipīḍiyā)	Active	Gujarati	Gujr	gu	guj	30,642	58	https://gu.wikipedia.org
+Interlingua Wikipedia	Wikipedia in interlingua	Active	Interlingua	Latn	ia	ina	30,066	46	https://ia.wikipedia.org
+Kotava Wikipedia	Wikipedia men Kotava	Active	Kotava	Latn	avk	avk	29,895	16	https://avk.wikipedia.org
+Nepali Wikipedia	नेपाली विकिपिडिया (Nepālī vikipiḍiyā)	Active	Nepali	Deva	ne	nep	29,686	128	https://ne.wikipedia.org
+Crimean Tatar Wikipedia	Qırımtatarca Vikipediya	Active	Crimean Tatar	Latn	crh	crh	29,586	32	https://crh.wikipedia.org
+Bavarian Wikipedia	Boarische Wikipedia	Active	Bavarian	Latn	bar	bar	27,198	82	https://bar.wikipedia.org
+Sicilian Wikipedia	Wikipedia ’n sicilianu	Active	Sicilian	Latn	scn	scn	26,249	40	https://scn.wikipedia.org
+Mongolian Wikipedia	Монгол Википедиа (Mongol Vikipyedia)	Active	Mongolian	Cyrl	mn	mon	26,058	133	https://mn.wikipedia.org
+Bishnupriya Manipuri Wikipedia	বিষ্ণুপ্রিয়া মণিপুরী উইকিপিডিয়া (Bişnupriya mônipuri u'ikipiḍiẏā)	Active	Bishnupriya Manipuri	Beng	bpy	bpy	25,092	22	https://bpy.wikipedia.org
+Saraiki Wikipedia	سرائیکی ویٖکیٖپیڈیا (Sarā'īkī vikipīḍiyā)	Active	Saraiki	Arab	skr	skr	24,231	22	https://skr.wikipedia.org
+Quechua Wikipedia	Qhichwa Wikipidiya	Active	Quechua (Southern Quechua)	Latn	qu	que	24,175	48	https://qu.wikipedia.org
+Sinhala Wikipedia	සිංහල විකිපීඩියා (Siṁhala wikipīḍiyā)	Active	Sinhala	Sinh	si	sin	24,028	86	https://si.wikipedia.org
+Navajo Wikipedia	Wikiibíídiiya Dinék'ehjí	Active	Navajo	Latn	nv	nav	22,662	22	https://nv.wikipedia.org
+Mingrelian Wikipedia	მარგალური ვიკიპედია (Margaluri vik’ip’edia)	Active	Mingrelian	Geor	xmf	xmf	21,873	32	https://xmf.wikipedia.org
+Ossetian Wikipedia	Ирон Википеди (Iron Vikipedi)	Active	Ossetian	Cyrl	os	oss	21,175	28	https://os.wikipedia.org
+Central Bikol Wikipedia	Wikipedyang Bikol Sentral	Active	Central Bikol	Latn	bcl	bcl	20,748	120	https://bcl.wikipedia.org
+Pashto Wikipedia	پښتو ويکيپېډيا (Pax̌tó wīkīpeḍyā)	Active	Pashto	Arab	ps	pus	20,576	57	https://ps.wikipedia.org
+North Frisian Wikipedia	Nordfriisk Wikipedia	Active	North Frisian	Latn	frr	frr	20,431	31	https://frr.wikipedia.org
+Odia Wikipedia	ଓଡ଼ିଆ ଉଇକିପିଡ଼ିଆ (Oṛiā uikipiṛiā)	Active	Odia	Orya	or	ori	19,725	59	https://or.wikipedia.org
+Sindhi Wikipedia	سنڌي وڪيپيڊيا (Sindhi wikipidia)	Active	Sindhi	Arab	sd	snd	19,297	48	https://sd.wikipedia.org
+Assamese Wikipedia	অসমীয়া ৱিকিপিডিয়া (Ôxômiya wikipidiya)	Active	Assamese	Beng	as	asm	19,267	103	https://as.wikipedia.org
+Tumbuka Wikipedia	Wikipedia Chitumbuka	Active	Tumbuka	Latn	tum	tum	18,802	32	https://tum.wikipedia.org
+Yakut Wikipedia	Сахалыы Бикипиэдьийэ (Sahalyy Bikipieçje)	Active	Yakut	Cyrl	sah	sah	17,673	38	https://sah.wikipedia.org
+Samogitian Wikipedia	Žemaitėška Vikipedėjė	Active	Samogitian	Latn	bat-smg	sgs	17,273	31	https://bat-smg.wikipedia.org
+Eastern Min Wikipedia	Bàng-uâ-cê: Bànguâpedia or Mìng-dĕ̤ng-ngṳ̄ Wikipedia	Active	Eastern Min	Latn	cdo	cdo	16,663	27	https://cdo.wikipedia.org
+Scottish Gaelic Wikipedia	Uicipeid na Gàidhlig	Active	Scottish Gaelic	Latn	gd	gla	15,997	31	https://gd.wikipedia.org
+Buginese Wikipedia	ᨓᨗᨀᨗᨄᨙᨉᨗᨕ ᨅᨔ ᨕᨘᨁᨗ (Wikipedia basa Ugi)	Active	Buginese	Bugi	bug	bug	15,953	14	https://bug.wikipedia.org
+Yiddish Wikipedia	יידישע וויקיפעדיע (Yidishe vikipedye)	Active	Yiddish	Hebr	yi	yid	15,580	52	https://yi.wikipedia.org
+Amharic Wikipedia	አማርኛ ዊኪፔዲያ (Amarəñña wikipediya)	Active	Amharic	Ethi	am	amh	15,442	44	https://am.wikipedia.org
+Ilocano Wikipedia	Wikipedia nga Ilokano	Active	Ilocano	Latn	ilo	ilo	15,425	34	https://ilo.wikipedia.org
+Limburgish Wikipedia	Limburgse Wikipedia	Active	Limburgish	Latn	li	lim	15,116	38	https://li.wikipedia.org
+Neapolitan Wikipedia	Wikipedia napulitana	Active	Neapolitan	Latn	nap	nap	14,934	37	https://nap.wikipedia.org
+Gorontalo Wikipedia	Wikipedia bahasa Hulontalo	Active	Gorontalo	Latn	gor	gor	14,831	26	https://gor.wikipedia.org
+Maithili Wikipedia	मैथिली विकिपिडिया (Maithilī vikipiḍiyā)	Active	Maithili	Deva	mai	mai	14,221	30	https://mai.wikipedia.org
+Faroese Wikipedia	Føroysk Wikipedia	Active	Faroese	Latn	fo	fao	14,166	45	https://fo.wikipedia.org
+Upper Sorbian Wikipedia	Hornjoserbska wikipedija	Active	Upper Sorbian	Latn	hsb	hsb	14,091	30	https://hsb.wikipedia.org
+Shan Wikipedia	ဝီႇၶီႇၽီးတီးယႃးတႆး (Wiː-kʰiː-pʰiː-tiː-jaɑː- táy)	Active	Shan	Mymr	shn	shn	14,010	21	https://shn.wikipedia.org
+Banyumasan Wikipedia	Wikipédia basa Banyumasan	Active	Banyumasan	Latn	map-bms	bany1247	13,929	18	https://map-bms.wikipedia.org
+Classical Chinese Wikipedia	文言維基大典 (Wéijī dàdiǎn wényán)	Active	Classical Chinese	Hant	zh-classical	lzh	13,711	57	https://zh-classical.wikipedia.org
+Santali Wikipedia	ᱥᱟᱱᱛᱟᱲᱤ ᱣᱤᱠᱤᱯᱤᱰᱤᱭᱟ (Santaṛi wikipiḍiya)	Active	Santali	Olck	sat	sat	13,578	40	https://sat.wikipedia.org
+Emilian–Romagnol Wikipedia	Emiliàn e rumagnòl Vichipedèia	Active	Emilian–Romagnol	Latn	eml	eml	13,481	32	https://eml.wikipedia.org
+Interlingue Wikipedia	Wikipedia in Interlingue	Active	Interlingue	Latn	ie	ile	13,271	35	https://ie.wikipedia.org
+Dagbani Wikipedia	Wikipidia Dagbani	Active	Dagbani	Latn	dag	dag	13,173	46	https://dag.wikipedia.org
+Acehnese Wikipedia	Wikipèdia bahsa Acèh	Active	Acehnese	Latn	ace	ace	12,986	29	https://ace.wikipedia.org
+Western Armenian Wikipedia	Արեւմտահայերէն Ուիքիփետիա (Arevmdahayerēn Uikʿipʿetia)	Active	Western Armenian	Armn	hyw	hyw	12,723	34	https://hyw.wikipedia.org
+Walloon Wikipedia	Wikipedia e walon	Active	Walloon	Latn	wa	wln	12,701	24	https://wa.wikipedia.org
+Sanskrit Wikipedia	संस्कृतविकिपीडिया (Saṃskṛta vikipīḍiyā)	Active	Sanskrit	Deva	sa	san	12,320	44	https://sa.wikipedia.org
+Fiji Hindi Wikipedia	Fiji Baat Wikipedia	Active	Fiji Hindi	Latn	hif	hif	11,828	52	https://hif.wikipedia.org
+Moroccan Amazigh Wikipedia	ⵡⵉⴽⵉⴱⵉⴷⵢⴰ ⵜⴰⵎⴰⵣⵉⵖⵜ ⵜⴰⵏⴰⵡⴰⵢⵜ (Wikibidya tamaziɣt tanawayt)	Active	Standard Moroccan Amazigh	Tfng	zgh	zgh	11,811	57	https://zgh.wikipedia.org
+Zulu Wikipedia	Wikipedia isiZulu	Active	Zulu	Latn	zu	zul	11,712	65	https://zu.wikipedia.org
+Khmer Wikipedia	វិគីភីឌាភាសាខ្មែរ (Vikiiphiidiaa phiăsaa khmae)	Active	Khmer	Khmr	km	khm	11,661	75	https://km.wikipedia.org
+Shona Wikipedia	Wikipedhiya chiShona	Active	Shona	Latn	sn	sna	11,491	18	https://sn.wikipedia.org
+Ligurian Wikipedia	Wikipedia Ligure	Active	Ligurian	Latn	lij	lij	11,429	27	https://lij.wikipedia.org
+Banjarese Wikipedia	Wikipidia basa Banjar	Active	Banjarese	Latn	bjn	bjn	11,357	40	https://bjn.wikipedia.org
+Meadow Mari Wikipedia	Олык Марий Википедий (Olyk Marij Vikipedij)	Active	Meadow Mari	Cyrl	mhr	mhr	11,330	25	https://mhr.wikipedia.org
+Shilha Wikipedia	Wikipidya taclḥiyt (ⵡⵉⴽⵉⵒⵉⴷⵢⴰ ⵜⴰⵛⵍⵃⵉⵜ)	Active	Shilha	Latn/Tfng	shi	shi	10,871	23	https://shi.wikipedia.org
+Moroccan Arabic Wikipedia	ويكيبيديا المغربية (Wīkībīdiyā maḡribiyy)	Active	Moroccan Arabic	Arab	ary	ary	10,739	46	https://ary.wikipedia.org
+Fula Wikipedia	Wikipedia Fulfude	Active	Fula	Latn	ff	ful	10,656	47	https://ff.wikipedia.org
+Karakalpak Wikipedia	Qaraqalpaq Wikipediası	Active	Karakalpak	Latn	kaa	kaa	10,477	46	https://kaa.wikipedia.org
+Meitei Wikipedia	ꯃꯤꯇꯩꯂꯣꯟ ꯋꯤꯀꯤꯄꯦꯗꯤꯌꯥ (Meeteilon weekeepaydeeya)	Active	Meitei	Mtei	mni	mni	10,448	25	https://mni.wikipedia.org
+Hill Mari Wikipedia	Кырык марла Википеди (Kyryk marla Vikipedi)	Active	Hill Mari	Cyrl	mrj	mrj	10,430	14	https://mrj.wikipedia.org
+Hakka Wikipedia	Pha̍k-fa-sṳ: Hakkâpedia or Hak-kâ-ngî Wikipedia	Active	Hakka Chinese	Latn	hak	hak	10,359	26	https://hak.wikipedia.org
+Kapampangan Wikipedia	Wikipediang Kapampángan	Active	Kapampangan	Latn	pam	pam	10,134	30	https://pam.wikipedia.org
+Rusyn Wikipedia	Русиньска Вікіпедія (Rusîn'ska Vikipedija)	Active	Rusyn	Cyrl	rue	rue	10,123	41	https://rue.wikipedia.org
+Uyghur Wikipedia	UEY: ئۇيغۇرچە ۋىكىپېدىيە (ULY: Uyghur wikipëdiye) (UYY: Uyghur vikipediyə) (UKY: Уйғур википедийә)	Active	Uyghur	Arab	ug	uig	9,591	29	https://ug.wikipedia.org
+Talysh Wikipedia	Tolyšə Vikipedijə	Active	Talysh	Latn	tly	tly	9,538	22	https://tly.wikipedia.org
+Tarantino Wikipedia	Uicchipèdie tarandíne	Active	Tarantino	Latn	roa-tara	mis	9,492	19	https://roa-tara.wikipedia.org
+Bhojpuri Wikipedia	बिहारी विकिपीडिया (Bihārī vikipīḍiyā)	Active	Bihari (Bhojpuri)	Deva	bh	bih	8,842	44	https://bh.wikipedia.org
+Northern Sotho Wikipedia	Wikipedia Sesotho sa Leboa	Active	Northern Sotho	Latn	nso	nso	8,774	22	https://nso.wikipedia.org
+Corsican Wikipedia	Corsipedia or Wikipedia in lingua corsa	Active	Corsican	Latn	co	cos	8,536	33	https://co.wikipedia.org
+Somali Wikipedia	Soomaali Wikipedia	Active	Somali	Latn	so	som	8,403	73	https://so.wikipedia.org
+Kinyarwanda Wikipedia	Wikipediya mu Ikinyarwanda	Active	Kinyarwanda	Latn	rw	kin	8,203	44	https://rw.wikipedia.org
+West Flemish Wikipedia	West-Vlamse Wikipedia	Active	West Flemish	Latn	vls	vls	8,154	28	https://vls.wikipedia.org
+Dutch Low Saxon Wikipedia	Nedersaksische Wikipedie	Active	Dutch Low Saxon	Latn	nds-nl	nds	8,028	31	https://nds-nl.wikipedia.org
+Māori Wikipedia	Wikipedia Māori	Active	Māori	Latn	mi	mri	7,998	22	https://mi.wikipedia.org
+Northern Sámi Wikipedia	Davvisámegiel Wikipedia	Active	Northern Sámi	Latn	se	sme	7,903	17	https://se.wikipedia.org
+Erzya Wikipedia	Эрзянь Википедия (Erzäń Vikipedija)	Active	Erzya	Cyrl	myv	myv	7,867	22	https://myv.wikipedia.org
+Sardinian Wikipedia	Wikipedia in sardu	Active	Sardinian	Latn	sc	srd	7,711	32	https://sc.wikipedia.org
+Moksha Wikipedia	Мокшень Википедиесь (Mokšenj Vikipedijesʹ)	Active	Moksha	Cyrl	mdf	mdf	7,599	22	https://mdf.wikipedia.org
+Kashmiri Wikipedia	کٲشُر وِکیٖپیٖڈیا (Kạ̄śur vikipīḍiyā)	Active	Kashmiri	Arab	ks	kas	7,553	26	https://ks.wikipedia.org
+Maltese Wikipedia	Wikipedija Malti	Active	Maltese	Latn	mt	mlt	7,512	56	https://mt.wikipedia.org
+Tibetan Wikipedia	བོད་ཡིག་གི་ཝེ་ཁེ་རིག་མཛོད (Wylie: Bod yig gi we khe rig mdzod)	Active	Central Tibetan (Lhasa Tibetan)	Tibt	bo	bod	7,095	54	https://bo.wikipedia.org
+Cornish Wikipedia	Wikipedya Kernowek	Active	Cornish	Latn	kw	cor	7,095	22	https://kw.wikipedia.org
+Veps Wikipedia	Vepsän Vikipedii	Active	Veps	Latn	vep	vep	7,064	25	https://vep.wikipedia.org
+Turkmen Wikipedia	Türkmençe Wikipediýa	Active	Turkmen	Latn	tk	tuk	6,969	33	https://tk.wikipedia.org
+Kabyle Wikipedia	Wikipedia taqbaylit	Active	Kabyle	Latn	kab	kab	6,926	26	https://kab.wikipedia.org
+Manx Wikipedia	Wikipedia yn Gaelg	Active	Manx	Latn	gv	glv	6,874	27	https://gv.wikipedia.org
+Zeelandic Wikipedia	Zeêuwstaelihe Wikipedia	Active	Zeelandic	Latn	zea	zea	6,864	25	https://zea.wikipedia.org
+Võro Wikipedia	Võrokeeline Vikipeediä	Active	Võro	Latn	fiu-vro	vro	6,831	16	https://fiu-vro.wikipedia.org
+Gan Wikipedia	Traditional Chinese: 贛語維基百科, simplified Chinese: 赣语维基百科 (Pha̍k-oa-chhi: Gon wéijī bǎikē)	Active	Gan Chinese	Hans/Hant	gan	gan	6,774	31	https://gan.wikipedia.org
+Abkhaz Wikipedia	Аԥсуа авикипедиа (Apsua avikipedia)	Active	Abkhaz	Cyrl	ab	abk	6,456	26	https://ab.wikipedia.org
+Inari Sámi Wikipedia	Anarâškielâlâš Wikipedia	Active	Inari Sámi	Latn	smn	smn	6,391	25	https://smn.wikipedia.org
+Picard Wikipedia	Wikipédia in lingue picarde	Active	Picard	Latn	pcd	pcd	5,991	25	https://pcd.wikipedia.org
+Guarani Wikipedia	Vikipetã avañe'ẽme	Active	Guarani	Latn	gn	grn	5,930	34	https://gn.wikipedia.org
+Franco-Provençal Wikipedia	Vouiquipèdia en arpetan	Active	Franco-Provençal	Latn	frp	frp	5,805	27	https://frp.wikipedia.org
+Komi Wikipedia	Коми Википедия (Komi Vikipedija)	Active	Komi	Cyrl	kv	kom	5,716	18	https://kv.wikipedia.org
+Udmurt Wikipedia	Удмурт Википедия (Udmurt Vikipedija)	Active	Udmurt	Cyrl	udm	udm	5,712	17	https://udm.wikipedia.org
+Kashubian Wikipedia	Kaszëbskô Wikipedijô	Active	Kashubian	Latn	csb	csb	5,481	24	https://csb.wikipedia.org
+Lao Wikipedia	ວິກິພີເດຍ ພາສາລາວ (Wi ki phī dīa phasa lao)	Active	Lao	Laoo	lo	lao	5,176	43	https://lo.wikipedia.org
+Aymara Wikipedia	Aymar Wikipidiya	Active	Aymara	Latn	ay	aym	5,174	24	https://ay.wikipedia.org
+Norman Wikipedia	Augeron, Cotentinais, Percheron [fr]: Viqùipédie normaunde, Auregnais: Ouitchipédie Nourmaounde, Brayon [fr], Cauchois, Rouennais [fr]: Viqùipédie normande, Guernésiais: Ouitchipédie normande, Jèrriais: Ouitchipédie Nouormande, Sercquiais: Witchipedi Normãdi	Active	Norman	Latn	nrm	nrm	5,054	16	https://nrm.wikipedia.org
+Old English Wikipedia	Engliscan Ƿikipǣdia	Active	Old English	Latn	ang	ang	4,912	47	https://ang.wikipedia.org
+Papiamento Wikipedia	Wikipedia na papiamentu	Active	Papiamento	Latn	pap	pap	4,839	26	https://pap.wikipedia.org
+Friulian Wikipedia	Vichipedie par furlan	Active	Friulian	Latn	fur	fur	4,832	27	https://fur.wikipedia.org
+Lingala Wikipedia	Lingála Wikipedia	Active	Lingala	Latn	ln	lin	4,796	32	https://ln.wikipedia.org
+Livvi-Karelian Wikipedia	Livvinkarjalan Wikipedii	Active	Livvi-Karelian	Latn	olo	olo	4,605	20	https://olo.wikipedia.org
+Twi Wikipedia	Wikipidia Twi	Active	Twi	Latn	tw	twi	4,492	42	https://tw.wikipedia.org
+Lingua Franca Nova Wikipedia	Vicipedia en lingua franca nova	Active	Lingua Franca Nova	Latn	lfn	lfn	4,467	25	https://lfn.wikipedia.org
+Lezgian Wikipedia	Лезги Википедия (Lezgi Vikipediä)	Active	Lezgian	Cyrl	lez	lez	4,437	22	https://lez.wikipedia.org
+Nahuatl Wikipedia	Huiquipedia nāhuatlahtōlcopa	Active	Nahuatl	Latn	nah	nah	4,287	19	https://nah.wikipedia.org
+Mirandese Wikipedia	Biquipédia an lhéngua mirandesa	Active	Mirandese	Latn	mwl	mwl	4,280	14	https://mwl.wikipedia.org
+Saterland Frisian Wikipedia	Seelterfräiske Wikipedia	Active	Saterland Frisian	Latn	stq	stq	4,128	15	https://stq.wikipedia.org
+Extremaduran Wikipedia	Güiquipeya en estremeñu	Active	Extremaduran	Latn	ext	ext	3,936	25	https://ext.wikipedia.org
+Judaeo-Spanish Wikipedia	Vikipedya en lingua Judeo-Espanyola	Active	Judaeo-Spanish	Latn	lad	lad	3,861	28	https://lad.wikipedia.org
+Romansh Wikipedia	Vichipedia rumantscha	Active	Romansh	Latn	rm	roh	3,792	27	https://rm.wikipedia.org
+Tuvan Wikipedia	Тыва Википедия (Tıwa Vikipediya)	Active	Tuvan	Cyrl	tyv	tyv	3,787	14	https://tyv.wikipedia.org
+Luganda Wikipedia	Wikipediya Luganda	Active	Luganda	Latn	lg	lug	3,709	35	https://lg.wikipedia.org
+Avar Wikipedia	Авар Википедия (Avar Vikipedija)	Active	Avar	Cyrl	av	ava	3,643	33	https://av.wikipedia.org
+Konkani Wikipedia	कोंकणी विकिपीडिया (Konknni Wikipidia) (ಕೊಂಕ್ಣಿ ವಿಕಿಪೀಡಿಯಾ)	Active	Konkani (Goan Konkani)	Deva/Latn/Knda	gom	gom	3,639	18	https://gom.wikipedia.org
+Doteli Wikipedia	डोटेली विकिपिडिया (Ḍōṭēlī vikipiḍiyā)	Active	Doteli	Deva	dty	dty	3,602	15	https://dty.wikipedia.org
+Ghanaian Pidgin Wikipedia	Ghanaian Pidgin Wikipedia	Active	Ghanaian Pidgin English	Latn	gpe	gpe	3,562	27	https://gpe.wikipedia.org
+Komi-Permyak Wikipedia	Перем коми Википедия (Perem komi Vikipedija)	Active	Komi-Permyak	Cyrl	koi	koi	3,469	11	https://koi.wikipedia.org
+Lower Sorbian Wikipedia	Dolnoserbska wikipedija	Active	Lower Sorbian	Latn	dsb	dsb	3,425	22	https://dsb.wikipedia.org
+Chavacano Wikipedia	Chavacano Wikipedia	Active	Zamboanga Chavacano	Latn	cbk-zam	cbk	3,230	21	https://cbk-zam.wikipedia.org
+Maldivian Wikipedia	ދިވެހި ވިކިޕީޑިޔާ (Dhivehi vikipīḍiyā)	Active	Maldivian	Thaa	dv	div	3,176	24	https://dv.wikipedia.org
+Betawi Wikipedia	Wikipédi basa Betawi	Active	Betawi	Latn	bew	bew	3,017	21	https://bew.wikipedia.org
+Gagauz Wikipedia	Gagauzca Vikipediya	Active	Gagauz	Latn	gag	gag	3,017	20	https://gag.wikipedia.org
+Zhuang Wikipedia	Veizgiek Bakgoh Vahcuengh	Active	Zhuang (Standard Zhuang)	Latn	za	zha	3,005	17	https://za.wikipedia.org
+Ripuarian Wikipedia	Wikkipedija en Ripoarisch Platt	Active	Ripuarian	Latn	ksh	ksh	3,003	19	https://ksh.wikipedia.org
+Hawaiian Wikipedia	Hawai‘i Wikipikia	Active	Hawaiian	Latn	haw	haw	2,946	30	https://haw.wikipedia.org
+Pa'O Wikipedia	ပအိုဝ်ႏဝီခီပီးဒီးယား (Pǎʼǒ wikhipi:di:ya)	Active	Pa'O	Mymr	blk	blk	2,892	20	https://blk.wikipedia.org
+Buryat Wikipedia	Буряад Википеэди (Buryaad Vikipjeedi)	Active	Buryat (Russia Buriat)	Cyrl	bxr	bxr	2,874	27	https://bxr.wikipedia.org
+Tulu Wikipedia	ತುಳು ವಿಕಿಪೀಡಿಯ (Tuḷu vikipīḍiya)	Active	Tulu	Knda	tcy	tcy	2,846	24	https://tcy.wikipedia.org
+Palatine German Wikipedia	Pälzisch Wikipedia	Active	Palatine German	Latn	pfl	pfl	2,824	12	https://pfl.wikipedia.org
+Sakizaya Wikipedia	Wikipitiya nu Sakizaya	Active	Sakizaya	Latn	szy	szy	2,734	18	https://szy.wikipedia.org
+Pangasinan Wikipedia	Wikipedia Pangasinan	Active	Pangasinan	Latn	pag	pag	2,617	14	https://pag.wikipedia.org
+Karachay-Balkar Wikipedia	Къарачай-Малкъар Википедия (Qaraçay-Malqar Wikipédiya)	Active	Karachay-Balkar	Cyrl	krc	krc	2,591	18	https://krc.wikipedia.org
+Komering Wikipedia	Wikipidiya basa Kumoring	Active	Komering	Latn	kge	kge	2,590	7	https://kge.wikipedia.org
+Atayal Wikipedia	Wikibitia na Tayal	Active	Atayal	Latn	tay	tay	2,583	8	https://tay.wikipedia.org
+Fon Wikipedia	Wikipedya ɖò Fɔngbemɛ	Active	Fon	Latn	fon	fon	2,573	23	https://fon.wikipedia.org
+Pali Wikipedia	पालि विकिपीडिया (Pāli vikipīḍiyā)	Active	Pali	Deva	pi	pli	2,545	6	https://pi.wikipedia.org
+Awadhi Wikipedia	अवधी विकिपीडिया (Avadhī vikipīḍiyā)	Active	Awadhi	Deva	awa	awa	2,513	19	https://awa.wikipedia.org
+Dagaare Wikipedia	Dagaare Wikipiideɛ	Active	Dagaare	Latn	dga	dga	2,440	15	https://dga.wikipedia.org
+Ingush Wikipedia	Гӏалгӏай Википеди (Ghalghaj Vikipedi)	Active	Ingush	Cyrl	inh	inh	2,405	14	https://inh.wikipedia.org
+Tswana Wikipedia	Wikipedia Setswana	Active	Tswana	Latn	tn	tsn	2,398	55	https://tn.wikipedia.org
+Xhosa Wikipedia	Wikipedia isiXhosa	Active	Xhosa	Latn	xh	xho	2,290	33	https://xh.wikipedia.org
+Atikamekw Wikipedia	Atikamekw Wikipetcia	Active	Atikamekw	Latn	atj	atj	2,075	11	https://atj.wikipedia.org
+Pennsylvania Dutch Wikipedia	Pennsilfaanisch-Deitsche Wikipedelche	Active	Pennsylvania Dutch	Latn	pdc	pdc	2,034	33	https://pdc.wikipedia.org
+Tongan Wikipedia	Wikipedia ʻi lea fakatonga	Active	Tongan	Latn	to	ton	2,023	20	https://to.wikipedia.org
+Mon Wikipedia	ဝဳကဳပဳဒဳယာမန် (Wīkīpīdīya mawn)	Active	Mon	Mymr	mnw	mnw	1,957	15	https://mnw.wikipedia.org
+Oromo Wikipedia	Oromoo Wikipedia	Active	Oromo	Latn	om	orm	1,954	17	https://om.wikipedia.org
+Classical Syriac Wikipedia	ܘܝܩܝܦܕܝܐ ܠܫܢܐ ܣܘܪܝܝܐ (Wīqīpedyāʾ leššānā suryāyā)	Active	Aramaic (Syriac)	Syrc	arc	arc	1,915	19	https://arc.wikipedia.org
+Madurese Wikipedia	Wikipèḍia bhâsa Madhurâ	Active	Madurese	Latn	mad	mad	1,904	44	https://mad.wikipedia.org
+Kikuyu Wikipedia	Wikipedia Gĩgĩkũyũ	Active	Kikuyu	Latn	ki	kik	1,883	16	https://ki.wikipedia.org
+Novial Wikipedia	Wikipedie in novial	Active	Novial	Latn	nov	nov	1,877	19	https://nov.wikipedia.org
+Nias Wikipedia	Wikipedia Li Niha	Active	Nias	Latn	nia	nia	1,760	9	https://nia.wikipedia.org
+Wolof Wikipedia	Wikipedia Wolof	Active	Wolof	Latn	wo	wol	1,736	21	https://wo.wikipedia.org
+Jamaican Patois Wikipedia	Jumiekan Patwa Wikipidia	Active	Jamaican Patois	Latn	jam	jam	1,731	20	https://jam.wikipedia.org
+Kabiye Wikipedia	Wikipediya kabɩyɛ	Active	Kabiye	Latn	kbp	kbp	1,714	11	https://kbp.wikipedia.org
+Iban Wikipedia	Iban Wikipedia	Active	Iban	Latn	iba	iba	1,676	17	https://iba.wikipedia.org
+Dusun Wikipedia	Wikipedia Kadazandusun	Active	Dusun	Latn	dtp	dtp	1,671	19	https://dtp.wikipedia.org
+Kalmyk Wikipedia	Хальмг Бикипеди (Haľmg Vikipedi)	Active	Kalmyk Oirat	Cyrl	xal	xal	1,655	11	https://xal.wikipedia.org
+Kabardian Wikipedia	Адыгэбзэ Уикипедиэ (Adıgəbzə Wikipediă)	Active	Kabardian	Cyrl	kbd	kbd	1,647	15	https://kbd.wikipedia.org
+Angika Wikipedia	विकिपीडिया	Active	Angika	Deva	anp	anp	1,645	13	https://anp.wikipedia.org
+Fijian Wikipedia	Vaka-Viti Wikipedia	Active	Fijian	Latn	fj	fij	1,583	13	https://fj.wikipedia.org
+Kongo Wikipedia	Wikipedia kikôngo	Active	Kongo	Latn	kg	kon	1,563	24	https://kg.wikipedia.org
+N'Ko Wikipedia	ߥߞߌߔߘߋߞߎ ߒߞߏ (Wkipdeku n'ko)	Active	N'Ko	Nkoo	nqo	nqo	1,547	19	https://nqo.wikipedia.org
+Gun Wikipedia	Gungbe Wikipedia	Active	Gun	Latn	guw	guw	1,543	12	https://guw.wikipedia.org
+Nigerian Pidgin Wikipedia	Naijá Wikipedia	Active	Nigerian Pidgin	Latn	pcm	pcm	1,500	20	https://pcm.wikipedia.org
+Sotho Wikipedia	Wikipedia Sesotho	Active	Sotho	Latn	st	sot	1,482	40	https://st.wikipedia.org
+Bislama Wikipedia	Wikipedia long Bislama	Active	Bislama	Latn	bi	bis	1,476	18	https://bi.wikipedia.org
+Tyap Wikipedia	Wukipedia nTyap	Active	Tyap	Latn	kcg	kcg	1,406	18	https://kcg.wikipedia.org
+Central Kanuri Wikipedia		Active	Central Kanuri	Latn	knc	knc	1,401	15	https://knc.wikipedia.org
+Tok Pisin Wikipedia	Wikipedia long Tok Pisin	Active	Tok Pisin	Latn	tpi	tpi	1,395	19	https://tpi.wikipedia.org
+Aromanian Wikipedia	Wikipedia pri Armâneaști	Active	Aromanian	Latn	roa-rup	rup	1,388	12	https://roa-rup.wikipedia.org
+Tetum Wikipedia	Wikipédia iha lia-tetun	Active	Tetum	Latn	tet	tet	1,381	14	https://tet.wikipedia.org
+Lojban Wikipedia	ni'o la .uikipedi'as. pe lo jbobau	Active	Lojban	Latn	jbo	jbo	1,340	17	https://jbo.wikipedia.org
+Old Church Slavonic Wikipedia	Словѣньска Википєдїꙗ (Slověnĭska Vikipedija)	Active	Old Church Slavonic	Cyrs	cu	chu	1,305	23	https://cu.wikipedia.org
+Mooré Wikipedia	Wikipidiya Mossi	Active	Mooré	Latn	mos	mos	1,294	30	https://mos.wikipedia.org
+Lak Wikipedia	Лакку мазрал Википедия (Lak:u mazral Vikipediaˤ)	Active	Lak	Cyrl	lbe	lbe	1,261	19	https://lbe.wikipedia.org
+Tahitian Wikipedia	Vitipetia Reo Tahiti	Active	Tahitian	Latn	ty	tah	1,233	14	https://ty.wikipedia.org
+Ewe Wikipedia	Wikipiɖia Eʋegbe	Active	Ewe	Latn	ee	ewe	1,221	24	https://ee.wikipedia.org
+Seediq Wikipedia	Seediq Wikipidiya	Active	Seediq	Latn	trv	trv	1,201	13	https://trv.wikipedia.org
+Kusaal Wikipedia	Wikipiidia Kʋsaal	Active	Kusaal	Latn	kus	kus	1,183	10	https://kus.wikipedia.org
+Samoan Wikipedia	Wikipedia gagana Sāmoa	Active	Samoan	Latn	sm	smo	1,175	14	https://sm.wikipedia.org
+Sylheti Wikipedia		Active	Sylheti	Sylo	syl	syl	1,170	13	https://syl.wikipedia.org
+Mandailing Batak Wikipedia	Wikipedia Saro Mandailing	Active	Mandailing Batak	Latn	btm	btm	1,167	10	https://btm.wikipedia.org
+Gurene Wikipedia	Gurenɛ Wikipedia	Active	Farefare (Gurene)	Latn	gur	gur	1,166	19	https://gur.wikipedia.org
+Amis Wikipedia	Wikipitiya 'Amis	Active	Amis	Latn	ami	ami	1,144	10	https://ami.wikipedia.org
+Sranan Tongo Wikipedia	Sranan Wikipedia	Active	Sranan Tongo	Latn	srn	srn	1,130	11	https://srn.wikipedia.org
+Swazi Wikipedia	Wikipedia siSwati	Active	Swazi	Latn	ss	ssw	1,125	24	https://ss.wikipedia.org
+Toba Batak Wikipedia	Wikipedia Batak Toba	Active	Toba Batak	Latn	bbc	bbc	1,122	13	https://bbc.wikipedia.org
+Southern Altai Wikipedia	Тӱштӱк алтай Википедия (Tüštük altay Vikipediya)	Active	Southern Altai	Cyrl	alt	alt	1,101	11	https://alt.wikipedia.org
+Latgalian Wikipedia	Vikipedeja latgaļu volūdā	Active	Latgalian	Latn	ltg	ltg	1,095	14	https://ltg.wikipedia.org
+Fante Wikipedia	Fante Wikipedia	Active	Fante	Latn	fat	fat	1,091	13	https://fat.wikipedia.org
+Chewa Wikipedia	Wikipedia Chichewa	Active	Chewa	Latn	ny	nya	1,087	17	https://ny.wikipedia.org
+Guianan Creole Wikipedia	Wikipédja an kriyòl gwiyannen	Active	French Guianese Creole	Latn	gcr	gcr	1,073	11	https://gcr.wikipedia.org
+Cherokee Wikipedia	ᏫᎩᏇᏗᏯ ᏣᎳᎩ (Wigiquediya tsalagi)	Active	Cherokee	Cher	chr	chr	1,000	25	https://chr.wikipedia.org
+Gothic Wikipedia	𐌲𐌿𐍄𐌹𐍃𐌺 𐍅𐌹𐌺𐌹𐍀𐌰𐌹𐌳𐌾𐌰 (Gutisk wikipaidja)	Active	Gothic	Goth	got	got	965	19	https://got.wikipedia.org
+Tsonga Wikipedia	Wikipediya Xitsonga	Active	Tsonga	Latn	ts	tso	949	19	https://ts.wikipedia.org
+Igala Wikipedia	Wikipídiya Igala	Active	Igala	Latn	igl	igl	910	5	https://igl.wikipedia.org
+Bambara Wikipedia	Wikipedi Bamanankan	Active	Bambara	Latn	bm	bam	897	14	https://bm.wikipedia.org
+Venda Wikipedia	Wikipedia nga tshiVenḓa	Active	Venda	Latn	ve	ven	824	18	https://ve.wikipedia.org
+Pannonian Rusyn Wikipedia	Википедия на панонским руским язику (Vikipedija na panonskim ruskim yaziku)	Active	Pannonian Rusyn	Cyrl	rsk	rsk	823	10	https://rsk.wikipedia.org
+Romani Wikipedia	Romani Vikipidiya	Active	Romani (Vlax Romani)	Latn	rmy	rmy	759	12	https://rmy.wikipedia.org
+Cheyenne Wikipedia	Vekepete'a Tsėhésenėstsestȯtse	Active	Cheyenne	Latn	chy	chy	723	12	https://chy.wikipedia.org
+Kirundi Wikipedia	Wikipediya mu Ikirundi	Active	Kirundi	Latn	rn	run	703	23	https://rn.wikipedia.org
+Wayuu Wikipedia	Wikipeetia süka wayuunaiki	Active	Wayuu	Latn	guc	guc	681	23	https://guc.wikipedia.org
+Iñupiaq Wikipedia	Uiqipitia Iñupiatun	Active	Iñupiaq	Latn	ik	ipk	600	19	https://ik.wikipedia.org
+Adyghe Wikipedia	Адыгэ Википедие (Adıgə Vikipedie)	Active	Adyghe	Cyrl	ady	ady	575	16	https://ady.wikipedia.org
+Chamorro Wikipedia	Wikipedia Chamoru	Active	Chamorro	Latn	ch	cha	558	12	https://ch.wikipedia.org
+Pontic Wikipedia	Ποντιακόν Βικιπαίδεια (Pontiakón Bikipaídeia)	Active	Pontic Greek	Grek	pnt	pnt	490	12	https://pnt.wikipedia.org
+Nupe Wikipedia	Wikipedia Nya Nupe	Active	Nupe	Latn	nup	nup	432	13	https://nup.wikipedia.org
+Obolo Wikipedia	Wìkìpedia Usem Obolo	Active	Obolo	Latn	ann	ann	429	7	https://ann.wikipedia.org
+Inuktitut Wikipedia	ᐃᓄᒃᑎᑐᑦ ᐊᕆᐅᙵᐃᐹ (Uikipitia inuktitut)	Active	Inuktitut	Cans	iu	iku	428	27	https://iu.wikipedia.org
+Paiwan Wikipedia	wikipidiya nua pinayuanan	Active	Paiwan	Latn	pwn	pwn	373	8	https://pwn.wikipedia.org
+Sango Wikipedia	Wïkïpêdïyäa na Sängö	Active	Sango	Latn	sg	sag	356	11	https://sg.wikipedia.org
+Tai Nuea Wikipedia	ᥝᥤᥱ ᥑᥤᥱ ᥚᥤᥱ ᥖᥤᥱ ᥕᥣᥱ ᥖᥭᥰ ᥖᥬᥲ ᥑᥨᥒᥰ	Active	Tai Nuea	Tale	tdd	tdd	339	5	https://tdd.wikipedia.org
+Tigrinya Wikipedia	ዊኪፐድያ ብትግርኛ (Wikipädya bətəgrəñña)	Active	Tigrinya	Ethi	ti	tir	338	16	https://ti.wikipedia.org
+Dinka Wikipedia	Wikipedia Thuɔŋjäŋ	Active	Dinka	Latn	din	din	338	12	https://din.wikipedia.org
+Dzongkha Wikipedia	རྫོང་ཁ་ཝེ་ཁེ་རིག་མཛོད (Rdzong kha we khe rig mdzod)	Active	Dzongkha	Tibt	dz	dzo	323	23	https://dz.wikipedia.org
+Greenlandic Wikipedia	Kalaallisut Wikipedia	Active	Greenlandic	Latn	kl	kal	245	14	https://kl.wikipedia.org
+Bajau Sama Wikipedia	Wikipidia Bajau Sama	Active	West Coast Bajau	Latn	bdr	bdr	236	13	https://bdr.wikipedia.org
+Southern Ndebele Wikipedia	Wikiphidiya yelimi lesiNdebele	Active	Southern Ndebele	Latn	nr	nbl	212	34	https://nr.wikipedia.org
+Tigre Wikipedia	ዊኪፒድያ ህግየ ትግሬ	Active	Tigre	Ethi	tig	tig	39	8	https://tig.wikipedia.org
+Cree Wikipedia	ᐎᑭᐱᑎᔭ ᓀᐦᐃᔭᐍᐏᐣ (Wikipitiya nēhiyawēwin)	Active	Cree	Cans	cr	cre	13	21	https://cr.wikipedia.org
+Ndonga Wikipedia (closed)		Closed	Ovambo (Ndonga)	Latn	ng	ndo	8	2	https://ng.wikipedia.org
+Choctaw Wikipedia (closed)		Closed	Choctaw	Latn	cho	cho	6	1	https://cho.wikipedia.org
+Kwanyama Wikipedia (closed)		Closed	Ovambo (Kwanyama)	Latn	kj	kua	4	1	https://kj.wikipedia.org
+Marshallese Wikipedia (closed)		Closed	Marshallese	Latn	mh	mah	4	1	https://mh.wikipedia.org
+Sichuan Yi Wikipedia (closed)		Closed	Nuosu	Yiii	ii	iii	3	2	https://ii.wikipedia.org
+Hiri Motu Wikipedia (closed)		Closed	Hiri Motu	Latn	ho	hmo	3	1	https://ho.wikipedia.org
+Northern Luri Wikipedia (locked)		Closed	Northern Luri	Arab	lrc	lrc	1	2	https://lrc.wikipedia.org
+Muscogee Wikipedia (closed)		Closed	Muscogee	Latn	mus	mus	1	1	https://mus.wikipedia.org
+Akan Wikipedia (closed)	Wikipidia Akan	Closed	Akan	Latn	ak (closed)	aka	0	11	https://ak.wikipedia.org
+Norfuk Wikipedia (locked)	Norfuk Wikkapedya	Closed	Norfuk	Latn	pih	pih	0	9	https://pih.wikipedia.org
+Nauruan Wikipedia (locked)	Wikipediya Naoero	Closed	Nauruan	Latn	na	nau	0	8	https://na.wikipedia.org
+Afar Wikipedia (closed)		Closed	Afar	Latn	aa	aa	0	3	https://aa.wikipedia.org
+Herero Wikipedia (closed)		Closed	Herero	Latn	hz	hz	0	1	https://hz.wikipedia.org
+Kanuri Wikipedia (closed)		Closed	Kanuri	Latn	kr	kr	0	1	https://kr.wikipedia.org
+Wikipedia 10 (closed)	Wikipedia 10	Closed	English	Latn	ten	mis	0	0	https://ten.wikipedia.org
+Klingon Wikipedia (deleted)		Deleted	Klingon	Latn	tlh	tlh	0	0	https://tlh.wikipedia.org
+Moldovan Wikipedia (deleted)		Deleted	Romanian (Moldovan)	Cyrl	mo	mold1248	0	0	https://mo.wikipedia.org
+September 11 Wiki (deleted)	September 11 Wiki	Deleted	English	Latn	Sep11	mis	0	0	https://sep11.wikipedia.org
+Siberian Wikipedia (deleted)		Deleted	fictitious "artificial Siberian language"	Cyrl	ru-sib	mis	0	0	https://ru-sib.wikipedia.org
+Toki Pona Wikipedia (deleted)		Deleted	Toki Pona	Latn	tokipona	tok	0	0	https://tokipona.wikipedia.org
+Test Wikipedia	Test Wikipedia	Closed	English	Latn	test	mis	0	0	https://test.wikipedia.org
+Test2 Wikipedia	Test2 Wikipedia	Closed	English	Latn	test2	mis	0	0	https://test2.wikipedia.org
+Nostalgia Wikipedia	Nostalgia Wikipedia	Closed	English	Latn	nostalgia	mis	0	0	https://nostalgia.wikipedia.org
+Wikipedia Afar	Qafár af	Incubator			aa	aar			https://incubator.wikimedia.org/wiki/Wp/aa
+Wikipedia Arbëresh	Arbërisht	Incubator			aae	aae			https://incubator.wikimedia.org/wiki/Wp/aae
+Wikipedia Bono	Bron	Incubator			abr	abr			https://incubator.wikimedia.org/wiki/Wp/abr
+Wikipedia Saint Lucian Creole	Kwéyòl	Incubator			acf	acf			https://incubator.wikimedia.org/wiki/Wp/acf
+Wikipedia Acholi	Acoli	Incubator			ach	ach			https://incubator.wikimedia.org/wiki/Wp/ach
+Wikipedia Mesopotamian Arabic	اللهجة العراقية	Incubator			acm	acm			https://incubator.wikimedia.org/wiki/Wp/acm
+Wikipedia Adangme	Dangbe	Incubator			ada	ada			https://incubator.wikimedia.org/wiki/Wp/ada
+Wikipedia Tunisian Arabic	تونسي/ Tounsi	Incubator			aeb	aeb			https://incubator.wikimedia.org/wiki/Wp/aeb
+Wikipedia Gulf Arabic	خليجي	Incubator			afb	afb			https://incubator.wikimedia.org/wiki/Wp/afb
+Wikipedia Ahirani	खान्देशी	Incubator			ahr	ahr			https://incubator.wikimedia.org/wiki/Wp/ahr
+Wikipedia Antiguan and Barbudan Creole	Aanteegan an' Baabyuudan	Incubator			aig	aig			https://incubator.wikimedia.org/wiki/Wp/aig
+Wikipedia Assyrian Neo-Aramaic	ܣܘܪܝܬ	Incubator			aii	aii			https://incubator.wikimedia.org/wiki/Wp/aii
+Wikipedia Ainu	アイヌ・イタㇰ / Aynu itak	Incubator			ain	ain			https://incubator.wikimedia.org/wiki/Wp/ain
+Wikipedia Adja	Adja	Incubator			ajg	ajg			https://incubator.wikimedia.org/wiki/Wp/ajg
+Wikipedia Judeo-Moroccan Arabic	מרוקאית יהודית	Incubator			aju	aju			https://incubator.wikimedia.org/wiki/Wp/aju
+Wikipedia Akpa	Akweya	Incubator			akf	akf			https://incubator.wikimedia.org/wiki/Wp/akf
+Wikipedia Anakalangu	akg	Incubator			akg	akg			https://incubator.wikimedia.org/wiki/Wp/akg
+Wikipedia Aklanon	Akeanon	Incubator			akl	akl			https://incubator.wikimedia.org/wiki/Wp/akl
+Wikipedia Araki	Soro-n Raki	Incubator			akr	akr			https://incubator.wikimedia.org/wiki/Wp/akr
+Wikipedia Alabama	Albaamo innaaɬiilka	Incubator			akz	akz			https://incubator.wikimedia.org/wiki/Wp/akz
+Wikipedia Aleut	Уна́ӈам тунуу́	Incubator			ale	ale			https://incubator.wikimedia.org/wiki/Wp/ale
+Wikipedia Gheg Albanian	Gegnisht	Incubator			aln	aln			https://incubator.wikimedia.org/wiki/Wp/aln
+Wikipedia Guerrero Amuzgo	Ñomndaa	Incubator			amu	amu			https://incubator.wikimedia.org/wiki/Wp/amu
+Wikipedia Obolo	Andoni	Incubator			ann	ann			https://incubator.wikimedia.org/wiki/Wp/ann
+Wikipedia Pemon	Arecuna	Incubator			aoc	aoc			https://incubator.wikimedia.org/wiki/Wp/aoc
+Wikipedia Levantine Arabic	الـلَّـهْـجَـةُ الـشَّـامِـيَّـة	Incubator			apc	apc			https://incubator.wikimedia.org/wiki/Wp/apc
+Wikipedia Western Apache	Ndee biyátiʼ	Incubator			apw	apw			https://incubator.wikimedia.org/wiki/Wp/apw
+Wikipedia Mapudungun	Mapudungun	Incubator			arn	arn			https://incubator.wikimedia.org/wiki/Wp/arn
+Wikipedia Araona	Orqnchi'a Aqoana	Incubator			aro	aro			https://incubator.wikimedia.org/wiki/Wp/aro
+Wikipedia Algerian Arabic	جازايريه	Incubator			arq	arq			https://incubator.wikimedia.org/wiki/Wp/arq
+Wikipedia Najdi Arabic	اللهجة النجدية	Incubator			ars	ars			https://incubator.wikimedia.org/wiki/Wp/ars
+Wikipedia American Sign	American sign language	Incubator			ase	ase			https://incubator.wikimedia.org/wiki/Wp/ase
+Wikipedia Libyan Arabic	ليبي	Incubator			ayl	ayl			https://incubator.wikimedia.org/wiki/Wp/ayl
+Wikipedia Balochi	بلوچی	Incubator			bal	bal			https://incubator.wikimedia.org/wiki/Wp/bal
+Wikipedia Bamum	ꚶꛉ꛰꛲ꚫꛦꚳ	Incubator			bax	bax			https://incubator.wikimedia.org/wiki/Wp/bax
+Wikipedia Ghomala'	Ghɔmálá’	Incubator			bbj	bbj			https://incubator.wikimedia.org/wiki/Wp/bbj
+Wikipedia Central Bai	Bairt ngvrt zix	Incubator			bca	bca			https://incubator.wikimedia.org/wiki/Wp/bca
+Wikipedia Southern Baluchi	جهلسری بلوچی	Incubator			bcc	bcc			https://incubator.wikimedia.org/wiki/Wp/bcc
+Wikipedia Baoulé	Baoulé	Incubator			bci	bci			https://incubator.wikimedia.org/wiki/Wp/bci
+Wikipedia Bemba	Chibemba	Incubator			bem	bem			https://incubator.wikimedia.org/wiki/Wp/bem
+Wikipedia Bari	Karo	Incubator			bfa	bfa			https://incubator.wikimedia.org/wiki/Wp/bfa
+Wikipedia Badaga	படக பாஷை	Incubator			bfq	bfq			https://incubator.wikimedia.org/wiki/Wp/bfq
+Wikipedia Haryanvi	हरियाणवी /ہریاݨوی	Incubator			bgc	bgc			https://incubator.wikimedia.org/wiki/Wp/bgc
+Wikipedia Western Baluchi	روچ کپتین بلوچی	Incubator			bgn	bgn			https://incubator.wikimedia.org/wiki/Wp/bgn
+Wikipedia Eastern Balochi	Balòci	Incubator			bgp	bgp			https://incubator.wikimedia.org/wiki/Wp/bgp
+Wikipedia Balkan Gagauz Turkish	Rumeli	Incubator			bgx	bgx			https://incubator.wikimedia.org/wiki/Wp/bgx
+Wikipedia Banggai	Banggai	Incubator			bgz	bgz			https://incubator.wikimedia.org/wiki/Wp/bgz
+Wikipedia Bhili	भीली	Incubator			bhb	bhb			https://incubator.wikimedia.org/wiki/Wp/bhb
+Wikipedia Bukhori	Bukhori	Incubator			bhh	bhh			https://incubator.wikimedia.org/wiki/Wp/bhh
+Wikipedia Bhilali	भीलाली	Incubator			bhi	bhi			https://incubator.wikimedia.org/wiki/Wp/bhi
+Wikipedia Bima	Nggahi Mbojo	Incubator			bhp	bhp			https://incubator.wikimedia.org/wiki/Wp/bhp
+Wikipedia Edo	Ẹ̀dó	Incubator			bin	bin			https://incubator.wikimedia.org/wiki/Wp/bin
+Wikipedia Kom	Itaŋikom	Incubator			bkm	bkm			https://incubator.wikimedia.org/wiki/Wp/bkm
+Wikipedia Bunun	Bunun	Incubator			bnn	bnn			https://incubator.wikimedia.org/wiki/Wp/bnn
+Wikipedia Asi	Bantoanon	Incubator			bno	bno			https://incubator.wikimedia.org/wiki/Wp/bno
+Wikipedia Bole	bòo pìkkà	Incubator			bol	bol			https://incubator.wikimedia.org/wiki/Wp/bol
+Wikipedia Botlikh	Буйхалъи мицIцIи	Incubator			bph	bph			https://incubator.wikimedia.org/wiki/Wp/bph
+Wikipedia Bakhtiari	بختیاری	Incubator			bqi	bqi			https://incubator.wikimedia.org/wiki/Wp/bqi
+Wikipedia Braj	ब्रज / ब्रजभाषा	Incubator			bra	bra			https://incubator.wikimedia.org/wiki/Wp/bra
+Wikipedia Brahui	Bráhuí /براوی	Incubator			brh	brh			https://incubator.wikimedia.org/wiki/Wp/brh
+Wikipedia Bodo	बर'	Incubator			brx	brx			https://incubator.wikimedia.org/wiki/Wp/brx
+Wikipedia Kata-vari	Kâta-vari	Incubator			bsh	bsh			https://incubator.wikimedia.org/wiki/Wp/bsh
+Wikipedia Biatah	bth	Incubator			bth	bth			https://incubator.wikimedia.org/wiki/Wp/bth
+Wikipedia Rinconada	Iriga Bicolano	Incubator			bto	bto			https://incubator.wikimedia.org/wiki/Wp/bto
+Wikipedia Batak Simalungun	Sahap Simalungun	Incubator			bts	bts			https://incubator.wikimedia.org/wiki/Wp/bts
+Wikipedia Batak Karo	Cakap Karo	Incubator			btx	btx			https://incubator.wikimedia.org/wiki/Wp/btx
+Wikipedia Alas	Batak Alas	Incubator			btz	btz			https://incubator.wikimedia.org/wiki/Wp/btz
+Wikipedia Bura	Bura-Pabir	Incubator			bwr	bwr			https://incubator.wikimedia.org/wiki/Wp/bwr
+Wikipedia Belizean Creole	Kriol	Incubator			bzj	bzj			https://incubator.wikimedia.org/wiki/Wp/bzj
+Wikipedia Kaqchikel	Kaqchikel Ch'ab'äl	Incubator			cak	cak			https://incubator.wikimedia.org/wiki/Wp/cak
+Wikipedia Chakma	𑄌𑄋𑄴𑄟𑄳𑄦 𑄞𑄌𑄴	Incubator			ccp	ccp			https://incubator.wikimedia.org/wiki/Wp/ccp
+Wikipedia Chibcha	Muysccubun	Incubator			chb	chb			https://incubator.wikimedia.org/wiki/Wp/chb
+Wikipedia Chinook Jargon	chinuk-wawa	Incubator			chn	chn			https://incubator.wikimedia.org/wiki/Wp/chn
+Wikipedia Choctaw	Choctaw	Incubator			cho	cho			https://incubator.wikimedia.org/wiki/Wp/cho
+Wikipedia Cia-Cia	바하사 찌아찌아	Incubator			cia	cia			https://incubator.wikimedia.org/wiki/Wp/cia
+Wikipedia Southwestern Ojibwe	Ojibwemowin, Anishinaabemowin	Incubator			ciw	ciw			https://incubator.wikimedia.org/wiki/Wp/ciw
+Wikipedia Eastern Cham	bạhsa Cam	Incubator			cjm	cjm			https://incubator.wikimedia.org/wiki/Wp/cjm
+Wikipedia Shor	Шор тили	Incubator			cjs	cjs			https://incubator.wikimedia.org/wiki/Wp/cjs
+Wikipedia Jin Chinese	晉語 / 晋语	Incubator			cjy	cjy			https://incubator.wikimedia.org/wiki/Wp/cjy
+Wikipedia Anufo	Anufɔ	Incubator			cko	cko			https://incubator.wikimedia.org/wiki/Wp/cko
+Wikipedia Chukchi	Ԓыгъоравэтԓьэн йиԓыйиԓ	Incubator			ckt	ckt			https://incubator.wikimedia.org/wiki/Wp/ckt
+Wikipedia Kavalan	Kbaran	Incubator			ckv	ckv			https://incubator.wikimedia.org/wiki/Wp/ckv
+Wikipedia Klallam	nəxʷsƛ̕ay̕əmúcən	Incubator			clm	clm			https://incubator.wikimedia.org/wiki/Wp/clm
+Wikipedia Chulym	Ось тили	Incubator			clw	clw			https://incubator.wikimedia.org/wiki/Wp/clw
+Wikipedia Northern Qiang	Rrmearr	Incubator			cng	cng			https://incubator.wikimedia.org/wiki/Wp/cng
+Wikipedia Asháninka	Asháninka	Incubator			cni	cni			https://incubator.wikimedia.org/wiki/Wp/cni
+Wikipedia Montenegrin	Crnogorski	Incubator			cnr	cnr			https://incubator.wikimedia.org/wiki/Wp/cnr
+Wikipedia Shenwa	Haqbaylit̠	Incubator			cnu	cnu			https://incubator.wikimedia.org/wiki/Wp/cnu
+Wikipedia Coptic	ⲘⲉⲧⲢⲉⲙ̀ⲛⲭⲏⲙⲓ / Μετ Ρεμενκημι	Incubator			cop	cop			https://incubator.wikimedia.org/wiki/Wp/cop
+Wikipedia Chinese Pidgin English	Yangjing Bang English / 白鴿英語	Incubator			cpi	cpi			https://incubator.wikimedia.org/wiki/Wp/cpi
+Wikipedia Capiznon	Capiceño	Incubator			cps	cps			https://incubator.wikimedia.org/wiki/Wp/cps
+Wikipedia Pu-Xian Min	Pó-sing-gṳ̂ / 莆仙語	Incubator			cpx	cpx			https://incubator.wikimedia.org/wiki/Wp/cpx
+Wikipedia Plains Cree	nēhiyawēwin	Incubator			crk	crk			https://incubator.wikimedia.org/wiki/Wp/crk
+Wikipedia Seychellois Creole	kreol	Incubator			crs	crs			https://incubator.wikimedia.org/wiki/Wp/crs
+Wikipedia Colombian Sign	Lengua de Señas Colombiana	Incubator			csn	csn			https://incubator.wikimedia.org/wiki/Wp/csn
+Wikipedia Southern Pinghua	桂南平話	Incubator			csp	csp			https://incubator.wikimedia.org/wiki/Wp/csp
+Wikipedia Chittagonian	চাটগাঁইয়া	Incubator			ctg	ctg			https://incubator.wikimedia.org/wiki/Wp/ctg
+Wikipedia Huizhou Chinese	徽語	Incubator			czh	czh			https://incubator.wikimedia.org/wiki/Wp/czh
+Wikipedia Min Zhong	閩中語	Incubator			czo	czo			https://incubator.wikimedia.org/wiki/Wp/czo
+Wikipedia Dargwa	Дарган	Incubator			dar	dar			https://incubator.wikimedia.org/wiki/Wp/dar
+Wikipedia Dendi	Dendi cinɛ	Incubator			ddn	ddn			https://incubator.wikimedia.org/wiki/Wp/ddn
+Wikipedia Tsez	цезйас мец	Incubator			ddo	ddo			https://incubator.wikimedia.org/wiki/Wp/ddo
+Wikipedia Dogri	डोगरी	Incubator			dgo	dgo			https://incubator.wikimedia.org/wiki/Wp/dgo
+Wikipedia Dimasa	Grao-Dima	Incubator			dis	dis			https://incubator.wikimedia.org/wiki/Wp/dis
+Wikipedia Zarma	Zarma ciine	Incubator			dje	dje			https://incubator.wikimedia.org/wiki/Wp/dje
+Wikipedia Dolgan	Долган тыла	Incubator			dlg	dlg			https://incubator.wikimedia.org/wiki/Wp/dlg
+Wikipedia Dungan	Хуэйзў йүян	Incubator			dng	dng			https://incubator.wikimedia.org/wiki/Wp/dng
+Wikipedia Dan	Yacouba	Incubator			dnj	dnj			https://incubator.wikimedia.org/wiki/Wp/dnj
+Wikipedia Rukai	Rukai	Incubator			dru	dru			https://incubator.wikimedia.org/wiki/Wp/dru
+Wikipedia Duala	Duálá	Incubator			dua	dua			https://incubator.wikimedia.org/wiki/Wp/dua
+Wikipedia Efik	Usem Efịk	Incubator			efi	efi			https://incubator.wikimedia.org/wiki/Wp/efi
+Wikipedia Ekpeye	ẹkpeye	Incubator			ekp	ekp			https://incubator.wikimedia.org/wiki/Wp/ekp
+Wikipedia Eastern Kayah	ကယး လီူး	Incubator			eky	eky			https://incubator.wikimedia.org/wiki/Wp/eky
+Wikipedia Enets	Онэй базаан	Incubator			enf	enf			https://incubator.wikimedia.org/wiki/Wp/enf
+Wikipedia Aheri Gondi	गोण्डि	Incubator			esg	esg			https://incubator.wikimedia.org/wiki/Wp/esg
+Wikipedia Siberian Yupik	Юпик / Yupik	Incubator			ess	ess			https://incubator.wikimedia.org/wiki/Wp/ess
+Wikipedia Central Alaskan Yup'ik	Yugtun	Incubator			esu	esu			https://incubator.wikimedia.org/wiki/Wp/esu
+Wikipedia Evenki	Эвэды̄ турэ̄н	Incubator			evn	evn			https://incubator.wikimedia.org/wiki/Wp/evn
+Wikipedia Meänkieli	meänkieli	Incubator			fit	fit			https://incubator.wikimedia.org/wiki/Wp/fit
+Wikipedia Kven	Kainun	Incubator			fkv	fkv			https://incubator.wikimedia.org/wiki/Wp/fkv
+Wikipedia Salish-Spokane-Kalispel	Séliš	Incubator			fla	fla			https://incubator.wikimedia.org/wiki/Wp/fla
+Wikipedia Cajun French	français cadien/français cadjin	Incubator			frc	frc			https://incubator.wikimedia.org/wiki/Wp/frc
+Wikipedia East Frisian Low Saxon	Ōstfräisk	Incubator			frs	frs			https://incubator.wikimedia.org/wiki/Wp/frs
+Wikipedia Fur	poor’íŋ belé’ŋ	Incubator			fvr	fvr			https://incubator.wikimedia.org/wiki/Wp/fvr
+Wikipedia Ga	Gã	Incubator			gaa	gaa			https://incubator.wikimedia.org/wiki/Wp/gaa
+Wikipedia Gayo	Basa Gayo	Incubator			gay	gay			https://incubator.wikimedia.org/wiki/Wp/gay
+Wikipedia Garhwali	गढ़वाली	Incubator			gbm	gbm			https://incubator.wikimedia.org/wiki/Wp/gbm
+Wikipedia Guadeloupean Creole	kreyòl	Incubator			gcf	gcf			https://incubator.wikimedia.org/wiki/Wp/gcf
+Wikipedia Colonia Tovar	Alemán Coloniero	Incubator			gct	gct			https://incubator.wikimedia.org/wiki/Wp/gct
+Wikipedia Godoberi	ГъибдилIи мицци	Incubator			gdo	gdo			https://incubator.wikimedia.org/wiki/Wp/gdo
+Wikipedia Gilbertese	Taetae ni kiribati	Incubator			gil	gil			https://incubator.wikimedia.org/wiki/Wp/gil
+Wikipedia Nanai	Нанай	Incubator			gld	gld			https://incubator.wikimedia.org/wiki/Wp/gld
+Wikipedia Ancient Greek	Ἑλληνική	Incubator			grc	grc			https://incubator.wikimedia.org/wiki/Wp/grc
+Wikipedia Garo	A·chikku	Incubator			grt	grt			https://incubator.wikimedia.org/wiki/Wp/grt
+Wikipedia Hän	Häł gołan	Incubator			haa	haa			https://incubator.wikimedia.org/wiki/Wp/haa
+Wikipedia Gorani	گۆرانی	Incubator			hac	hac			https://incubator.wikimedia.org/wiki/Wp/hac
+Wikipedia Harari	ሀረሪ	Incubator			har	har			https://incubator.wikimedia.org/wiki/Wp/har
+Wikipedia Hiligaynon	Hiligaynon	Incubator			hil	hil			https://incubator.wikimedia.org/wiki/Wp/hil
+Wikipedia Haji	Bahasa Haji	Incubator			hji	hji			https://incubator.wikimedia.org/wiki/Wp/hji
+Wikipedia Hunde	Kihunde	Incubator			hke	hke			https://incubator.wikimedia.org/wiki/Wp/hke
+Wikipedia Hmar	Manmasi	Incubator			hmr	hmr			https://incubator.wikimedia.org/wiki/Wp/hmr
+Wikipedia Chhattisgarhi	छत्तीसगढ़ी	Incubator			hne	hne			https://incubator.wikimedia.org/wiki/Wp/hne
+Wikipedia Hani	Haqniqdoq	Incubator			hni	hni			https://incubator.wikimedia.org/wiki/Wp/hni
+Wikipedia Hiri Motu	Hiri Motu	Incubator			ho	hmo			https://incubator.wikimedia.org/wiki/Wp/ho
+Wikipedia Ho	𑢹𑣉𑣉 𑣎𑣋𑣜	Incubator			hoc	hoc			https://incubator.wikimedia.org/wiki/Wp/hoc
+Wikipedia Hunsrik	Riograndenser Hunsrückisch	Incubator			hrx	hrx			https://incubator.wikimedia.org/wiki/Wp/hrx
+Wikipedia Xiang	湘语	Incubator			hsn	hsn			https://incubator.wikimedia.org/wiki/Wp/hsn
+Wikipedia Herero	Otjiherero	Incubator			hz	her			https://incubator.wikimedia.org/wiki/Wp/hz
+Wikipedia Iban	Jaku Iban	Incubator			iba	iba			https://incubator.wikimedia.org/wiki/Wp/iba
+Wikipedia Ibibio	Usem Ibibio	Incubator			ibb	ibb			https://incubator.wikimedia.org/wiki/Wp/ibb
+Wikipedia Idoma	Ìdɔ́mà	Incubator			idu	idu			https://incubator.wikimedia.org/wiki/Wp/idu
+Wikipedia Sichuan Yi	ꆇꉙ	Incubator			ii	iii			https://incubator.wikimedia.org/wiki/Wp/ii
+Wikipedia Inuinnaqtun	Inuinnaqtun / ᐃᓄᐃᓐᓇᖅᑐᓐ‎	Incubator			ikt	ikt			https://incubator.wikimedia.org/wiki/Wp/ikt
+Wikipedia Iranun	Iranun	Incubator			ilp	ilp			https://incubator.wikimedia.org/wiki/Wp/ilp
+Wikipedia Esan	Ishan	Incubator			ish	ish			https://incubator.wikimedia.org/wiki/Wp/ish
+Wikipedia Ishkashimi	škošmi zəvůk	Incubator			isk	isk			https://incubator.wikimedia.org/wiki/Wp/isk
+Wikipedia Interslavic	Medžuslovjansky / Меджусловјанскы	Incubator			isv	isv			https://incubator.wikimedia.org/wiki/Wp/isv
+Wikipedia Ingrian	Ižoran keel	Incubator			izh	izh			https://incubator.wikimedia.org/wiki/Wp/izh
+Wikipedia Jambi Malay	Baso Jambi	Incubator			jax	jax			https://incubator.wikimedia.org/wiki/Wp/jax
+Wikipedia Krymchak	Kırımçakça/Кърымчахча	Incubator			jct	jct			https://incubator.wikimedia.org/wiki/Wp/jct
+Wikipedia Judeo-Tat	Жугьури	Incubator			jdt	jdt			https://incubator.wikimedia.org/wiki/Wp/jdt
+Wikipedia Jeju	제주말	Incubator			jje	jje			https://incubator.wikimedia.org/wiki/Wp/jje
+Wikipedia Koro	jkr	Incubator			jkr	jkr			https://incubator.wikimedia.org/wiki/Wp/jkr
+Wikipedia Jarai	Jrai	Incubator			jra	jra			https://incubator.wikimedia.org/wiki/Wp/jra
+Wikipedia Jutish	jysk	Incubator			jut	jut			https://incubator.wikimedia.org/wiki/Wp/jut
+Wikipedia Judeo-Yemeni Arabic	jye	Incubator			jye	jye			https://incubator.wikimedia.org/wiki/Wp/jye
+Wikipedia Jingpo	Jinghpaw ga	Incubator			kac	kac			https://incubator.wikimedia.org/wiki/Wp/kac
+Wikipedia Karai-Karai	Karai-Karai	Incubator			kai	kai			https://incubator.wikimedia.org/wiki/Wp/kai
+Wikipedia Jju	Diryem Jju	Incubator			kaj	kaj			https://incubator.wikimedia.org/wiki/Wp/kaj
+Wikipedia Khanty	ханты ясаӈ	Incubator			kca	kca			https://incubator.wikimedia.org/wiki/Wp/kca
+Wikipedia Kalanga	TjiKalanga	Incubator			kck	kck			https://incubator.wikimedia.org/wiki/Wp/kck
+Wikipedia Karaim	karaj tili	Incubator			kdr	kdr			https://incubator.wikimedia.org/wiki/Wp/kdr
+Wikipedia Cape Verdean Creole	kriolu kabuverdianu	Incubator			kea	kea			https://incubator.wikimedia.org/wiki/Wp/kea
+Wikipedia Qʼeqchiʼ	Kekchi	Incubator			kek	kek			https://incubator.wikimedia.org/wiki/Wp/kek
+Wikipedia Ket	Остыганна ӄа'	Incubator			ket	ket			https://incubator.wikimedia.org/wiki/Wp/ket
+Wikipedia Koya	కోయా	Incubator			kff	kff			https://incubator.wikimedia.org/wiki/Wp/kff
+Wikipedia Kutchi	કચ્છી	Incubator			kfr	kfr			https://incubator.wikimedia.org/wiki/Wp/kfr
+Wikipedia Bilaspuri	𑚠𑚮𑚥𑚭𑚨𑚞𑚱𑚤𑚯	Incubator			kfs	kfs			https://incubator.wikimedia.org/wiki/Wp/kfs
+Wikipedia Tai Lue	ᦅᧄᦺᦑᦟᦹᧉ	Incubator			khb	khb			https://incubator.wikimedia.org/wiki/Wp/khb
+Wikipedia Khowar	کھوار	Incubator			khw	khw			https://incubator.wikimedia.org/wiki/Wp/khw
+Wikipedia Koalib	Kowalib	Incubator			kib	kib			https://incubator.wikimedia.org/wiki/Wp/kib
+Wikipedia Tofa	Тоъфа дыл	Incubator			kim	kim			https://incubator.wikimedia.org/wiki/Wp/kim
+Wikipedia Sheshi kham	शेषी पाङ	Incubator			kip	kip			https://incubator.wikimedia.org/wiki/Wp/kip
+Wikipedia Kirmanjki	Zazakiyê Zımey	Incubator			kiu	kiu			https://incubator.wikimedia.org/wiki/Wp/kiu
+Wikipedia Kwanyama	Oshikwanyama	Incubator			kj	kua			https://incubator.wikimedia.org/wiki/Wp/kj
+Wikipedia Khakas	Хакас	Incubator			kjh	kjh			https://incubator.wikimedia.org/wiki/Wp/kjh
+Wikipedia Khinalug	каьтш мицӀ	Incubator			kjj	kjj			https://incubator.wikimedia.org/wiki/Wp/kjj
+Wikipedia Eastern Pwo	ဖၠုံလိက်	Incubator			kjp	kjp			https://incubator.wikimedia.org/wiki/Wp/kjp
+Wikipedia Kosarek	Kosarek Yale	Incubator			kkl	kkl			https://incubator.wikimedia.org/wiki/Wp/kkl
+Wikipedia Kangean	Bĕsa Kangéan	Incubator			kkv	kkv			https://incubator.wikimedia.org/wiki/Wp/kkv
+Wikipedia Khorasani Turkish	خراسان تركچىسى	Incubator			kmz	kmz			https://incubator.wikimedia.org/wiki/Wp/kmz
+Wikipedia Central Kanuri	Kànùrí	Incubator			knc	knc			https://incubator.wikimedia.org/wiki/Wp/knc
+Wikipedia Kankanaey	Kankana-ey	Incubator			kne	kne			https://incubator.wikimedia.org/wiki/Wp/kne
+Wikipedia Maharashtri Konkani	महाराष्ट्रीय कोंकणी	Incubator			knn	knn			https://incubator.wikimedia.org/wiki/Wp/knn
+Wikipedia Kensiu	Kensiw	Incubator			kns	kns			https://incubator.wikimedia.org/wiki/Wp/kns
+Wikipedia Koho	Kơho	Incubator			kpm	kpm			https://incubator.wikimedia.org/wiki/Wp/kpm
+Wikipedia Krio	Krio	Incubator			kri	kri			https://incubator.wikimedia.org/wiki/Wp/kri
+Wikipedia Kinaray-a	Kinaray-a	Incubator			krj	krj			https://incubator.wikimedia.org/wiki/Wp/krj
+Wikipedia Karelian	Karjalan kieli	Incubator			krl	krl			https://incubator.wikimedia.org/wiki/Wp/krl
+Wikipedia Kurukh	कुड़ुख	Incubator			kru	kru			https://incubator.wikimedia.org/wiki/Wp/kru
+Wikipedia Bafia	Rikpa	Incubator			ksf	ksf			https://incubator.wikimedia.org/wiki/Wp/ksf
+Wikipedia S'gaw Karen	စှီၤ/ကညီကျိာ်	Incubator			ksw	ksw			https://incubator.wikimedia.org/wiki/Wp/ksw
+Wikipedia Kumyk	Къумукъ тил	Incubator			kum	kum			https://incubator.wikimedia.org/wiki/Wp/kum
+Wikipedia Western Kayah	ꤊꤢꤛꤢ꤭ ꤜꤟꤤ꤬	Incubator			kyu	kyu			https://incubator.wikimedia.org/wiki/Wp/kyu
+Wikipedia Kikai	シマユミタ	Incubator			kzg	kzg			https://incubator.wikimedia.org/wiki/Wp/kzg
+Wikipedia Kaidipang	kzp	Incubator			kzp	kzp			https://incubator.wikimedia.org/wiki/Wp/kzp
+Wikipedia Lepcha	ᰛᰩᰴ	Incubator			lep	lep			https://incubator.wikimedia.org/wiki/Wp/lep
+Wikipedia Kaili	Kaili	Incubator			lew	lew			https://incubator.wikimedia.org/wiki/Wp/lew
+Wikipedia Lisu	ꓡꓲ-ꓢꓴ	Incubator			lis	lis			https://incubator.wikimedia.org/wiki/Wp/lis
+Wikipedia Livonian	Līvõ	Incubator			liv	liv			https://incubator.wikimedia.org/wiki/Wp/liv
+Wikipedia Lampung Api	cawa Lampung	Incubator			ljp	ljp			https://incubator.wikimedia.org/wiki/Wp/ljp
+Wikipedia Laki	لکی/laki	Incubator			lki	lki			https://incubator.wikimedia.org/wiki/Wp/lki
+Wikipedia Lakota	Lakȟótiyapi	Incubator			lkt	lkt			https://incubator.wikimedia.org/wiki/Wp/lkt
+Wikipedia Malawi Lomwe	Elhomwe	Incubator			lon	lon			https://incubator.wikimedia.org/wiki/Wp/lon
+Wikipedia Louisiana Creole	Kouri-Vini	Incubator			lou	lou			https://incubator.wikimedia.org/wiki/Wp/lou
+Wikipedia Northern Luri	لۊری شومالی	Incubator			lrc	lrc			https://incubator.wikimedia.org/wiki/Wp/lrc
+Wikipedia Achomi	اچُمی	Incubator			lrl	lrl			https://incubator.wikimedia.org/wiki/Wp/lrl
+Wikipedia Luba-Katanga	Kiluba	Incubator			lu	lub			https://incubator.wikimedia.org/wiki/Wp/lu
+Wikipedia Luba-Kasai	Tshiluba	Incubator			lua	lua			https://incubator.wikimedia.org/wiki/Wp/lua
+Wikipedia Luvale	Chiluvale	Incubator			lue	lue			https://incubator.wikimedia.org/wiki/Wp/lue
+Wikipedia Dholuo	Dholuo	Incubator			luo	luo			https://incubator.wikimedia.org/wiki/Wp/luo
+Wikipedia Mizo	Mizo	Incubator			lus	lus			https://incubator.wikimedia.org/wiki/Wp/lus
+Wikipedia Southern Luri	لُری	Incubator			luz	luz			https://incubator.wikimedia.org/wiki/Wp/luz
+Wikipedia Laz	ლაზური/Lazuri	Incubator			lzz	lzz			https://incubator.wikimedia.org/wiki/Wp/lzz
+Wikipedia Magahi	𑂧𑂏𑂯𑂲/मगही/মগহী	Incubator			mag	mag			https://incubator.wikimedia.org/wiki/Wp/mag
+Wikipedia Makassarese	ᨅᨔ ᨆᨀᨔᨑ/Basa Mangkasara'	Incubator			mak	mak			https://incubator.wikimedia.org/wiki/Wp/mak
+Wikipedia Mampruli	Ŋmampulli	Incubator			maw	maw			https://incubator.wikimedia.org/wiki/Wp/maw
+Wikipedia Maguindanaon	Basa Magindanawn	Incubator			mdh	mdh			https://incubator.wikimedia.org/wiki/Wp/mdh
+Wikipedia Kedah Malay	Pelet Utagha	Incubator			meo	meo			https://incubator.wikimedia.org/wiki/Wp/meo
+Wikipedia Hassaniya	حسانية	Incubator			mey	mey			https://incubator.wikimedia.org/wiki/Wp/mey
+Wikipedia Kelantan-Pattani Malay	Kecek Klate-Taning	Incubator			mfa	mfa			https://incubator.wikimedia.org/wiki/Wp/mfa
+Wikipedia Bangka	Bahasa Bangka	Incubator			mfb	mfb			https://incubator.wikimedia.org/wiki/Wp/mfb
+Wikipedia Mauritian Creole	Morisyen	Incubator			mfe	mfe			https://incubator.wikimedia.org/wiki/Wp/mfe
+Wikipedia Magar	मगर ढुट	Incubator			mgp	mgp			https://incubator.wikimedia.org/wiki/Wp/mgp
+Wikipedia Marshallese	Mahjet	Incubator			mh	mah			https://incubator.wikimedia.org/wiki/Wp/mh
+Wikipedia Mi'kmaq	Míkmawísimk	Incubator			mic	mic			https://incubator.wikimedia.org/wiki/Wp/mic
+Wikipedia Mandaic	ࡌࡀࡍࡃࡀࡉࡉ	Incubator			mid	mid			https://incubator.wikimedia.org/wiki/Wp/mid
+Wikipedia Karbi	Arleng	Incubator			mjw	mjw			https://incubator.wikimedia.org/wiki/Wp/mjw
+Wikipedia Mahali	ᱢᱟᱦᱟᱞᱤ	Incubator			mjx	mjx			https://incubator.wikimedia.org/wiki/Wp/mjx
+Wikipedia Kupang Malay	Basa Kupang	Incubator			mkn	mkn			https://incubator.wikimedia.org/wiki/Wp/mkn
+Wikipedia Kituba	Monokutuba	Incubator			mkw	mkw			https://incubator.wikimedia.org/wiki/Wp/mkw
+Wikipedia Manchu	ᠮᠠᠨᠵᡠ ᡤᡳᠰᡠᠨ	Incubator			mnc	mnc			https://incubator.wikimedia.org/wiki/Wp/mnc
+Wikipedia Mandinka	Mandi'nka/ߡߊ߲߬ߘߌ߲߬ߞߊ/مَانْدِينْكَا	Incubator			mnk	mnk			https://incubator.wikimedia.org/wiki/Wp/mnk
+Wikipedia Min Bei	Mâing-bă̤-ngṳ̌ / 閩北語	Incubator			mnp	mnp			https://incubator.wikimedia.org/wiki/Wp/mnp
+Wikipedia Minriq	Menriq	Incubator			mnq	mnq			https://incubator.wikimedia.org/wiki/Wp/mnq
+Wikipedia Mansi	Маньси	Incubator			mns	mns			https://incubator.wikimedia.org/wiki/Wp/mns
+Wikipedia Innu-aimun	Innu-aimun	Incubator			moe	moe			https://incubator.wikimedia.org/wiki/Wp/moe
+Wikipedia Mohawk	Kanien’kéha	Incubator			moh	moh			https://incubator.wikimedia.org/wiki/Wp/moh
+Wikipedia Moro	Dhimorong	Incubator			mor	mor			https://incubator.wikimedia.org/wiki/Wp/mor
+Wikipedia Mooré	Mooré	Incubator			mos	mos			https://incubator.wikimedia.org/wiki/Wp/mos
+Wikipedia South Marquesan	ʻEo ʻenata	Incubator			mqm	mqm			https://incubator.wikimedia.org/wiki/Wp/mqm
+Wikipedia Mara	Mara	Incubator			mrh	mrh			https://incubator.wikimedia.org/wiki/Wp/mrh
+Wikipedia North Marquesan	ʻEo ʻenana	Incubator			mrq	mrq			https://incubator.wikimedia.org/wiki/Wp/mrq
+Wikipedia Margi	Margi	Incubator			mrt	mrt			https://incubator.wikimedia.org/wiki/Wp/mrt
+Wikipedia Muong	Thiểng Mường	Incubator			mtq	mtq			https://incubator.wikimedia.org/wiki/Wp/mtq
+Wikipedia Musi	Pelémbang	Incubator			mui	mui			https://incubator.wikimedia.org/wiki/Wp/mui
+Wikipedia Muscogee	Mvskoke	Incubator			mus	mus			https://incubator.wikimedia.org/wiki/Wp/mus
+Wikipedia Inner Mongolian	ᠮᠣᠩᠭᠣᠯ	Incubator			mvf	mvf			https://incubator.wikimedia.org/wiki/Wp/mvf
+Wikipedia Hmong Daw	lus Hmoob / lug Moob / lol Hmongb	Incubator			mww	mww			https://incubator.wikimedia.org/wiki/Wp/mww
+Wikipedia Jamiltepec Mixtec	Cristobál-Chayuco	Incubator			mxt	mxt			https://incubator.wikimedia.org/wiki/Wp/mxt
+Wikipedia Macanese Patois	Patuá	Incubator			mzs	mzs			https://incubator.wikimedia.org/wiki/Wp/mzs
+Wikipedia Khoekhoe	Khoekhoegowab	Incubator			naq	naq			https://incubator.wikimedia.org/wiki/Wp/naq
+Wikipedia Central Huasteca Nahuatl	Nāhuatlahtōlli	Incubator			nch	nch			https://incubator.wikimedia.org/wiki/Wp/nch
+Wikipedia Classical Nahuatl	Nāhuatlahtōlli	Incubator			nci	nci			https://incubator.wikimedia.org/wiki/Wp/nci
+Wikipedia Northern Ndebele	isiNdebele saseNyakatho	Incubator			nd	nde			https://incubator.wikimedia.org/wiki/Wp/nd
+Wikipedia Ndau	Chindau	Incubator			ndc	ndc			https://incubator.wikimedia.org/wiki/Wp/ndc
+Wikipedia Negidal	Неғида хэсэнин	Incubator			neg	neg			https://incubator.wikimedia.org/wiki/Wp/neg
+Wikipedia Ndonga	Owambo	Incubator			ng	ndo			https://incubator.wikimedia.org/wiki/Wp/ng
+Wikipedia Nǁng	ǂKhomani	Incubator			ngh	ngh			https://incubator.wikimedia.org/wiki/Wp/ngh
+Wikipedia Guerrero Nahuatl	nawatlajtoli	Incubator			ngu	ngu			https://incubator.wikimedia.org/wiki/Wp/ngu
+Wikipedia Eastern Huasteca Nahuatl	Mexkatl	Incubator			nhe	nhe			https://incubator.wikimedia.org/wiki/Wp/nhe
+Wikipedia Central Nahuatl	Nauatlajtoli	Incubator			nhn	nhn			https://incubator.wikimedia.org/wiki/Wp/nhn
+Wikipedia Ngaju	Kutak Ngaju	Incubator			nij	nij			https://incubator.wikimedia.org/wiki/Wp/nij
+Wikipedia Southeastern Kolami	కొలామి	Incubator			nit	nit			https://incubator.wikimedia.org/wiki/Wp/nit
+Wikipedia Niuean	Ko e vagahau Niuē	Incubator			niu	niu			https://incubator.wikimedia.org/wiki/Wp/niu
+Wikipedia Nivkh	нивх диф	Incubator			niv	niv			https://incubator.wikimedia.org/wiki/Wp/niv
+Wikipedia Njerep	Dʒū Njēré	Incubator			njr	njr			https://incubator.wikimedia.org/wiki/Wp/njr
+Wikipedia Wancho	𞋒𞋀𞋉𞋃𞋕	Incubator			nnp	nnp			https://incubator.wikimedia.org/wiki/Wp/nnp
+Wikipedia Northern Thai	กำเมือง	Incubator			nod	nod			https://incubator.wikimedia.org/wiki/Wp/nod
+Wikipedia Nogai	Ногай тили	Incubator			nog	nog			https://incubator.wikimedia.org/wiki/Wp/nog
+Wikipedia Old Norse	norrǿnt mál	Incubator			non	non			https://incubator.wikimedia.org/wiki/Wp/non
+Wikipedia Southern Ndebele	isiNdebele seSewula	Incubator			nr	nbl			https://incubator.wikimedia.org/wiki/Wp/nr
+Wikipedia Niuafoʻou	Ko te lea faka Niuafoʻou	Incubator			num	num			https://incubator.wikimedia.org/wiki/Wp/num
+Wikipedia Nupe	Nupe	Incubator			nup	nup			https://incubator.wikimedia.org/wiki/Wp/nup
+Wikipedia Nuer	Thok Nath	Incubator			nus	nus			https://incubator.wikimedia.org/wiki/Wp/nus
+Wikipedia Nkore	Runyankore	Incubator			nyn	nyn			https://incubator.wikimedia.org/wiki/Wp/nyn
+Wikipedia Noongar	Noongar	Incubator			nys	nys			https://incubator.wikimedia.org/wiki/Wp/nys
+Wikipedia Nzema	Nzima	Incubator			nzi	nzi			https://incubator.wikimedia.org/wiki/Wp/nzi
+Wikipedia Orok	ульта / Ulta	Incubator			oaa	oaa			https://incubator.wikimedia.org/wiki/Wp/oaa
+Wikipedia Northwestern Ojibwa	Ojibwemowin	Incubator			ojb	ojb			https://incubator.wikimedia.org/wiki/Wp/ojb
+Wikipedia Oji-Cree	Anishininiimowin	Incubator			ojs	ojs			https://incubator.wikimedia.org/wiki/Wp/ojs
+Wikipedia Okinoerabu	島ムニ	Incubator			okn	okn			https://incubator.wikimedia.org/wiki/Wp/okn
+Wikipedia O'odham	ʼOʼodham ha-ñeʼokĭ	Incubator			ood	ood			https://incubator.wikimedia.org/wiki/Wp/ood
+Wikipedia Osing	Using	Incubator			osi	osi			https://incubator.wikimedia.org/wiki/Wp/osi
+Wikipedia Mezquital Otomi	Hñahñu	Incubator			ote	ote			https://incubator.wikimedia.org/wiki/Wp/ote
+Wikipedia Querétaro Otomi	Hñohño	Incubator			otq	otq			https://incubator.wikimedia.org/wiki/Wp/otq
+Wikipedia Palauan	a tekoi	Incubator			pau	pau			https://incubator.wikimedia.org/wiki/Wp/pau
+Wikipedia Bouyei	Giay	Incubator			pcc	pcc			https://incubator.wikimedia.org/wiki/Wp/pcc
+Wikipedia Plautdietsch	Plautdietsch	Incubator			pdt	pdt			https://incubator.wikimedia.org/wiki/Wp/pdt
+Wikipedia Petjo	Peco' Creole	Incubator			pey	pey			https://incubator.wikimedia.org/wiki/Wp/pey
+Wikipedia Pahari-Potwari	پوٹھواری, پہاڑی	Incubator			phr	phr			https://incubator.wikimedia.org/wiki/Wp/phr
+Wikipedia Pitkern	Norfuk / Pitkern	Incubator			pih	pih			https://incubator.wikimedia.org/wiki/Wp/pih
+Wikipedia Solomon Islands Pijin	Pijin blo'Solomon	Incubator			pis	pis			https://incubator.wikimedia.org/wiki/Wp/pis
+Wikipedia Palenquero	pln	Incubator			pln	pln			https://incubator.wikimedia.org/wiki/Wp/pln
+Wikipedia Pamona	Pamona	Incubator			pmf	pmf			https://incubator.wikimedia.org/wiki/Wp/pmf
+Wikipedia Papuan Malay	Melayu Papua	Incubator			pmy	pmy			https://incubator.wikimedia.org/wiki/Wp/pmy
+Wikipedia Pohnpeian	Mahsen en Pohnpei	Incubator			pon	pon			https://incubator.wikimedia.org/wiki/Wp/pon
+Wikipedia Polabian	Wenske	Incubator			pox	pox			https://incubator.wikimedia.org/wiki/Wp/pox
+Wikipedia Pipil	Nawat	Incubator			ppl	ppl			https://incubator.wikimedia.org/wiki/Wp/ppl
+Wikipedia Prussian	Prūsiskan	Incubator			prg	prg			https://incubator.wikimedia.org/wiki/Wp/prg
+Wikipedia Central Malay	Bengkulu	Incubator			pse	pse			https://incubator.wikimedia.org/wiki/Wp/pse
+Wikipedia Puyuma	Pinuyumayan	Incubator			pyu	pyu			https://incubator.wikimedia.org/wiki/Wp/pyu
+Wikipedia Pazeh	Pazih	Incubator			pzh	pzh			https://incubator.wikimedia.org/wiki/Wp/pzh
+Wikipedia Kʼicheʼ	Kʼicheʼ	Incubator			quc	quc			https://incubator.wikimedia.org/wiki/Wp/quc
+Wikipedia Kichwa	Kichwa	Incubator			qug	qug			https://incubator.wikimedia.org/wiki/Wp/qug
+Wikipedia Ancash Quechua	Nunashimi	Incubator			qwh	qwh			https://incubator.wikimedia.org/wiki/Wp/qwh
+Wikipedia Puno Quechua	Punu	Incubator			qxp	qxp			https://incubator.wikimedia.org/wiki/Wp/qxp
+Wikipedia Qashqai	Qashqay /قشقايی ديلى	Incubator			qxq	qxq			https://incubator.wikimedia.org/wiki/Wp/qxq
+Wikipedia Rade	Klei Êđê	Incubator			rad	rad			https://incubator.wikimedia.org/wiki/Wp/rad
+Wikipedia Rajasthani	राजस्थानी	Incubator			raj	raj			https://incubator.wikimedia.org/wiki/Wp/raj
+Wikipedia Rapa Nui	Arero rapa nui	Incubator			rap	rap			https://incubator.wikimedia.org/wiki/Wp/rap
+Wikipedia Cook Islands Māori	Maori Kuki Airani	Incubator			rar	rar			https://incubator.wikimedia.org/wiki/Wp/rar
+Wikipedia Miraya Bikol	Miraya Bikol	Incubator			rbl	rbl			https://incubator.wikimedia.org/wiki/Wp/rbl
+Wikipedia Reunion creole	Kréol réyoné	Incubator			rcf	rcf			https://incubator.wikimedia.org/wiki/Wp/rcf
+Wikipedia Rejang	Hejang	Incubator			rej	rej			https://incubator.wikimedia.org/wiki/Wp/rej
+Wikipedia Romagnol	Rumagnôl	Incubator			rgn	rgn			https://incubator.wikimedia.org/wiki/Wp/rgn
+Wikipedia Tarifit	Tarifiyt	Incubator			rif	rif			https://incubator.wikimedia.org/wiki/Wp/rif
+Wikipedia Rajbanshi	राजबंशी‎	Incubator			rjs	rjs			https://incubator.wikimedia.org/wiki/Wp/rjs
+Wikipedia Rakhine	ရခိုင်	Incubator			rki	rki			https://incubator.wikimedia.org/wiki/Wp/rki
+Wikipedia Rangpuri	অংপুরি	Incubator			rkt	rkt			https://incubator.wikimedia.org/wiki/Wp/rkt
+Wikipedia Carpathian Romani	Romaňi čhib	Incubator			rmc	rmc			https://incubator.wikimedia.org/wiki/Wp/rmc
+Wikipedia Finnish Kalo	Kaalengo tšimb	Incubator			rmf	rmf			https://incubator.wikimedia.org/wiki/Wp/rmf
+Wikipedia Baltic Romani	Романы / Romani	Incubator			rml	rml			https://incubator.wikimedia.org/wiki/Wp/rml
+Wikipedia Balkan Romani	Rromani / Романи / Ρομανι	Incubator			rmn	rmn			https://incubator.wikimedia.org/wiki/Wp/rmn
+Wikipedia Pannonian Rusyn	Руски язик	Incubator			rsk	rsk			https://incubator.wikimedia.org/wiki/Wp/rsk
+Wikipedia Rotuman	Fäeag Rotuạm	Incubator			rtm	rtm			https://incubator.wikimedia.org/wiki/Wp/rtm
+Wikipedia Marwari	मारवाड़ी	Incubator			rwr	rwr			https://incubator.wikimedia.org/wiki/Wp/rwr
+Wikipedia Okinawan	うちなーぐち/沖縄口	Incubator			ryu	ryu			https://incubator.wikimedia.org/wiki/Wp/ryu
+Wikipedia Sasak	Base Sasak	Incubator			sas	sas			https://incubator.wikimedia.org/wiki/Wp/sas
+Wikipedia Sassarese	Sassaresu	Incubator			sdc	sdc			https://incubator.wikimedia.org/wiki/Wp/sdc
+Wikipedia Southern Kurdish	کوردی خوارگ	Incubator			sdh	sdh			https://incubator.wikimedia.org/wiki/Wp/sdh
+Wikipedia Bukar–Sadong	Bidayŭh Bukar-Sadung	Incubator			sdo	sdo			https://incubator.wikimedia.org/wiki/Wp/sdo
+Wikipedia Selkup	шöйӄумый эты	Incubator			sel	sel			https://incubator.wikimedia.org/wiki/Wp/sel
+Wikipedia Shughni	xuǧnůn ziv/хуг̌ну̊н зив	Incubator			sgh	sgh			https://incubator.wikimedia.org/wiki/Wp/sgh
+Wikipedia Surgujia	सरगुजिया	Incubator			sgj	sgj			https://incubator.wikimedia.org/wiki/Wp/sgj
+Wikipedia Sanglechi	Dargi	Incubator			sgy	sgy			https://incubator.wikimedia.org/wiki/Wp/sgy
+Wikipedia Shoshoni	Sosoni' da̲i̲gwape	Incubator			shh	shh			https://incubator.wikimedia.org/wiki/Wp/shh
+Wikipedia Shipibo	Shipibo	Incubator			shp	shp			https://incubator.wikimedia.org/wiki/Wp/shp
+Wikipedia Shawiya	tacawit	Incubator			shy	shy			https://incubator.wikimedia.org/wiki/Wp/shy
+Wikipedia Sikkimese	འབྲས་ལྗོངས་སྐད་	Incubator			sip	sip			https://incubator.wikimedia.org/wiki/Wp/sip
+Wikipedia Kildin Sami	Кӣллт са̄мь кӣлл	Incubator			sjd	sjd			https://incubator.wikimedia.org/wiki/Wp/sjd
+Wikipedia Xibe	ᠰᡳᠪᡝᡤᡳᠰᡠᠨ	Incubator			sjo	sjo			https://incubator.wikimedia.org/wiki/Wp/sjo
+Wikipedia Ume Sami	ubmejesámiengiälla	Incubator			sju	sju			https://incubator.wikimedia.org/wiki/Wp/sju
+Wikipedia Lower Silesian	Schläsch	Incubator			sli	sli			https://incubator.wikimedia.org/wiki/Wp/sli
+Wikipedia Salar	Salırça	Incubator			slr	slr			https://incubator.wikimedia.org/wiki/Wp/slr
+Wikipedia Selayar	Basa Silajara	Incubator			sly	sly			https://incubator.wikimedia.org/wiki/Wp/sly
+Wikipedia Southern Sami	Åarjelsaemien	Incubator			sma	sma			https://incubator.wikimedia.org/wiki/Wp/sma
+Wikipedia Skolt Sami	sääʹmǩiõll	Incubator			sms	sms			https://incubator.wikimedia.org/wiki/Wp/sms
+Wikipedia Sumbawa	basa Semawa	Incubator			smw	smw			https://incubator.wikimedia.org/wiki/Wp/smw
+Wikipedia Jagoi	sne	Incubator			sne	sne			https://incubator.wikimedia.org/wiki/Wp/sne
+Wikipedia Soninke	Sooninkanxanne	Incubator			snk	snk			https://incubator.wikimedia.org/wiki/Wp/snk
+Wikipedia Soqotri	ماتڸ دسقطري	Incubator			sqt	sqt			https://incubator.wikimedia.org/wiki/Wp/sqt
+Wikipedia Sarikoli	سەرىقۇلى زىڤ	Incubator			srh	srh			https://incubator.wikimedia.org/wiki/Wp/srh
+Wikipedia Campidanese Sardinian	sardu campidanesu	Incubator			sro	sro			https://incubator.wikimedia.org/wiki/Wp/sro
+Wikipedia Thao	Thaw a lalawa	Incubator			ssf	ssf			https://incubator.wikimedia.org/wiki/Wp/ssf
+Wikipedia Stellingwerfs	Stellingwarfs	Incubator			stl	stl			https://incubator.wikimedia.org/wiki/Wp/stl
+Wikipedia Siberian Tatar	Сибертатарца	Incubator			sty	sty			https://incubator.wikimedia.org/wiki/Wp/sty
+Wikipedia Susu	Sosoxui	Incubator			sus	sus			https://incubator.wikimedia.org/wiki/Wp/sus
+Wikipedia Sunwar	सुनुवार	Incubator			suz	suz			https://incubator.wikimedia.org/wiki/Wp/suz
+Wikipedia Sangir	Sangihẹ̆	Incubator			sxn	sxn			https://incubator.wikimedia.org/wiki/Wp/sxn
+Wikipedia Hla’alua	Hla’alua	Incubator			sxr	sxr			https://incubator.wikimedia.org/wiki/Wp/sxr
+Wikipedia Sylheti	ꠍꠤꠟꠐꠤ	Incubator			syl	syl			https://incubator.wikimedia.org/wiki/Wp/syl
+Wikipedia Eastern Tamang	तामाङ	Incubator			taj	taj			https://incubator.wikimedia.org/wiki/Wp/taj
+Wikipedia Yami	Cizicizing No Tao	Incubator			tao	tao			https://incubator.wikimedia.org/wiki/Wp/tao
+Wikipedia Tai Nüa	ᥖᥭᥰ ᥖᥬᥲ ᥑᥨᥒᥰ	Incubator			tdd	tdd			https://incubator.wikimedia.org/wiki/Wp/tdd
+Wikipedia Western Tamang	तामाङ	Incubator			tdg	tdg			https://incubator.wikimedia.org/wiki/Wp/tdg
+Wikipedia Rana Tharu	राना थारू‎	Incubator			thr	thr			https://incubator.wikimedia.org/wiki/Wp/thr
+Wikipedia Tigre	ትግሬ	Incubator			tig	tig			https://incubator.wikimedia.org/wiki/Wp/tig
+Wikipedia Tiv	Tiv	Incubator			tiv	tiv			https://incubator.wikimedia.org/wiki/Wp/tiv
+Wikipedia Tokelauan	Tokelau	Incubator			tkl	tkl			https://incubator.wikimedia.org/wiki/Wp/tkl
+Wikipedia Tokunoshima	シマユミィタ	Incubator			tkn	tkn			https://incubator.wikimedia.org/wiki/Wp/tkn
+Wikipedia Tlingit	Lingít	Incubator			tli	tli			https://incubator.wikimedia.org/wiki/Wp/tli
+Wikipedia Jewish Babylonian Aramaic	ארמית	Incubator			tmr	tmr			https://incubator.wikimedia.org/wiki/Wp/tmr
+Wikipedia Tonga	ChiTonga	Incubator			tog	tog			https://incubator.wikimedia.org/wiki/Wp/tog
+Wikipedia Kokborok	Kokborok (Tripuri)	Incubator			trp	trp			https://incubator.wikimedia.org/wiki/Wp/trp
+Wikipedia Torwali	توروالی	Incubator			trw	trw			https://incubator.wikimedia.org/wiki/Wp/trw
+Wikipedia Tausug	Bahasa Sūg	Incubator			tsg	tsg			https://incubator.wikimedia.org/wiki/Wp/tsg
+Wikipedia Tsou	Tsou	Incubator			tsu	tsu			https://incubator.wikimedia.org/wiki/Wp/tsu
+Wikipedia Isan	ภาษาอีสาน	Incubator			tts	tts			https://incubator.wikimedia.org/wiki/Wp/tts
+Wikipedia Tati	تاتی	Incubator			ttt	ttt			https://incubator.wikimedia.org/wiki/Wp/ttt
+Wikipedia Tunica	Luhchi Yoroni	Incubator			tun	tun			https://incubator.wikimedia.org/wiki/Wp/tun
+Wikipedia Tucano	Yepamahsã	Incubator			tuo	tuo			https://incubator.wikimedia.org/wiki/Wp/tuo
+Wikipedia Tuvaluan	Ngangana Tuvalu	Incubator			tvl	tvl			https://incubator.wikimedia.org/wiki/Wp/tvl
+Wikipedia Taivoan	Taivoan	Incubator			tvx	tvx			https://incubator.wikimedia.org/wiki/Wp/tvx
+Wikipedia West Tarangan	Rau Jarjar	Incubator			txn	txn			https://incubator.wikimedia.org/wiki/Wp/txn
+Wikipedia Tày	Tiểng Tày	Incubator			tyz	tyz			https://incubator.wikimedia.org/wiki/Wp/tyz
+Wikipedia Central Atlas Tamazight	ⵜⴰⵎⴰⵣⵉⵖⵜ (ⴰⵟⵍⴰⵙ ⴰⵏⴰⵎⵎⴰⵙ) / Tmaziɣt	Incubator			tzm	tzm			https://incubator.wikimedia.org/wiki/Wp/tzm
+Wikipedia Unserdeutsch	uln	Incubator			uln	uln			https://incubator.wikimedia.org/wiki/Wp/uln
+Wikipedia Vai	ꕙꔤ	Incubator			vai	vai			https://incubator.wikimedia.org/wiki/Wp/vai
+Wikipedia East Franconian German	Oschdfrängisch	Incubator			vmf	vmf			https://incubator.wikimedia.org/wiki/Wp/vmf
+Wikipedia Makhuwa	Emakuana	Incubator			vmw	vmw			https://incubator.wikimedia.org/wiki/Wp/vmw
+Wikipedia Wolaitta	Wolayttatto Doonaa	Incubator			wal	wal			https://incubator.wikimedia.org/wiki/Wp/wal
+Wikipedia Warao	Warao	Incubator			wba	wba			https://incubator.wikimedia.org/wiki/Wp/wba
+Wikipedia Wakhi	زبان واخانی/ X̌ikwor zik / х̆икв̆ор зик	Incubator			wbl	wbl			https://incubator.wikimedia.org/wiki/Wp/wbl
+Wikipedia Westphalian	Westfalish	Incubator			wep	wep			https://incubator.wikimedia.org/wiki/Wp/wep
+Wikipedia Fakauvea	Faka'uwea	Incubator			wls	wls			https://incubator.wikimedia.org/wiki/Wp/wls
+Wikipedia Waale	Waale	Incubator			wlx	wlx			https://incubator.wikimedia.org/wiki/Wp/wlx
+Wikipedia Adilabad Gondi	గోండి	Incubator			wsg	wsg			https://incubator.wikimedia.org/wiki/Wp/wsg
+Wikipedia Waxiang	Waxianghua / 瓦鄉話	Incubator			wxa	wxa			https://incubator.wikimedia.org/wiki/Wp/wxa
+Wikipedia Wymysorys	Wymysöryś	Incubator			wym	wym			https://incubator.wikimedia.org/wiki/Wp/wym
+Wikipedia Kgalagadi	Kalahari	Incubator			xkv	xkv			https://incubator.wikimedia.org/wiki/Wp/xkv
+Wikipedia Manado Malay	Manado	Incubator			xmm	xmm			https://incubator.wikimedia.org/wiki/Wp/xmm
+Wikipedia Kanakanavu	Kanakanavu	Incubator			xnb	xnb			https://incubator.wikimedia.org/wiki/Wp/xnb
+Wikipedia Likpakpaanl	Likpakpaanl	Incubator			xon	xon			https://incubator.wikimedia.org/wiki/Wp/xon
+Wikipedia Mohegan-Pequot	Mohiks	Incubator			xpq	xpq			https://incubator.wikimedia.org/wiki/Wp/xpq
+Wikipedia Saisiyat	SaiSiyat	Incubator			xsy	xsy			https://incubator.wikimedia.org/wiki/Wp/xsy
+Wikipedia Yazghulami	зѓамиѓай	Incubator			yah	yah			https://incubator.wikimedia.org/wiki/Wp/yah
+Wikipedia Yaghnobi	яғнобӣ зивок	Incubator			yai	yai			https://incubator.wikimedia.org/wiki/Wp/yai
+Wikipedia Yonaguni	与那国物言/ドゥナンムヌイ	Incubator			yoi	yoi			https://incubator.wikimedia.org/wiki/Wp/yoi
+Wikipedia Nenets	ненэцяʼ вада	Incubator			yrk	yrk			https://incubator.wikimedia.org/wiki/Wp/yrk
+Wikipedia Nheengatu	Nheengatu	Incubator			yrl	yrl			https://incubator.wikimedia.org/wiki/Wp/yrl
+Wikipedia Yucatec Maya	Maaya t'aan	Incubator			yua	yua			https://incubator.wikimedia.org/wiki/Wp/yua
+Wikipedia Isthmus Zapotec	diidxazá	Incubator			zai	zai			https://incubator.wikimedia.org/wiki/Wp/zai
+Wikipedia Zenaga	Tuẓẓungiyya	Incubator			zen	zen			https://incubator.wikimedia.org/wiki/Wp/zen
+Wikipedia Negeri Sembilan Malay	Bahasa Melayu Negeri Sembilan	Incubator			zmi	zmi			https://incubator.wikimedia.org/wiki/Wp/zmi

--- a/src/data/IANAData.tsx
+++ b/src/data/IANAData.tsx
@@ -129,7 +129,7 @@ export function addIANAVariantLocales(
       if (!bcpLang) return;
 
       const iso639_3 = bcpLang.ID;
-      const localeCode = `${prefix}_${variant.ID}`;
+      const localeCode = `${iso639_3}_${variant.ID}`;
 
       locales[localeCode] = {
         ID: localeCode,

--- a/src/data/SupplementalData.tsx
+++ b/src/data/SupplementalData.tsx
@@ -6,6 +6,7 @@ import {
 } from './PopulationData';
 import { computeContainedTerritoryStats, loadTerritoryGDPLiteracy } from './TerritoryData';
 import { getLanguageCountsFromCLDR, loadCLDRCoverage } from './UnicodeData';
+import { loadAndApplyWikipediaData } from './WikipediaData';
 
 /**
  * Get more data that is not necessary for the initial page load
@@ -16,7 +17,11 @@ export async function loadSupplementalData(coreData: CoreData): Promise<void> {
   }
 
   // TODO - this should be done in parallel so we cannot pass in things we are mutating
-  await Promise.all([loadCLDRCoverage(coreData), loadTerritoryGDPLiteracy(coreData.territories)]);
+  await Promise.all([
+    loadCLDRCoverage(coreData),
+    loadTerritoryGDPLiteracy(coreData.territories),
+    loadAndApplyWikipediaData(coreData),
+  ]);
 
   const censusImports = await loadCensusData();
   censusImports.forEach((censusImport) => {

--- a/src/data/WikipediaData.tsx
+++ b/src/data/WikipediaData.tsx
@@ -1,0 +1,79 @@
+import {
+  BCP47LocaleCode,
+  LocaleData,
+  ScriptCode,
+  WikipediaData,
+  WikipediaStatus,
+} from '../types/DataTypes';
+import { LanguageDictionary } from '../types/LanguageTypes';
+
+import { CoreData } from './CoreData';
+
+export async function loadAndApplyWikipediaData(coreData: CoreData): Promise<void> {
+  const wikiData = await loadWikipediaData();
+  if (wikiData) {
+    applyWikipediaData(coreData.languagesBySource.All, coreData.locales, wikiData);
+  }
+}
+
+async function loadWikipediaData(): Promise<WikipediaData[] | void> {
+  return await fetch('data/wikipedias.tsv')
+    .then((res) => res.text())
+    .then((text) => {
+      return text
+        .split('\n')
+        .slice(1)
+        .map((line) => {
+          const parts = line.split('\t');
+          return {
+            titleEnglish: parts[0],
+            titleLocal: parts[1],
+            status: parts[2] as WikipediaStatus,
+            languageName: parts[3],
+            scriptCodes: parts[4] ? (parts[4].split('/') as ScriptCode[]) : [],
+            wikipediaSubdomain: parts[5],
+            localeCode: parts[6] as BCP47LocaleCode,
+            articles: parseInt(parts[7].replace(/,/g, '')),
+            activeUsers: parseInt(parts[8].replace(/,/g, '')),
+            url: parts[9],
+          } as WikipediaData;
+        });
+    })
+    .catch((err) => console.error('Error loading TSV:', err));
+}
+
+// Add wikipedia data to corresponding objects (languages, locales)
+//
+// Note there are a few cases there are multiple Wikipedia, for instance there is
+// both a closed Muscogee wikipedia as well as a new one with Incubator status -- the
+// former gets overrides by the Incubator one.
+export function applyWikipediaData(
+  languages: LanguageDictionary,
+  locales: Record<BCP47LocaleCode, LocaleData>,
+  wikiData: WikipediaData[],
+): void {
+  wikiData.forEach((wiki) => {
+    // Most Wikipedias simply correspond to a language, eg. eng
+    const lang = languages[wiki.localeCode];
+    if (lang) {
+      lang.wikipedia = wiki;
+    }
+
+    // Some have extra locale data eg. bel_tarask
+    const locale = locales[wiki.localeCode];
+    if (locale) {
+      locale.wikipedia = wiki;
+    }
+
+    // And some can support multiple scripts eg. zh_Hans and zh_Hant
+    if (wiki.scriptCodes.length > 0) {
+      wiki.scriptCodes.forEach((script) => {
+        const scriptLocaleCode = `${wiki.localeCode}_${script}` as BCP47LocaleCode;
+        const scriptLocale = locales[scriptLocaleCode];
+        if (scriptLocale) {
+          scriptLocale.wikipedia = wiki;
+        }
+      });
+    }
+  });
+}

--- a/src/generic/LinkButton.tsx
+++ b/src/generic/LinkButton.tsx
@@ -8,9 +8,24 @@ type Props = {
 export default function LinkButton({ href, children }: React.PropsWithChildren<Props>) {
   return (
     <a href={href}>
-      <button role="link" style={{ marginLeft: '1em', marginBottom: '0.25em', padding: '0.25em' }}>
+      <button
+        role="link"
+        style={{
+          marginLeft: '0.5em',
+          marginBottom: '0.25em',
+          padding: children != '' ? '0.25em' : '0',
+        }}
+      >
         {children}
-        <ExternalLinkIcon size="1em" style={{ marginLeft: '0.25em' }} />
+        <ExternalLinkIcon
+          size="1em"
+          style={{
+            marginLeft: '0.25em',
+            verticalAlign: 'middle',
+            paddingBottom: '0.125em',
+            paddingRight: '0.125em',
+          }}
+        />
       </button>
     </a>
   );

--- a/src/generic/LinkButton.tsx
+++ b/src/generic/LinkButton.tsx
@@ -13,7 +13,7 @@ export default function LinkButton({ href, children }: React.PropsWithChildren<P
         style={{
           marginLeft: '0.5em',
           marginBottom: '0.25em',
-          padding: children != '' ? '0.25em' : '0',
+          padding: children !== '' ? '0.25em' : '0',
         }}
       >
         {children}

--- a/src/types/DataTypes.tsx
+++ b/src/types/DataTypes.tsx
@@ -160,6 +160,7 @@ export interface LocaleData extends ObjectBase {
   populationSource: PopulationSourceCategory;
   populationSpeaking: number;
   officialStatus?: OfficialStatus;
+  wikipedia?: WikipediaData;
 
   // References to other objects, filled in after loading the TSV
   language?: LanguageData;
@@ -194,3 +195,22 @@ export interface VariantTagData extends ObjectBase {
   languages: LanguageData[];
   locales: LocaleData[];
 }
+
+export enum WikipediaStatus {
+  Active = 'Active',
+  Closed = 'Closed',
+  Incubator = 'Incubator',
+}
+
+export type WikipediaData = {
+  titleEnglish: string;
+  titleLocal: string;
+  status: WikipediaStatus;
+  languageName: string;
+  scriptCodes: ScriptCode[];
+  wikipediaSubdomain: string; // eg. en, fr, simple, zh-classical, map-bms
+  localeCode: BCP47LocaleCode; // eg. eng, fra, mis, lzh, bany1247
+  articles: number;
+  activeUsers: number;
+  url: string;
+};

--- a/src/types/LanguageTypes.tsx
+++ b/src/types/LanguageTypes.tsx
@@ -10,7 +10,14 @@
 import React from 'react';
 
 import { CLDRCoverageData } from './CLDRTypes';
-import { LocaleData, ObjectBase, ScriptCode, VariantTagData, WritingSystemData } from './DataTypes';
+import {
+  LocaleData,
+  ObjectBase,
+  ScriptCode,
+  VariantTagData,
+  WikipediaData,
+  WritingSystemData,
+} from './DataTypes';
 import { ObjectType } from './PageParamTypes';
 
 export type LanguageDictionary = Record<LanguageCode, LanguageData>;
@@ -96,6 +103,7 @@ export interface LanguageData extends ObjectBase {
   cldrDataProvider?: LanguageData | LocaleData;
 
   warnings: Partial<Record<LanguageField, string>>;
+  wikipedia?: WikipediaData;
 
   // References to other objects, filled in after loading the TSV
   locales: LocaleData[];

--- a/src/views/common/ObjectWikipediaInfo.tsx
+++ b/src/views/common/ObjectWikipediaInfo.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import Deemphasized from '../../generic/Deemphasized';
+import LinkButton from '../../generic/LinkButton';
+import { ObjectData, WikipediaData, WikipediaStatus } from '../../types/DataTypes';
+import { ObjectType } from '../../types/PageParamTypes';
+
+import HoverableObjectName from './HoverableObjectName';
+
+const ObjectWikipediaInfo: React.FC<{ object: ObjectData; size?: 'normal' | 'compact' }> = ({
+  object,
+  size = 'normal',
+}) => {
+  if (!(object.type === ObjectType.Language || object.type === ObjectType.Locale)) {
+    return null;
+  }
+
+  if (!object.wikipedia) {
+    // Locales often don't have specific Wikipedias, but their language may
+    if (object.type === ObjectType.Locale) {
+      const language = object.language;
+      if (language?.wikipedia) {
+        return (
+          <>
+            <span style={{ color: getStatusColor(language.wikipedia.status) }}>
+              {language.wikipedia.status}
+            </span>{' '}
+            (see <HoverableObjectName object={language} />)
+          </>
+        );
+      }
+    }
+
+    return <Deemphasized>No Wikipedia</Deemphasized>;
+  }
+
+  const wikipedia = object.wikipedia as WikipediaData;
+
+  return (
+    <>
+      <span style={{ color: getStatusColor(wikipedia.status) }}>{wikipedia.status}</span>
+      {wikipedia.status === WikipediaStatus.Active && (
+        <>
+          {': '}
+          {wikipedia.articles.toLocaleString()} articles
+          {size === 'normal' && `, ${wikipedia.activeUsers.toLocaleString()} active users`}
+        </>
+      )}
+      <LinkButton href={wikipedia.url}>{size === 'normal' ? wikipedia.url : ''}</LinkButton>
+    </>
+  );
+};
+
+function getStatusColor(status: WikipediaStatus) {
+  switch (status) {
+    case WikipediaStatus.Active:
+      return 'var(--color-text-green)';
+    case WikipediaStatus.Closed:
+      return 'var(--color-text-red)';
+    case WikipediaStatus.Incubator:
+      return 'var(--color-text-yellow)';
+  }
+}
+
+export default ObjectWikipediaInfo;

--- a/src/views/language/LanguageDetails.tsx
+++ b/src/views/language/LanguageDetails.tsx
@@ -8,7 +8,6 @@ import Deemphasized from '../../generic/Deemphasized';
 import Hoverable from '../../generic/Hoverable';
 import LinkButton from '../../generic/LinkButton';
 import { LanguageData, LanguageField } from '../../types/LanguageTypes';
-import { CLDRCoverageText, ICUSupportStatus } from '../common/CLDRCoverageInfo';
 import DetailsField from '../common/details/DetailsField';
 import DetailsSection from '../common/details/DetailsSection';
 import HoverableObjectName from '../common/HoverableObjectName';
@@ -16,6 +15,7 @@ import PopulationWarning from '../common/PopulationWarning';
 import TreeListRoot from '../common/TreeList/TreeListRoot';
 import { getLocaleTreeNodes } from '../locale/LocaleHierarchy';
 
+import LanguageDetailsVitalityAndViability from './LanguageDetailsVitalityAndViability';
 import { getLanguageTreeNodes } from './LanguageHierarchy';
 
 type Props = {
@@ -27,7 +27,7 @@ const LanguageDetails: React.FC<Props> = ({ lang }) => {
     <div className="Details">
       <LanguageIdentification lang={lang} />
       <LanguageAttributes lang={lang} />
-      <LanguageVitalityAndViability lang={lang} />
+      <LanguageDetailsVitalityAndViability lang={lang} />
       <LanguageConnections lang={lang} />
     </div>
   );
@@ -142,37 +142,6 @@ const LanguageAttributes: React.FC<{ lang: LanguageData }> = ({ lang }) => {
           </CommaSeparated>
         </DetailsField>
       )}
-    </DetailsSection>
-  );
-};
-
-const LanguageVitalityAndViability: React.FC<{ lang: LanguageData }> = ({ lang }) => {
-  const {
-    vitalityISO,
-    vitalityEth2013,
-    vitalityEth2025,
-    viabilityConfidence,
-    viabilityExplanation,
-  } = lang;
-
-  return (
-    <DetailsSection title="Vitality & Viability">
-      {vitalityISO && <DetailsField title="ISO Vitality / Status:">{vitalityISO}</DetailsField>}
-      {vitalityEth2013 && (
-        <DetailsField title="Ethnologue Vitality (2013):">{vitalityEth2013}</DetailsField>
-      )}
-      {vitalityEth2025 && (
-        <DetailsField title="Ethnologue Vitality (2025):">{vitalityEth2025}</DetailsField>
-      )}
-      <DetailsField title="Should use in World Atlas:">
-        {viabilityConfidence} ... {viabilityExplanation}
-      </DetailsField>
-      <DetailsField title="CLDR Coverage:">
-        <CLDRCoverageText object={lang} />
-      </DetailsField>
-      <DetailsField title="ICU Support:">
-        <ICUSupportStatus object={lang} />
-      </DetailsField>
     </DetailsSection>
   );
 };

--- a/src/views/language/LanguageDetailsVitalityAndViability.tsx
+++ b/src/views/language/LanguageDetailsVitalityAndViability.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import { LanguageData } from '../../types/LanguageTypes';
+import { CLDRCoverageText, ICUSupportStatus } from '../common/CLDRCoverageInfo';
+import DetailsField from '../common/details/DetailsField';
+import DetailsSection from '../common/details/DetailsSection';
+import ObjectWikipediaInfo from '../common/ObjectWikipediaInfo';
+
+const LanguageDetailsVitalityAndViability: React.FC<{ lang: LanguageData }> = ({ lang }) => {
+  const {
+    vitalityISO,
+    vitalityEth2013,
+    vitalityEth2025,
+    viabilityConfidence,
+    viabilityExplanation,
+  } = lang;
+
+  return (
+    <DetailsSection title="Vitality & Viability">
+      {vitalityISO && <DetailsField title="ISO Vitality / Status:">{vitalityISO}</DetailsField>}
+      {vitalityEth2013 && (
+        <DetailsField title="Ethnologue Vitality (2013):">{vitalityEth2013}</DetailsField>
+      )}
+      {vitalityEth2025 && (
+        <DetailsField title="Ethnologue Vitality (2025):">{vitalityEth2025}</DetailsField>
+      )}
+      <DetailsField title="Should use in World Atlas:">
+        {viabilityConfidence} ... {viabilityExplanation}
+      </DetailsField>
+      <DetailsField title="CLDR Coverage:">
+        <CLDRCoverageText object={lang} />
+      </DetailsField>
+      <DetailsField title="ICU Support:">
+        <ICUSupportStatus object={lang} />
+      </DetailsField>
+      <DetailsField title="Wikipedia:">
+        <ObjectWikipediaInfo object={lang} />
+      </DetailsField>
+    </DetailsSection>
+  );
+};
+
+export default LanguageDetailsVitalityAndViability;

--- a/src/views/language/LanguageTable.tsx
+++ b/src/views/language/LanguageTable.tsx
@@ -9,6 +9,7 @@ import { LanguageData, LanguageField } from '../../types/LanguageTypes';
 import { SortBy } from '../../types/PageParamTypes';
 import { CLDRCoverageText, ICUSupportStatus } from '../common/CLDRCoverageInfo';
 import HoverableObjectName from '../common/HoverableObjectName';
+import ObjectWikipediaInfo from '../common/ObjectWikipediaInfo';
 import PopulationWarning from '../common/PopulationWarning';
 import { CodeColumn, EndonymColumn, NameColumn } from '../common/table/CommonColumns';
 import ObjectTable from '../common/table/ObjectTable';
@@ -134,6 +135,11 @@ const LanguageTable: React.FC = () => {
           render: (lang) => <HoverableEnumeration items={getUniqueTerritoriesForLanguage(lang)} />,
           isNumeric: true,
           sortParam: SortBy.CountOfTerritories,
+        },
+        {
+          key: 'Wikipedia',
+          render: (object) => <ObjectWikipediaInfo object={object} size="compact" />,
+          isInitiallyVisible: false,
         },
       ]}
     />

--- a/src/views/locale/LocaleDetails.tsx
+++ b/src/views/locale/LocaleDetails.tsx
@@ -7,6 +7,7 @@ import { LocaleData } from '../../types/DataTypes';
 import DetailsField from '../common/details/DetailsField';
 import DetailsSection from '../common/details/DetailsSection';
 import HoverableObjectName from '../common/HoverableObjectName';
+import ObjectWikipediaInfo from '../common/ObjectWikipediaInfo';
 
 import LocaleCensusCitation from './LocaleCensusCitation';
 import { getOfficialLabel } from './LocaleStrings';
@@ -16,16 +17,21 @@ type Props = {
 };
 
 const LocaleDetails: React.FC<Props> = ({ locale }) => {
-  const { officialStatus } = locale;
+  const { officialStatus, wikipedia } = locale;
   return (
     <div className="Details">
       <LocaleDefinitionSection locale={locale} />
       <LocalePopulationSection locale={locale} />
-      {officialStatus && (
-        <DetailsSection title="Other">
+      <DetailsSection title="Other">
+        {officialStatus && (
           <DetailsField title="Government Status:">{getOfficialLabel(officialStatus)}</DetailsField>
-        </DetailsSection>
-      )}
+        )}
+        {wikipedia && (
+          <DetailsField title="Wikipedia:">
+            <ObjectWikipediaInfo object={locale} />
+          </DetailsField>
+        )}
+      </DetailsSection>
     </div>
   );
 };

--- a/src/views/locale/LocaleTable.tsx
+++ b/src/views/locale/LocaleTable.tsx
@@ -7,6 +7,7 @@ import { numberToFixedUnlessSmall } from '../../generic/numberUtils';
 import { LocaleData } from '../../types/DataTypes';
 import { SortBy } from '../../types/PageParamTypes';
 import HoverableObjectName from '../common/HoverableObjectName';
+import ObjectWikipediaInfo from '../common/ObjectWikipediaInfo';
 import PopulationWarning from '../common/PopulationWarning';
 import { CodeColumn, EndonymColumn, NameColumn } from '../common/table/CommonColumns';
 import ObjectTable from '../common/table/ObjectTable';
@@ -79,6 +80,11 @@ const LocaleTable: React.FC = () => {
           isInitiallyVisible: false,
           isNumeric: true,
           sortParam: SortBy.CountOfLanguages,
+        },
+        {
+          key: 'Wikipedia',
+          render: (object) => <ObjectWikipediaInfo object={object} size="compact" />,
+          isInitiallyVisible: false,
         },
       ]}
     />


### PR DESCRIPTION
This PR adds Wikipedia information to languages & locales in the Details view and the Table view.

|View|Explanation|Screenshot|
|--|--|--|
|[Chinese Vitality](http://localhost:5173/lang-nav/data?objectID=zho&view=Details)|There's a new row showing the wikipedia information.|<img width="832" height="238" alt="Screenshot 2025-09-17 at 10 57 07" src="https://github.com/user-attachments/assets/d3810e51-0b90-4444-8327-e9e0977913ec" />
|[Language table](http://localhost:5173/lang-nav/data?view=Table&limit=13&page=11)|There is a new column (defaults to hidden) that shows wikipedia data. I scrolled to a few pages in so you could see some languages in different states of wikipedia development. You'll notice its a bit more abridged to fit in a smaller space.|<img width="682" height="548" alt="Screenshot 2025-09-17 at 10 59 50" src="https://github.com/user-attachments/assets/465edf53-267e-48fc-9753-48ee0fc6e20a" />|
|[Locale table filtering "Belar*" results](http://localhost:5173/lang-nav/data?view=Table&objectType=Locale&searchString=belar)|Since we show wikipedias for locales, this shows what it looks like if we default to the language or if the locale (eg. bel_tarask) has its own wikipedia.|<img width="924" height="465" alt="Screenshot 2025-09-17 at 11 01 09" src="https://github.com/user-attachments/assets/61a4fc3b-bf17-4d30-9641-7a068c8272a5" />
