### PR TITLE
feat: implement vitality metascore calculation and integrate (#213)

### DIFF
--- a/src/views/language/LanguageCard.tsx
+++ b/src/views/language/LanguageCard.tsx
@@ -20,7 +20,7 @@ interface Props {
 const LanguageCard: React.FC<Props> = ({ lang, includeRelations }) => {
   const { updatePageParams } = usePageParams();
   const sortFunction = getSortFunction();
-  const { ID, locales, modality, populationEstimate, vitalityEth2013 } = lang;
+  const { ID, locales, modality, populationEstimate } = lang;
   const countryLocales = uniqueBy(
     locales.filter((l) => l.territory?.scope === TerritoryScope.Country).sort(sortFunction),
     (l) => l.territoryCode,
@@ -48,8 +48,8 @@ const LanguageCard: React.FC<Props> = ({ lang, includeRelations }) => {
         </div>
       )}
       <div>
-        <h4>Vitality</h4>
-        <LanguageVitalityMeter value={vitalityEth2013} />
+        <h4>Vitality Metascore</h4>
+        <LanguageVitalityMeter lang={lang} />
       </div>
 
       {includeRelations && countryLocales.length > 0 && (

--- a/src/views/language/LanguageCard.tsx
+++ b/src/views/language/LanguageCard.tsx
@@ -11,6 +11,7 @@ import ObjectTitle from '../common/ObjectTitle';
 import PopulationWarning from '../common/PopulationWarning';
 
 import LanguageVitalityMeter from './LanguageVitalityMeter';
+import { VitalityMeterType } from './LanguageVitalityComputation';
 
 interface Props {
   lang: LanguageData;
@@ -49,7 +50,7 @@ const LanguageCard: React.FC<Props> = ({ lang, includeRelations }) => {
       )}
       <div>
         <h4>Vitality</h4>
-        <LanguageVitalityMeter lang={lang} />
+        <LanguageVitalityMeter lang={lang} type={VitalityMeterType.Metascore} />
       </div>
 
       {includeRelations && countryLocales.length > 0 && (

--- a/src/views/language/LanguageCard.tsx
+++ b/src/views/language/LanguageCard.tsx
@@ -10,8 +10,8 @@ import HoverableObjectName from '../common/HoverableObjectName';
 import ObjectTitle from '../common/ObjectTitle';
 import PopulationWarning from '../common/PopulationWarning';
 
-import LanguageVitalityMeter from './LanguageVitalityMeter';
 import { VitalityMeterType } from './LanguageVitalityComputation';
+import LanguageVitalityMeter from './LanguageVitalityMeter';
 
 interface Props {
   lang: LanguageData;

--- a/src/views/language/LanguageCard.tsx
+++ b/src/views/language/LanguageCard.tsx
@@ -48,7 +48,7 @@ const LanguageCard: React.FC<Props> = ({ lang, includeRelations }) => {
         </div>
       )}
       <div>
-        <h4>Vitality Metascore</h4>
+        <h4>Vitality</h4>
         <LanguageVitalityMeter lang={lang} />
       </div>
 

--- a/src/views/language/LanguageDetailsVitalityAndViability.tsx
+++ b/src/views/language/LanguageDetailsVitalityAndViability.tsx
@@ -1,34 +1,76 @@
 import React from 'react';
 
+import Hoverable from '../../generic/Hoverable';
 import { LanguageData } from '../../types/LanguageTypes';
 import { CLDRCoverageText, ICUSupportStatus } from '../common/CLDRCoverageInfo';
 import DetailsField from '../common/details/DetailsField';
 import DetailsSection from '../common/details/DetailsSection';
 import ObjectWikipediaInfo from '../common/ObjectWikipediaInfo';
 
+import { getAllVitalityScores } from './LanguageVitalityComputation';
 import LanguageVitalityMeter from './LanguageVitalityMeter';
 
+// Component for individual vitality meters with hover explanations
+const VitalityMeter: React.FC<{
+  score: number | null;
+  value: string | null;
+  title: string;
+  explanation: string;
+}> = ({ score, value, title, explanation }) => {
+  if (score === null || value === null) {
+    return null;
+  }
+
+  return (
+    <DetailsField title={title}>
+      <span>{value} </span>
+      <Hoverable hoverContent={`${title}: ${score} (${explanation})`}>
+        <meter
+          min={0}
+          low={3}
+          high={7}
+          optimum={8}
+          max={9}
+          value={score}
+          title={`${title}: ${score}`}
+          style={{ width: '100%', minWidth: '8em' }}
+        />
+      </Hoverable>
+    </DetailsField>
+  );
+};
+
 const LanguageDetailsVitalityAndViability: React.FC<{ lang: LanguageData }> = ({ lang }) => {
-  const {
-    vitalityISO,
-    vitalityEth2013,
-    vitalityEth2025,
-    viabilityConfidence,
-    viabilityExplanation,
-  } = lang;
+  const { viabilityConfidence, viabilityExplanation } = lang;
+
+  const vitalityScores = getAllVitalityScores(lang);
 
   return (
     <DetailsSection title="Vitality & Viability">
-      {vitalityISO && <DetailsField title="ISO Vitality / Status:">{vitalityISO}</DetailsField>}
-      {vitalityEth2013 && (
-        <DetailsField title="Ethnologue Vitality (2013):">
-          <span>{vitalityEth2013} </span>
-          <LanguageVitalityMeter value={vitalityEth2013} />
-        </DetailsField>
-      )}
-      {vitalityEth2025 && (
-        <DetailsField title="Ethnologue Vitality (2025):">{vitalityEth2025}</DetailsField>
-      )}
+      <DetailsField title="Vitality Metascore:">
+        <LanguageVitalityMeter lang={lang} />
+      </DetailsField>
+
+      <VitalityMeter
+        score={vitalityScores.iso.score}
+        value={vitalityScores.iso.value}
+        title="ISO Vitality / Status:"
+        explanation={`ISO scale: Living=9, Constructed=3, Historical=1, Extinct=0`}
+      />
+
+      <VitalityMeter
+        score={vitalityScores.eth2013.score}
+        value={vitalityScores.eth2013.value}
+        title="Ethnologue (2013):"
+        explanation={`Ethnologue 2013 scale: National=9, Regional=8, Trade=7, Educational=6, Written=5, Threatened=4, Shifting=3, Moribund=2, Nearly Extinct=1, Extinct=0`}
+      />
+
+      <VitalityMeter
+        score={vitalityScores.eth2025.score}
+        value={vitalityScores.eth2025.value}
+        title="Ethnologue (2025):"
+        explanation={`Ethnologue 2025 scale: Institutional=9, Stable=6, Endangered=3, Extinct=0`}
+      />
       <DetailsField title="Should use in World Atlas:">
         {viabilityConfidence} ... {viabilityExplanation}
       </DetailsField>

--- a/src/views/language/LanguageDetailsVitalityAndViability.tsx
+++ b/src/views/language/LanguageDetailsVitalityAndViability.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { LanguageData } from '../../types/LanguageTypes';
 import { CLDRCoverageText, ICUSupportStatus } from '../common/CLDRCoverageInfo';
 import DetailsField from '../common/details/DetailsField';

--- a/src/views/language/LanguageDetailsVitalityAndViability.tsx
+++ b/src/views/language/LanguageDetailsVitalityAndViability.tsx
@@ -1,76 +1,33 @@
 import React from 'react';
-
-import Hoverable from '../../generic/Hoverable';
 import { LanguageData } from '../../types/LanguageTypes';
 import { CLDRCoverageText, ICUSupportStatus } from '../common/CLDRCoverageInfo';
 import DetailsField from '../common/details/DetailsField';
 import DetailsSection from '../common/details/DetailsSection';
 import ObjectWikipediaInfo from '../common/ObjectWikipediaInfo';
 
-import { getAllVitalityScores } from './LanguageVitalityComputation';
+import { VitalityMeterType } from './LanguageVitalityComputation';
 import LanguageVitalityMeter from './LanguageVitalityMeter';
-
-// Component for individual vitality meters with hover explanations
-const VitalityMeter: React.FC<{
-  score: number | null;
-  value: string | null;
-  title: string;
-  explanation: string;
-}> = ({ score, value, title, explanation }) => {
-  if (score === null || value === null) {
-    return null;
-  }
-
-  return (
-    <DetailsField title={title}>
-      <span>{value} </span>
-      <Hoverable hoverContent={`${title}: ${score} (${explanation})`}>
-        <meter
-          min={0}
-          low={3}
-          high={7}
-          optimum={8}
-          max={9}
-          value={score}
-          title={`${title}: ${score}`}
-          style={{ width: '100%', minWidth: '8em' }}
-        />
-      </Hoverable>
-    </DetailsField>
-  );
-};
 
 const LanguageDetailsVitalityAndViability: React.FC<{ lang: LanguageData }> = ({ lang }) => {
   const { viabilityConfidence, viabilityExplanation } = lang;
 
-  const vitalityScores = getAllVitalityScores(lang);
-
   return (
     <DetailsSection title="Vitality & Viability">
       <DetailsField title="Vitality Metascore:">
-        <LanguageVitalityMeter lang={lang} />
+        <LanguageVitalityMeter lang={lang} type={VitalityMeterType.Metascore} />
       </DetailsField>
 
-      <VitalityMeter
-        score={vitalityScores.iso.score}
-        value={vitalityScores.iso.value}
-        title="ISO Vitality / Status:"
-        explanation={`ISO scale: Living=9, Constructed=3, Historical=1, Extinct=0`}
-      />
+      <DetailsField title="ISO Vitality / Status:">
+        <LanguageVitalityMeter lang={lang} type={VitalityMeterType.ISO} />
+      </DetailsField>
 
-      <VitalityMeter
-        score={vitalityScores.eth2013.score}
-        value={vitalityScores.eth2013.value}
-        title="Ethnologue (2013):"
-        explanation={`Ethnologue 2013 scale: National=9, Regional=8, Trade=7, Educational=6, Written=5, Threatened=4, Shifting=3, Moribund=2, Nearly Extinct=1, Extinct=0`}
-      />
+      <DetailsField title="Ethnologue (2013):">
+        <LanguageVitalityMeter lang={lang} type={VitalityMeterType.Eth2013} />
+      </DetailsField>
 
-      <VitalityMeter
-        score={vitalityScores.eth2025.score}
-        value={vitalityScores.eth2025.value}
-        title="Ethnologue (2025):"
-        explanation={`Ethnologue 2025 scale: Institutional=9, Stable=6, Endangered=3, Extinct=0`}
-      />
+      <DetailsField title="Ethnologue (2025):">
+        <LanguageVitalityMeter lang={lang} type={VitalityMeterType.Eth2025} />
+      </DetailsField>
       <DetailsField title="Should use in World Atlas:">
         {viabilityConfidence} ... {viabilityExplanation}
       </DetailsField>

--- a/src/views/language/LanguageVitalityComputation.tsx
+++ b/src/views/language/LanguageVitalityComputation.tsx
@@ -1,0 +1,155 @@
+import { LanguageData } from '../../types/LanguageTypes';
+
+/**
+ * Maps Ethnologue 2013 vitality levels to 0-9 scale
+ * Ethnologue 2013 scale: 1=National, 2=Regional, 3=Trade, 4=Educational, 5=Written, 6=Threatened, 7=Shifting, 8=Moribund, 9=Nearly Extinct, 10=Extinct
+ * Our scale: 9=National, 8=Regional, 7=Trade, 6=Educational, 5=Written, 4=Threatened, 3=Shifting, 2=Moribund, 1=Nearly Extinct, 0=Extinct
+ */
+export function getEthnologue2013Score(vitality: string): number | null {
+  if (!vitality) return null;
+
+  switch (vitality.toLowerCase()) {
+    case 'national':
+      return 9;
+    case 'regional':
+      return 8;
+    case 'trade':
+      return 7;
+    case 'educational':
+      return 6;
+    case 'written':
+      return 5;
+    case 'threatened':
+      return 4;
+    case 'shifting':
+      return 3;
+    case 'moribund':
+      return 2;
+    case 'nearly extinct':
+      return 1;
+    case 'extinct':
+      return 0;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Maps Ethnologue 2025 vitality levels to 0-9 scale
+ * Ethnologue 2025: Institutional = 9, Stable = 6, Endangered = 3, Extinct = 0
+ */
+export function getEthnologue2025Score(vitality: string): number | null {
+  if (!vitality) return null;
+
+  switch (vitality.toLowerCase()) {
+    case 'institutional':
+      return 9;
+    case 'stable':
+      return 6;
+    case 'endangered':
+      return 3;
+    case 'extinct':
+      return 0;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Maps ISO vitality levels to 0-9 scale
+ * ISO: Living = 9, Constructed = 3, Historical = 1, Extinct = 0
+ */
+export function getISOScore(vitality: string): number | null {
+  if (!vitality) return null;
+
+  switch (vitality.toLowerCase()) {
+    case 'living':
+      return 9;
+    case 'constructed':
+      return 3;
+    case 'historical':
+      return 1;
+    case 'extinct':
+      return 0;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Computes the vitality metascore for a language using the algorithm:
+ * 1. If both Ethnologue 2013 & 2025 values exist, return the average
+ * 2. If only one Ethnologue value exists, return that
+ * 3. If neither Ethnologue value exists, use ISO scale
+ */
+export function computeVitalityMetascore(lang: LanguageData): {
+  score: number | null;
+  explanation: string;
+  sources: string[];
+} {
+  const eth2013Score = getEthnologue2013Score(lang.vitalityEth2013 || '');
+  const eth2025Score = getEthnologue2025Score(lang.vitalityEth2025 || '');
+  const isoScore = getISOScore(lang.vitalityISO || '');
+
+  const sources: string[] = [];
+  let explanation = '';
+
+  if (eth2013Score !== null && eth2025Score !== null) {
+    // Both Ethnologue values exist - return average
+    const average = (eth2013Score + eth2025Score) / 2;
+    sources.push('Ethnologue 2013', 'Ethnologue 2025');
+    explanation = `Average of Ethnologue 2013 (${eth2013Score}) and Ethnologue 2025 (${eth2025Score}) = ${average}`;
+    return { score: average, explanation, sources };
+  }
+
+  if (eth2013Score !== null) {
+    // Only Ethnologue 2013 exists
+    sources.push('Ethnologue 2013');
+    explanation = `Ethnologue 2013 score: ${eth2013Score}`;
+    return { score: eth2013Score, explanation, sources };
+  }
+
+  if (eth2025Score !== null) {
+    // Only Ethnologue 2025 exists
+    sources.push('Ethnologue 2025');
+    explanation = `Ethnologue 2025 score: ${eth2025Score}`;
+    return { score: eth2025Score, explanation, sources };
+  }
+
+  if (isoScore !== null) {
+    // Use ISO as fallback
+    sources.push('ISO');
+    explanation = `ISO score: ${isoScore}`;
+    return { score: isoScore, explanation, sources };
+  }
+
+  // No vitality data available
+  explanation = 'No vitality data available';
+  return { score: null, explanation, sources };
+}
+
+/**
+ * Gets all available vitality scores for a language
+ */
+export function getAllVitalityScores(lang: LanguageData): {
+  iso: { score: number | null; value: string | null };
+  eth2013: { score: number | null; value: string | null };
+  eth2025: { score: number | null; value: string | null };
+  metascore: { score: number | null; explanation: string; sources: string[] };
+} {
+  return {
+    iso: {
+      score: getISOScore(lang.vitalityISO || ''),
+      value: lang.vitalityISO || null,
+    },
+    eth2013: {
+      score: getEthnologue2013Score(lang.vitalityEth2013 || ''),
+      value: lang.vitalityEth2013 || null,
+    },
+    eth2025: {
+      score: getEthnologue2025Score(lang.vitalityEth2025 || ''),
+      value: lang.vitalityEth2025 || null,
+    },
+    metascore: computeVitalityMetascore(lang),
+  };
+}

--- a/src/views/language/LanguageVitalityComputation.tsx
+++ b/src/views/language/LanguageVitalityComputation.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { LanguageData } from '../../types/LanguageTypes';
 
 export enum VitalityMeterType {

--- a/src/views/language/LanguageVitalityComputation.tsx
+++ b/src/views/language/LanguageVitalityComputation.tsx
@@ -85,7 +85,6 @@ export function getISOScore(vitality: string): number | null {
 export function computeVitalityMetascore(lang: LanguageData): {
   score: number | null;
   explanation: string;
-  sources: string[];
 } {
   const eth2013Score = getEthnologue2013Score(lang.vitalityEth2013 || '');
   const eth2025Score = getEthnologue2025Score(lang.vitalityEth2025 || '');

--- a/src/views/language/LanguageVitalityComputation.tsx
+++ b/src/views/language/LanguageVitalityComputation.tsx
@@ -1,4 +1,12 @@
+import React from 'react';
 import { LanguageData } from '../../types/LanguageTypes';
+
+export enum VitalityMeterType {
+  Metascore = 'Metascore',
+  ISO = 'ISO',
+  Eth2013 = 'Eth2013',
+  Eth2025 = 'Eth2025',
+}
 
 /**
  * Maps Ethnologue 2013 vitality levels to 0-9 scale
@@ -84,70 +92,135 @@ export function getISOScore(vitality: string): number | null {
  */
 export function computeVitalityMetascore(lang: LanguageData): {
   score: number | null;
-  explanation: string;
+  explanation: React.ReactNode;
 } {
   const eth2013Score = getEthnologue2013Score(lang.vitalityEth2013 || '');
   const eth2025Score = getEthnologue2025Score(lang.vitalityEth2025 || '');
   const isoScore = getISOScore(lang.vitalityISO || '');
 
-  const sources: string[] = [];
-  let explanation = '';
+  let explanation: React.ReactNode = '';
 
   if (eth2013Score !== null && eth2025Score !== null) {
     // Both Ethnologue values exist - return average
     const average = (eth2013Score + eth2025Score) / 2;
-    sources.push('Ethnologue 2013', 'Ethnologue 2025');
-    explanation = `Average of Ethnologue 2013 (${eth2013Score}) and Ethnologue 2025 (${eth2025Score}) = ${average}`;
-    return { score: average, explanation, sources };
+    explanation = (
+      <div>
+        <div>{average.toFixed(1)}</div>
+        <div style={{ marginTop: '0.25em' }}>Average of Ethnologue 2013 and Ethnologue 2025</div>
+        <div style={{ marginLeft: '2em' }}>
+          Ethnologue 2013: {eth2013Score}
+          {lang.vitalityEth2013 ? ` (${lang.vitalityEth2013})` : ''}
+        </div>
+        <div style={{ marginLeft: '2em' }}>
+          Ethnologue 2025: {eth2025Score}
+          {lang.vitalityEth2025 ? ` (${lang.vitalityEth2025})` : ''}
+        </div>
+      </div>
+    );
+    return { score: average, explanation };
   }
 
   if (eth2013Score !== null) {
     // Only Ethnologue 2013 exists
-    sources.push('Ethnologue 2013');
-    explanation = `Ethnologue 2013 score: ${eth2013Score}`;
-    return { score: eth2013Score, explanation, sources };
+    explanation = (
+      <div>
+        <div>{eth2013Score}</div>
+        <div style={{ marginTop: '0.25em' }}>Based on Ethnologue 2013</div>
+        <div style={{ marginLeft: '2em' }}>
+          Ethnologue 2013: {eth2013Score}
+          {lang.vitalityEth2013 ? ` (${lang.vitalityEth2013})` : ''}
+        </div>
+      </div>
+    );
+    return { score: eth2013Score, explanation };
   }
 
   if (eth2025Score !== null) {
     // Only Ethnologue 2025 exists
-    sources.push('Ethnologue 2025');
-    explanation = `Ethnologue 2025 score: ${eth2025Score}`;
-    return { score: eth2025Score, explanation, sources };
+    explanation = (
+      <div>
+        <div>{eth2025Score}</div>
+        <div style={{ marginTop: '0.25em' }}>Based on Ethnologue 2025</div>
+        <div style={{ marginLeft: '2em' }}>
+          Ethnologue 2025: {eth2025Score}
+          {lang.vitalityEth2025 ? ` (${lang.vitalityEth2025})` : ''}
+        </div>
+      </div>
+    );
+    return { score: eth2025Score, explanation };
   }
 
   if (isoScore !== null) {
     // Use ISO as fallback
-    sources.push('ISO');
-    explanation = `ISO score: ${isoScore}`;
-    return { score: isoScore, explanation, sources };
+    explanation = (
+      <div>
+        <div>{isoScore}</div>
+        <div style={{ marginTop: '0.25em' }}>Based on ISO Vitality / Status</div>
+        <div style={{ marginLeft: '2em' }}>
+          ISO: {isoScore}
+          {lang.vitalityISO ? ` (${lang.vitalityISO})` : ''}
+        </div>
+      </div>
+    );
+    return { score: isoScore, explanation };
   }
 
   // No vitality data available
   explanation = 'No vitality data available';
-  return { score: null, explanation, sources };
+  return { score: null, explanation };
 }
 
 /**
  * Gets all available vitality scores for a language
  */
 export function getAllVitalityScores(lang: LanguageData): {
-  iso: { score: number | null; value: string | null };
-  eth2013: { score: number | null; value: string | null };
-  eth2025: { score: number | null; value: string | null };
-  metascore: { score: number | null; explanation: string; sources: string[] };
+  iso: { score: number | null; value: string | null; explanation: React.ReactNode };
+  eth2013: { score: number | null; value: string | null; explanation: React.ReactNode };
+  eth2025: { score: number | null; value: string | null; explanation: React.ReactNode };
+  metascore: { score: number | null; explanation: React.ReactNode };
 } {
   return {
     iso: {
       score: getISOScore(lang.vitalityISO || ''),
       value: lang.vitalityISO || null,
+      explanation: (
+        <div>
+          <div>{getISOScore(lang.vitalityISO || '') ?? 'N/A'}</div>
+          <div style={{ marginTop: '0.25em' }}>Based on ISO Vitality / Status</div>
+          <div style={{ marginLeft: '2em' }}>
+            ISO: {getISOScore(lang.vitalityISO || '') ?? 'N/A'}
+            {lang.vitalityISO ? ` (${lang.vitalityISO})` : ''}
+          </div>
+        </div>
+      ),
     },
     eth2013: {
       score: getEthnologue2013Score(lang.vitalityEth2013 || ''),
       value: lang.vitalityEth2013 || null,
+      explanation: (
+        <div>
+          <div>{getEthnologue2013Score(lang.vitalityEth2013 || '') ?? 'N/A'}</div>
+          <div style={{ marginTop: '0.25em' }}>Based on Ethnologue 2013</div>
+          <div style={{ marginLeft: '2em' }}>
+            Ethnologue 2013: {getEthnologue2013Score(lang.vitalityEth2013 || '') ?? 'N/A'}
+            {lang.vitalityEth2013 ? ` (${lang.vitalityEth2013})` : ''}
+          </div>
+        </div>
+      ),
     },
     eth2025: {
       score: getEthnologue2025Score(lang.vitalityEth2025 || ''),
       value: lang.vitalityEth2025 || null,
+      explanation: (
+        <div>
+          <div>{getEthnologue2025Score(lang.vitalityEth2025 || '') ?? 'N/A'}</div>
+          <div style={{ marginTop: '0.25em' }}>Based on Ethnologue 2025</div>
+          <div style={{ marginLeft: '2em' }}>
+            Ethnologue 2025: {getEthnologue2025Score(lang.vitalityEth2025 || '') ?? 'N/A'}
+            {lang.vitalityEth2025 ? ` (${lang.vitalityEth2025})` : ''}
+          </div>
+        </div>
+      ),
     },
     metascore: computeVitalityMetascore(lang),
   };

--- a/src/views/language/LanguageVitalityComputation.tsx
+++ b/src/views/language/LanguageVitalityComputation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { LanguageData } from '../../types/LanguageTypes';
 import LinkButton from '../../generic/LinkButton';
+import { LanguageData } from '../../types/LanguageTypes';
 
 export enum VitalityMeterType {
   Metascore = 'Metascore',
@@ -21,18 +21,18 @@ export function getEthnologue2013Score(vitality: string): number | null {
   switch (vitality.toLowerCase()) {
     case 'national':
       return 9;
-    case 'provincial': 
+    case 'provincial':
     case 'regional':
       return 8;
     case 'trade':
-    case 'wider communication': 
+    case 'wider communication':
       return 7;
     case 'educational':
       return 6;
     case 'written':
-    case 'developing': 
+    case 'developing':
       return 5;
-    case 'vigorous': 
+    case 'vigorous':
     case 'threatened':
       return 4;
     case 'shifting':
@@ -97,7 +97,7 @@ export function getISOScore(vitality: string): number | null {
 export function getVitalityExplanation(
   type: VitalityMeterType,
   lang: LanguageData,
-  score: number | null
+  score: number | null,
 ): React.ReactNode {
   switch (type) {
     case VitalityMeterType.ISO:
@@ -111,8 +111,11 @@ export function getVitalityExplanation(
     case VitalityMeterType.Eth2013:
       return (
         <div>
-          <div>Ethnologue 2013 Vitality: {lang.vitalityEth2013} 
-            <LinkButton href="https://www.ethnologue.com/methodology/#language-status">methodology</LinkButton>
+          <div>
+            Ethnologue 2013 Vitality: {lang.vitalityEth2013}
+            <LinkButton href="https://www.ethnologue.com/methodology/#language-status">
+              methodology
+            </LinkButton>
           </div>
           <div>Normalized to a score of {score} out of 9.</div>
         </div>
@@ -126,7 +129,7 @@ export function getVitalityExplanation(
         </div>
       );
 
-    case VitalityMeterType.Metascore:
+    case VitalityMeterType.Metascore: {
       const eth2013Score = getEthnologue2013Score(lang.vitalityEth2013 || '');
       const eth2025Score = getEthnologue2025Score(lang.vitalityEth2025 || '');
 
@@ -135,9 +138,16 @@ export function getVitalityExplanation(
         const average = (eth2013Score + eth2025Score) / 2;
         return (
           <div>
-            <div>Ethnologue changed the methodology of its vitality scores. So we convert them to a normalized score and averaged the data from 2013 and 2025. Average: {average.toFixed(1)}.</div>
+            <div>
+              Ethnologue changed the methodology of its vitality scores. So we convert them to a
+              normalized score and averaged the data from 2013 and 2025. Average:{' '}
+              {average.toFixed(1)}.
+            </div>
             <div style={{ marginLeft: '2em' }}>
-              2013: {lang.vitalityEth2013} ({eth2013Score}) <LinkButton href="https://www.ethnologue.com/methodology/#language-status">methodology</LinkButton>
+              2013: {lang.vitalityEth2013} ({eth2013Score}){' '}
+              <LinkButton href="https://www.ethnologue.com/methodology/#language-status">
+                methodology
+              </LinkButton>
             </div>
             <div style={{ marginLeft: '2em' }}>
               2025: {lang.vitalityEth2025?.split(' ')[1]} ({eth2025Score})
@@ -147,6 +157,7 @@ export function getVitalityExplanation(
       }
       // No vitality data available
       return 'No vitality data available';
+    }
 
     default:
       return 'Unknown vitality type';
@@ -194,7 +205,7 @@ export function computeVitalityMetascore(lang: LanguageData): {
  * Gets all available vitality scores for a language
  */
 export function getAllVitalityScores(
-  lang: LanguageData
+  lang: LanguageData,
 ): Record<VitalityMeterType, { score: number | null; explanation: React.ReactNode }> {
   const isoScore = getISOScore(lang.vitalityISO || '');
   const eth2013Score = getEthnologue2013Score(lang.vitalityEth2013 || '');

--- a/src/views/language/LanguageVitalityMeter.tsx
+++ b/src/views/language/LanguageVitalityMeter.tsx
@@ -6,7 +6,6 @@ import { LanguageData } from '../../types/LanguageTypes';
 
 import {
   VitalityMeterType,
-  computeVitalityMetascore,
   getAllVitalityScores,
 } from './LanguageVitalityComputation';
 
@@ -17,35 +16,7 @@ interface Props {
 
 const LanguageVitalityMeter: React.FC<Props> = ({ lang, type }) => {
   const scores = getAllVitalityScores(lang);
-
-  let value: number | null = null;
-  let hoverText: React.ReactNode = '';
-
-  switch (type) {
-    case VitalityMeterType.Metascore: {
-      const meta = computeVitalityMetascore(lang);
-      value = meta.score;
-      hoverText = meta.explanation;
-      break;
-    }
-    case VitalityMeterType.ISO: {
-      value = scores.iso.score;
-      hoverText = scores.iso.explanation;
-      break;
-    }
-    case VitalityMeterType.Eth2013: {
-      value = scores.eth2013.score;
-      hoverText = scores.eth2013.explanation;
-      break;
-    }
-    case VitalityMeterType.Eth2025: {
-      value = scores.eth2025.score;
-      hoverText = scores.eth2025.explanation;
-      break;
-    }
-    default:
-      break;
-  }
+  const { score: value, explanation: hoverText } = scores[type];
 
   if (value === null) {
     return <Deemphasized>Data not available</Deemphasized>;

--- a/src/views/language/LanguageVitalityMeter.tsx
+++ b/src/views/language/LanguageVitalityMeter.tsx
@@ -4,10 +4,7 @@ import Deemphasized from '../../generic/Deemphasized';
 import Hoverable from '../../generic/Hoverable';
 import { LanguageData } from '../../types/LanguageTypes';
 
-import {
-  VitalityMeterType,
-  getAllVitalityScores,
-} from './LanguageVitalityComputation';
+import { VitalityMeterType, getAllVitalityScores } from './LanguageVitalityComputation';
 
 interface Props {
   lang: LanguageData;

--- a/src/views/language/LanguageVitalityMeter.tsx
+++ b/src/views/language/LanguageVitalityMeter.tsx
@@ -4,31 +4,62 @@ import Deemphasized from '../../generic/Deemphasized';
 import Hoverable from '../../generic/Hoverable';
 import { LanguageData } from '../../types/LanguageTypes';
 
-import { computeVitalityMetascore } from './LanguageVitalityComputation';
+import {
+  VitalityMeterType,
+  computeVitalityMetascore,
+  getAllVitalityScores,
+} from './LanguageVitalityComputation';
 
 interface Props {
   lang: LanguageData;
+  type: VitalityMeterType;
 }
 
-const LanguageVitalityMeter: React.FC<Props> = ({ lang }) => {
-  const metascore = computeVitalityMetascore(lang);
+const LanguageVitalityMeter: React.FC<Props> = ({ lang, type }) => {
+  const scores = getAllVitalityScores(lang);
 
-  if (metascore.score === null) {
+  let value: number | null = null;
+  let hoverText: React.ReactNode = '';
+
+  switch (type) {
+    case VitalityMeterType.Metascore: {
+      const meta = computeVitalityMetascore(lang);
+      value = meta.score;
+      hoverText = meta.explanation;
+      break;
+    }
+    case VitalityMeterType.ISO: {
+      value = scores.iso.score;
+      hoverText = scores.iso.explanation;
+      break;
+    }
+    case VitalityMeterType.Eth2013: {
+      value = scores.eth2013.score;
+      hoverText = scores.eth2013.explanation;
+      break;
+    }
+    case VitalityMeterType.Eth2025: {
+      value = scores.eth2025.score;
+      hoverText = scores.eth2025.explanation;
+      break;
+    }
+    default:
+      break;
+  }
+
+  if (value === null) {
     return <Deemphasized>Data not available</Deemphasized>;
   }
 
   return (
-    <Hoverable
-      hoverContent={`Vitality Metascore: ${metascore.score.toFixed(1)} (${metascore.explanation})`}
-    >
+    <Hoverable hoverContent={hoverText}>
       <meter
         min={0} // Extinct
         low={3} // Shifting/Endangered -- below this, the meter is colored red
         high={7} // Trade/Stable -- below this, the meter is colored yellow
         optimum={8} // Regional -- tells the renderer that high and above is green
         max={9} // National/Institutional/Living
-        value={metascore.score}
-        title={`Vitality Metascore: ${metascore.score.toFixed(1)}`}
+        value={value}
         style={{ width: '100%', minWidth: '8em' }}
       />
     </Hoverable>

--- a/src/views/language/LanguageVitalityMeter.tsx
+++ b/src/views/language/LanguageVitalityMeter.tsx
@@ -2,59 +2,33 @@ import React from 'react';
 
 import Deemphasized from '../../generic/Deemphasized';
 import Hoverable from '../../generic/Hoverable';
+import { LanguageData } from '../../types/LanguageTypes';
+
+import { computeVitalityMetascore } from './LanguageVitalityComputation';
 
 interface Props {
-  value?: string;
+  lang: LanguageData;
 }
 
-const LanguageVitalityMeter: React.FC<Props> = ({ value }) => {
-  if (!value) {
+const LanguageVitalityMeter: React.FC<Props> = ({ lang }) => {
+  const metascore = computeVitalityMetascore(lang);
+
+  if (metascore.score === null) {
     return <Deemphasized>Data not available</Deemphasized>;
   }
 
-  // Map Ethnologue vitality levels to meter values (inverted scale)
-  // Ethnologue scale: 1=National, 2=Regional, 3=Trade, 4=Educational, 5=Written, 6=Threatened, 7=Shifting, 8=Moribund, 9=Nearly Extinct, 10=Extinct
-  // We want: 9=National, 8=Regional, 7=Trade, 6=Educational, 5=Written, 4=Threatened, 3=Shifting, 2=Moribund, 1=Nearly Extinct, 0=Extinct
-  const getMeterValue = (vitality: string): number => {
-    switch (vitality.toLowerCase()) {
-      case 'national':
-        return 9;
-      case 'regional':
-        return 8;
-      case 'trade':
-        return 7;
-      case 'educational':
-        return 6;
-      case 'written':
-        return 5;
-      case 'threatened':
-        return 4;
-      case 'shifting':
-        return 3;
-      case 'moribund':
-        return 2;
-      case 'nearly extinct':
-        return 1;
-      case 'extinct':
-        return 0;
-      default:
-        // For any unknown values, return a neutral value
-        return 5;
-    }
-  };
-
-  const meterValue = getMeterValue(value);
-
   return (
-    <Hoverable hoverContent={value}>
+    <Hoverable
+      hoverContent={`Vitality Metascore: ${metascore.score.toFixed(1)} (${metascore.explanation})`}
+    >
       <meter
         min={0} // Extinct
-        low={3} // Shifting
-        high={7} // Trade
-        optimum={8} // Regional
-        max={9} // National
-        value={meterValue}
-        title={`Vitality: ${value}`}
+        low={3} // Shifting/Endangered
+        high={7} // Trade/Stable
+        optimum={8} // Regional/Institutional
+        max={9} // National/Living
+        value={metascore.score}
+        title={`Vitality Metascore: ${metascore.score.toFixed(1)}`}
         style={{ width: '100%', minWidth: '8em' }}
       />
     </Hoverable>

--- a/src/views/language/LanguageVitalityMeter.tsx
+++ b/src/views/language/LanguageVitalityMeter.tsx
@@ -23,10 +23,10 @@ const LanguageVitalityMeter: React.FC<Props> = ({ lang }) => {
     >
       <meter
         min={0} // Extinct
-        low={3} // Shifting/Endangered
-        high={7} // Trade/Stable
-        optimum={8} // Regional/Institutional
-        max={9} // National/Living
+        low={3} // Shifting/Endangered -- below this, the meter is colored red
+        high={7} // Trade/Stable -- below this, the meter is colored yellow
+        optimum={8} // Regional -- tells the renderer that high and above is green
+        max={9} // National/Institutional/Living
         value={metascore.score}
         title={`Vitality Metascore: ${metascore.score.toFixed(1)}`}
         style={{ width: '100%', minWidth: '8em' }}


### PR DESCRIPTION
### Summary
Implements the **Vitality Metascore** system to reconcile ISO, Ethnologue 2013, and Ethnologue 2025 vitality measures.

### Changes
- **`LanguageVitalityComputation.tsx`**
  - `getEthnologue2013Score()`: maps values to 0–9 scale  
  - `getEthnologue2025Score()`: maps values to 0–9 scale (Institutional=9, Stable=6, Endangered=3, Extinct=0)  
  - `getISOScore()`: maps ISO values to 0–9 scale (Living=9, Constructed=3, Historical=1, Extinct=0)  
  - `computeVitalityMetascore()`:  
    - If both Ethnologue values exist → average  
    - If only one exists → use that  
    - If none exist → fallback to ISO scale  
  - `getAllVitalityScores()`: returns all vitality scores for display  

- **`LanguageVitalityMeter.tsx`**
  - Accepts a `LanguageData` object  
  - Uses the metascore computation  
  - Shows hover explanation with calculation details  

- **`LanguageCard.tsx`**
  - Displays "Vitality Metascore" instead of plain "Vitality"  
  - Uses new metascore system  

- **`LanguageDetailsVitalityAndViability.tsx`**
  - Displays:  
    - Vitality Metascore (meter + hover details)  
    - ISO Vitality / Status  
    - Ethnologue (2013)  
    - Ethnologue (2025)  
  - All values shown with meters and hover explanations  

### Screenshots
this is new look of languageCard:
<img width="549" height="378" alt="Screenshot 2025-09-25 at 3 44 37 PM" src="https://github.com/user-attachments/assets/e7b32db6-101d-4aa7-afb8-fc22fe22d937" />

below are the images for the languageCardDetails:
<img width="453" height="233" alt="Screenshot 2025-09-25 at 3 47 32 PM" src="https://github.com/user-attachments/assets/d7e6139e-f55c-4722-8684-65e076a53a9e" />
<img width="861" height="276" alt="Screenshot 2025-09-25 at 3 47 43 PM" src="https://github.com/user-attachments/assets/741646a2-6cf3-442f-9b2c-661bb33a8448" />
<img width="861" height="276" alt="Screenshot 2025-09-25 at 3 47 57 PM" src="https://github.com/user-attachments/assets/9ecf4aae-8ef1-4798-ad5f-4b1ae4f1f676" />
<img width="861" height="276" alt="Screenshot 2025-09-25 at 3 48 03 PM" src="https://github.com/user-attachments/assets/ad08c96f-65ea-4327-8de8-7d219653198b" />


### Issue
Closes #213
