### PR TITLE
Refactor: Make more optional fields for objects

### DIFF
--- a/src/controls/pathnav/getParentsAndDescendents.tsx
+++ b/src/controls/pathnav/getParentsAndDescendents.tsx
@@ -30,9 +30,9 @@ export function getObjectChildren(object?: ObjectData): (ObjectData | undefined)
     case ObjectType.Locale:
       return object.containedLocales ?? [];
     case ObjectType.Territory:
-      return [...object.containsTerritories, ...object.dependentTerritories];
+      return [...(object.containsTerritories ?? []), ...(object.dependentTerritories ?? [])];
     case ObjectType.WritingSystem:
-      return object.childWritingSystems;
+      return object.childWritingSystems ?? [];
     case ObjectType.VariantTag:
       return object.locales;
   }

--- a/src/controls/sort.tsx
+++ b/src/controls/sort.tsx
@@ -51,50 +51,11 @@ function getSortFunctionParameterized(
       };
     case SortBy.CountOfTerritories:
       return (a: ObjectData, b: ObjectData) => {
-        switch (a.type) {
-          case ObjectType.Language:
-            return b.type === ObjectType.Language
-              ? getUniqueTerritoriesForLanguage(b).length -
-                  getUniqueTerritoriesForLanguage(a).length
-              : -1;
-          case ObjectType.Locale:
-            return 0; // Each locale only has one territory
-          case ObjectType.Census:
-            return 0; // Each census only has one territory
-          case ObjectType.WritingSystem:
-            return 0; // Not a useful sort for writing systems
-          case ObjectType.Territory:
-            return b.type === ObjectType.Territory
-              ? b.containsTerritories.length - a.containsTerritories.length
-              : -1;
-          case ObjectType.VariantTag:
-            return 0; // Not a useful sort for variant tags
-        }
+        return getCountOfTerritories(b) - getCountOfTerritories(a);
       };
     case SortBy.CountOfLanguages:
       return (a: ObjectData, b: ObjectData) => {
-        switch (a.type) {
-          case ObjectType.Language:
-            return b.type === ObjectType.Language
-              ? b.childLanguages.length - a.childLanguages.length
-              : -1;
-          case ObjectType.Locale:
-            return b.type === ObjectType.Locale
-              ? (b.containedLocales?.length || 0) - (a.containedLocales?.length || 0)
-              : -1;
-          case ObjectType.Census:
-            return b.type === ObjectType.Census ? b.languageCount - a.languageCount : -1;
-          case ObjectType.WritingSystem:
-            return b.type === ObjectType.WritingSystem
-              ? Object.values(b.languages).length - Object.values(a.languages).length
-              : -1;
-          case ObjectType.Territory:
-            return b.type === ObjectType.Territory ? b.locales.length - a.locales.length : -1;
-          case ObjectType.VariantTag:
-            return b.type === ObjectType.VariantTag
-              ? (b.languageCodes?.length || 0) - (a.languageCodes?.length || 0)
-              : -1;
-        }
+        return getCountOfLanguages(b) - getCountOfLanguages(a);
       };
     case SortBy.Population:
       return (a: ObjectData, b: ObjectData) => {
@@ -229,6 +190,39 @@ function getDate(object: ObjectData): number {
     case ObjectType.VariantTag:
       return object.dateAdded?.getTime() ?? 0;
     default:
+      return 0;
+  }
+}
+
+function getCountOfLanguages(object: ObjectData): number {
+  switch (object.type) {
+    case ObjectType.Language:
+      return object.childLanguages.length;
+    case ObjectType.Locale:
+      return object.containedLocales?.length || 0;
+    case ObjectType.Census:
+      return object.languageCount;
+    case ObjectType.WritingSystem:
+      return object.languages ? Object.values(object.languages).length : 0;
+    case ObjectType.Territory:
+      return object.locales?.length || 0;
+    case ObjectType.VariantTag:
+      return object.languageCodes?.length || 0;
+    default:
+      return 0;
+  }
+}
+
+function getCountOfTerritories(object: ObjectData): number {
+  switch (object.type) {
+    case ObjectType.Language:
+      return getUniqueTerritoriesForLanguage(object).length;
+    case ObjectType.Territory:
+      return object.containsTerritories?.length || 0;
+    case ObjectType.Locale:
+    case ObjectType.Census:
+    case ObjectType.WritingSystem:
+    case ObjectType.VariantTag:
       return 0;
   }
 }

--- a/src/data/CensusData.tsx
+++ b/src/data/CensusData.tsx
@@ -269,6 +269,7 @@ export function addCensusData(dataContext: DataContextType, censusData: CensusIm
       const territory = dataContext.getTerritory(census.isoRegionCode);
       if (territory != null && territory.type === ObjectType.Territory) {
         census.territory = territory;
+        if (territory.censuses == null) territory.censuses = [];
         territory.censuses.push(census);
       }
 
@@ -290,6 +291,7 @@ export function addCensusRecordsToLocales(
     const locale = getLocale(languageCode + '_' + census.isoRegionCode);
     if (locale?.type === ObjectType.Locale) {
       // Add the census to the locale
+      if (locale.censusRecords == null) locale.censusRecords = [];
       locale.censusRecords.push({
         census,
         populationEstimate,

--- a/src/data/DataAssociations.tsx
+++ b/src/data/DataAssociations.tsx
@@ -54,6 +54,7 @@ export function connectWritingSystems(
 
     if (language != null) {
       writingSystem.primaryLanguage = language;
+      if (!writingSystem.languages) writingSystem.languages = {};
       writingSystem.languages[language.ID] = language;
       language.writingSystems[writingSystem.ID] = writingSystem;
     }
@@ -62,9 +63,10 @@ export function connectWritingSystems(
     }
     if (parentWritingSystem != null) {
       writingSystem.parentWritingSystem = parentWritingSystem;
+      if (!parentWritingSystem.childWritingSystems) parentWritingSystem.childWritingSystems = [];
       parentWritingSystem.childWritingSystems.push(writingSystem);
     }
-    if (containsWritingSystemsCodes.length > 0) {
+    if (containsWritingSystemsCodes && containsWritingSystemsCodes.length > 0) {
       writingSystem.containsWritingSystems = containsWritingSystemsCodes
         .map((code) => writingSystems[code])
         .filter(Boolean);
@@ -77,7 +79,10 @@ export function connectWritingSystems(
     if (primaryScriptCode != null) {
       const primaryWritingSystem = writingSystems[primaryScriptCode];
       if (primaryWritingSystem != null) {
+        if (!primaryWritingSystem.languages) primaryWritingSystem.languages = {};
         primaryWritingSystem.languages[language.ID] = language;
+        if (!primaryWritingSystem.populationUpperBound)
+          primaryWritingSystem.populationUpperBound = 0;
         primaryWritingSystem.populationUpperBound += language.populationCited || 0;
         language.primaryWritingSystem = primaryWritingSystem;
         language.writingSystems[primaryWritingSystem.ID] = primaryWritingSystem;
@@ -108,6 +113,7 @@ export function connectLocales(
       : null;
 
     if (territory != null) {
+      if (!territory.locales) territory.locales = [];
       territory.locales.push(locale);
       locale.territory = territory;
       locale.populationSpeakingPercent = (locale.populationSpeaking * 100) / territory.population;
@@ -117,12 +123,15 @@ export function connectLocales(
       locale.language = language;
     }
     if (writingSystem != null) {
+      if (!writingSystem.localesWhereExplicit) writingSystem.localesWhereExplicit = [];
       writingSystem.localesWhereExplicit.push(locale);
       locale.writingSystem = writingSystem;
 
       if (language != null) {
+        if (!writingSystem.languages) writingSystem.languages = {};
         writingSystem.languages[language.ID] = language;
         if (language.primaryScriptCode != locale.explicitScriptCode) {
+          if (!writingSystem.populationUpperBound) writingSystem.populationUpperBound = 0;
           writingSystem.populationUpperBound += locale.populationSpeaking || 0;
         }
       }
@@ -197,12 +206,13 @@ export function computeOtherPopulationStatistics(
 
 function computeWritingSystemDescendentPopulation(writingSystem: WritingSystemData): number {
   const { childWritingSystems } = writingSystem;
-  const descendentPopulation = childWritingSystems.reduce(
-    (total, childSystem) => total + computeWritingSystemDescendentPopulation(childSystem),
-    0,
-  );
+  const descendentPopulation =
+    childWritingSystems?.reduce(
+      (total, childSystem) => total + computeWritingSystemDescendentPopulation(childSystem),
+      0,
+    ) || 0;
   writingSystem.populationOfDescendents = descendentPopulation;
-  return descendentPopulation + writingSystem.populationUpperBound;
+  return descendentPopulation + (writingSystem.populationUpperBound ?? 0);
 }
 
 function computeLanguageDescendentPopulation(lang: LanguageData, source: LanguageSource): number {

--- a/src/data/DataParsing.tsx
+++ b/src/data/DataParsing.tsx
@@ -48,17 +48,17 @@ export function parseLanguageLine(line: string): LanguageData {
     names: [nameDisplay, nameSubtitle, nameEndonym].filter((s) => s != null),
 
     vitalityISO: undefined, // Added by ISO import
-    vitalityEth2013: parts[6] !== '' ? parts[6] : undefined,
-    vitalityEth2025: parts[7] !== '' ? parts[7] : undefined,
-    digitalSupport: parts[8] !== '' ? parts[8] : undefined,
-    viabilityConfidence: parts[13] !== '' ? parts[13] : 'No',
-    viabilityExplanation: parts[14] !== '' ? parts[14] : undefined,
+    vitalityEth2013: parts[6] || undefined,
+    vitalityEth2025: parts[7] || undefined,
+    digitalSupport: parts[8] || undefined,
+    viabilityConfidence: parts[13] || undefined,
+    viabilityExplanation: parts[14] || undefined,
 
     populationAdjusted,
     populationCited,
 
-    modality: parts[4] !== '' ? (parts[4] as LanguageModality) : undefined,
-    primaryScriptCode: parts[5] !== '' ? parts[5] : undefined,
+    modality: (parts[4] || undefined) as LanguageModality | undefined,
+    primaryScriptCode: parts[5] || undefined,
 
     sourceSpecific,
   };
@@ -73,8 +73,8 @@ export function parseLocaleLine(line: string): LocaleData | null {
     console.error(`Locale line not the right length, ${parts.length} parts: ${line}`);
     return null;
   }
-  const nameEndonym = parts[2] !== '' ? parts[2] : undefined;
-  const variantTagCode = parts[6] !== '' ? parts[6].toLowerCase() : undefined;
+  const nameEndonym = parts[2] || undefined;
+  const variantTagCode = (parts[6] || undefined)?.toLowerCase();
 
   return {
     type: ObjectType.Locale,
@@ -83,21 +83,21 @@ export function parseLocaleLine(line: string): LocaleData | null {
     localeSource: 'regularInput',
 
     nameDisplay: parts[1],
-    nameEndonym: parts[2] !== '' ? parts[2] : undefined,
+    nameEndonym: parts[2] || undefined,
     names: [parts[1], nameEndonym].filter((s) => s != null),
     languageCode: parts[3],
     territoryCode: parts[4],
-    explicitScriptCode: parts[5] !== '' ? parts[5] : undefined,
+    explicitScriptCode: parts[5] || undefined,
     variantTagCode,
     populationSource: parts[7] as PopulationSourceCategory,
     populationSpeaking: Number.parseInt(parts[8]?.replace(/,/g, '')),
-    officialStatus: parts[9] !== '' ? (parts[9] as OfficialStatus) : undefined,
+    officialStatus: (parts[9] || undefined) as OfficialStatus | undefined,
   };
 }
 
 export function parseWritingSystem(line: string): WritingSystemData {
   const parts = line.split('\t');
-  const nameEndonym = parts[3] !== '' ? parts[3] : undefined;
+  const nameEndonym = parts[3] || undefined;
   return {
     type: ObjectType.WritingSystem,
 
@@ -110,11 +110,11 @@ export function parseWritingSystem(line: string): WritingSystemData {
     nameEndonym,
     names: [parts[1], parts[2], nameEndonym].filter((s) => s != null),
     unicodeVersion: parts[4] !== '' ? parseFloat(parts[4]) : undefined,
-    sample: parts[5] !== '' ? parts[5] : undefined,
+    sample: parts[5] || undefined,
     rightToLeft: parts[6] === 'Yes' ? true : parts[6] === 'no' ? false : undefined,
-    primaryLanguageCode: parts[7] !== '' ? parts[7] : undefined,
-    territoryOfOriginCode: parts[8] !== '' ? parts[8] : undefined,
-    parentWritingSystemCode: parts[9] !== '' ? parts[9] : undefined,
+    primaryLanguageCode: parts[7] || undefined,
+    territoryOfOriginCode: parts[8] || undefined,
+    parentWritingSystemCode: parts[9] || undefined,
     containsWritingSystemsCodes: parts[10] !== '' ? parts[10].split(', ') : [],
   };
 }

--- a/src/data/DataParsing.tsx
+++ b/src/data/DataParsing.tsx
@@ -92,8 +92,6 @@ export function parseLocaleLine(line: string): LocaleData | null {
     populationSource: parts[7] as PopulationSourceCategory,
     populationSpeaking: Number.parseInt(parts[8]?.replace(/,/g, '')),
     officialStatus: parts[9] !== '' ? (parts[9] as OfficialStatus) : undefined,
-
-    censusRecords: [], // Populated later
   };
 }
 
@@ -111,25 +109,12 @@ export function parseWritingSystem(line: string): WritingSystemData {
     nameFull: parts[2],
     nameEndonym,
     names: [parts[1], parts[2], nameEndonym].filter((s) => s != null),
-    unicodeVersion: parts[4] !== '' ? parseFloat(parts[4]) : null,
-    sample: parts[5] !== '' ? parts[5] : null,
-    rightToLeft: parts[6] === 'Yes' ? true : parts[6] === 'no' ? false : null,
-    primaryLanguageCode: parts[7] !== '' ? parts[7] : null,
-    territoryOfOriginCode: parts[8] !== '' ? parts[8] : null,
-    parentWritingSystemCode: parts[9] !== '' ? parts[9] : null,
+    unicodeVersion: parts[4] !== '' ? parseFloat(parts[4]) : undefined,
+    sample: parts[5] !== '' ? parts[5] : undefined,
+    rightToLeft: parts[6] === 'Yes' ? true : parts[6] === 'no' ? false : undefined,
+    primaryLanguageCode: parts[7] !== '' ? parts[7] : undefined,
+    territoryOfOriginCode: parts[8] !== '' ? parts[8] : undefined,
+    parentWritingSystemCode: parts[9] !== '' ? parts[9] : undefined,
     containsWritingSystemsCodes: parts[10] !== '' ? parts[10].split(', ') : [],
-
-    // Derived when combining other data
-    populationUpperBound: 0,
-    populationOfDescendents: 0,
-
-    // References to other objects, filled in with DataAssociations methods
-    languages: {},
-    localesWhereExplicit: [],
-    primaryLanguage: undefined,
-    territoryOfOrigin: undefined,
-    parentWritingSystem: undefined,
-    childWritingSystems: [],
-    containsWritingSystems: [],
   };
 }

--- a/src/data/PopulationData.tsx
+++ b/src/data/PopulationData.tsx
@@ -23,17 +23,15 @@ const POPULATION_ESTIMATE_RULES: CensusCmp[] = [
 
 export function computeLocalePopulationFromCensuses(dataContext: DataContextType): void {
   dataContext.locales.forEach((locale) => {
-    let records = locale.censusRecords;
-    if (records.length === 0) {
-      return; // No census records, nothing to compute
-    }
+    if (!locale.censusRecords || locale.censusRecords.length === 0) return; // No census records, nothing to compute
+    let records = [...locale.censusRecords];
 
     // Apply a series of rules to determine the best population estimate.
     for (const rule of POPULATION_ESTIMATE_RULES) {
-      records = records.sort(rule);
+      records = records?.sort(rule);
       // Filter the records to ones that match the first one
-      const bestRecords = records.filter((otherRecord) => rule(records[0], otherRecord) === 0);
-      if (bestRecords.length == 1) {
+      const bestRecords = records?.filter((otherRecord) => rule(records[0], otherRecord) === 0);
+      if (bestRecords?.length == 1) {
         // If we have a single best record, use it
         setLocalePopulationEstimate(locale, bestRecords[0]);
         return; // We found a unique best estimate
@@ -63,11 +61,11 @@ function recomputeRegionalLocalePopulation(territory: TerritoryData | undefined)
     return; // Only recompute for regional locales
   }
   // Re-compute the estimate for the contained territories first.
-  territory.containsTerritories.forEach((childTerritory) => {
+  territory.containsTerritories?.forEach((childTerritory) => {
     recomputeRegionalLocalePopulation(childTerritory);
   });
   // Now go through the locales and re-compute their population
-  territory.locales.forEach((locale) => {
+  territory.locales?.forEach((locale) => {
     locale.populationSpeaking =
       locale.containedLocales?.reduce(
         // Each absolute number may come from a different year, so instead of adding up censuses from

--- a/src/data/PopulationData.tsx
+++ b/src/data/PopulationData.tsx
@@ -28,10 +28,10 @@ export function computeLocalePopulationFromCensuses(dataContext: DataContextType
 
     // Apply a series of rules to determine the best population estimate.
     for (const rule of POPULATION_ESTIMATE_RULES) {
-      records = records?.sort(rule);
+      records = records.sort(rule);
       // Filter the records to ones that match the first one
-      const bestRecords = records?.filter((otherRecord) => rule(records[0], otherRecord) === 0);
-      if (bestRecords?.length == 1) {
+      const bestRecords = records.filter((otherRecord) => rule(records[0], otherRecord) === 0);
+      if (bestRecords.length === 1) {
         // If we have a single best record, use it
         setLocalePopulationEstimate(locale, bestRecords[0]);
         return; // We found a unique best estimate

--- a/src/data/TerritoryData.tsx
+++ b/src/data/TerritoryData.tsx
@@ -39,8 +39,8 @@ export function parseTerritoryLine(line: string): TerritoryData {
     names: [parts[1]],
     scope: parts[2] as TerritoryScope,
     population: Number.parseInt(parts[3].replace(/,/g, '')),
-    containedUNRegionCode: parts[4] !== '' ? parts[4] : '',
-    sovereignCode: parts[5] !== '' ? parts[5] : '',
+    containedUNRegionCode: parts[4] || undefined,
+    sovereignCode: parts[5] || undefined,
   };
 }
 

--- a/src/types/DataTypes.tsx
+++ b/src/types/DataTypes.tsx
@@ -57,8 +57,8 @@ export interface TerritoryData extends ObjectBase {
   nameDisplay: string;
   scope: TerritoryScope;
   population: number;
-  containedUNRegionCode: UNM49Code;
-  sovereignCode: ISO3166Code;
+  containedUNRegionCode?: UNM49Code;
+  sovereignCode?: ISO3166Code;
 
   // Supplemental data
   literacyPercent?: number;
@@ -66,11 +66,11 @@ export interface TerritoryData extends ObjectBase {
 
   // References to other objects, filled in after loading the TSV
   parentUNRegion?: TerritoryData;
-  containsTerritories: TerritoryData[];
+  containsTerritories?: TerritoryData[];
   sovereign?: TerritoryData;
-  dependentTerritories: TerritoryData[];
-  locales: LocaleData[];
-  censuses: CensusData[];
+  dependentTerritories?: TerritoryData[];
+  locales?: LocaleData[];
+  censuses?: CensusData[];
 }
 
 export type ScriptCode = string; // ISO 15924 script code, eg. Latn, Cyrl, etc.
@@ -89,30 +89,32 @@ export interface WritingSystemData extends ObjectBase {
   codeDisplay: ScriptCode; // This should be stable
   scope: WritingSystemScope;
 
-  nameDisplayOriginal: string;
-  nameFull: string;
+  nameDisplay: string;
+  nameDisplayOriginal?: string;
+  nameFull?: string;
   nameEndonym?: string;
-  unicodeVersion: number | null;
-  sample: string | null;
-  rightToLeft: boolean | null;
-  primaryLanguageCode: LanguageCode | null;
-  territoryOfOriginCode: TerritoryCode | null;
-  parentWritingSystemCode: ScriptCode | null;
-  containsWritingSystemsCodes: ScriptCode[];
+  names: string[];
+
+  unicodeVersion?: number;
+  sample?: string;
+  rightToLeft?: boolean;
+  primaryLanguageCode?: LanguageCode;
+  territoryOfOriginCode?: TerritoryCode;
+  parentWritingSystemCode?: ScriptCode;
+  containsWritingSystemsCodes?: ScriptCode[];
 
   // Derived when combining data
-  populationUpperBound: number;
-  nameDisplay: string;
-  populationOfDescendents: number;
+  populationUpperBound?: number;
+  populationOfDescendents?: number;
 
   // References to other objects, filled in after loading the TSV
   primaryLanguage?: LanguageData;
   territoryOfOrigin?: TerritoryData;
-  languages: Record<LanguageCode, LanguageData>;
-  localesWhereExplicit: LocaleData[];
+  languages?: Record<LanguageCode, LanguageData>;
+  localesWhereExplicit?: LocaleData[];
   parentWritingSystem?: WritingSystemData;
-  childWritingSystems: WritingSystemData[];
-  containsWritingSystems: WritingSystemData[];
+  childWritingSystems?: WritingSystemData[];
+  containsWritingSystems?: WritingSystemData[];
 }
 
 // BCP-47 Locale	Locale Display Name	Native Locale Name	Language Code	Territory ISO	Explicit Script	Variant IANA Tag	Pop Source	Best Guess	Official Language
@@ -158,7 +160,7 @@ export interface LocaleData extends ObjectBase {
   explicitScriptCode?: ScriptCode;
   variantTagCode?: VariantIANATag; // TODO Variant tags can be singular (eg. roh-rumgr) or composite (eg. oc-lengadoc-grclass)
 
-  populationSource: PopulationSourceCategory;
+  populationSource?: PopulationSourceCategory;
   populationSpeaking: number;
   officialStatus?: OfficialStatus;
   wikipedia?: WikipediaData;
@@ -176,7 +178,7 @@ export interface LocaleData extends ObjectBase {
   populationWriting?: number;
   populationWritingPercent?: number;
   populationCensus?: CensusData; // The census record that provides the population estimate
-  censusRecords: LocaleInCensus[]; // Maps census ID to population estimate
+  censusRecords?: LocaleInCensus[]; // Maps census ID to population estimate
 }
 
 export type VariantIANATag = string; // IANA tag, eg. valencia in cat-ES-valencia

--- a/src/types/DataTypes.tsx
+++ b/src/types/DataTypes.tsx
@@ -57,10 +57,10 @@ export interface TerritoryData extends ObjectBase {
   nameDisplay: string;
   scope: TerritoryScope;
   population: number;
-  containedUNRegionCode?: UNM49Code;
-  sovereignCode?: ISO3166Code;
 
   // Supplemental data
+  containedUNRegionCode?: UNM49Code;
+  sovereignCode?: ISO3166Code;
   literacyPercent?: number;
   gdp?: number;
 

--- a/src/views/census/CensusHierarchy.tsx
+++ b/src/views/census/CensusHierarchy.tsx
@@ -36,7 +36,7 @@ export function getCensusTreeNodes(
 ): TreeNodeData[] {
   return territories
     .filter(filterFunction ?? (() => true))
-    .filter((territory) => territory.censuses.length > 0)
+    .filter((territory) => territory.censuses && territory.censuses.length > 0)
     .sort(sortFunction)
     .map((t) => getTerritoryTreeNode(t, sortFunction, filterFunction));
 }
@@ -58,6 +58,7 @@ function getCensusNodesForTerritory(
   sortFunction: (a: ObjectData, b: ObjectData) => number,
   filterFunction: (a: ObjectData) => boolean,
 ): TreeNodeData[] {
+  if (!territory.censuses) return [];
   return territory.censuses
     .filter(filterFunction)
     .sort(sortFunction)

--- a/src/views/census/TableOfCountriesWithCensuses.tsx
+++ b/src/views/census/TableOfCountriesWithCensuses.tsx
@@ -22,7 +22,7 @@ const TableOfCountriesWithCensuses: React.FC = () => {
           NameColumn,
           {
             key: 'Censuses',
-            render: (territory) => territory.censuses.length,
+            render: (territory) => territory.censuses?.length,
             isNumeric: true,
           },
           ...Object.values(CensusCollectorType).map((collectorType) => ({
@@ -32,7 +32,7 @@ const TableOfCountriesWithCensuses: React.FC = () => {
                 <div style={{ maxWidth: '10em' }}>
                   <CommaSeparated limit={1}>
                     {territory.censuses
-                      .filter((census) => census.collectorType === collectorType)
+                      ?.filter((census) => census.collectorType === collectorType)
                       .map((census) => (
                         <HoverableObjectName key={census.ID} object={census} />
                       ))}
@@ -49,7 +49,7 @@ const TableOfCountriesWithCensuses: React.FC = () => {
           },
           {
             key: 'Languages',
-            render: (territory) => territory.locales.length,
+            render: (territory) => territory.locales?.length,
             isNumeric: true,
             sortParam: SortBy.CountOfLanguages,
           },

--- a/src/views/common/ObjectField.tsx
+++ b/src/views/common/ObjectField.tsx
@@ -85,9 +85,9 @@ export function getObjectPopulation(object: ObjectData): number {
     case ObjectType.Census:
       return object.eligiblePopulation;
     case ObjectType.WritingSystem:
-      return object.populationUpperBound;
+      return object.populationUpperBound ?? 0;
     case ObjectType.Territory:
-      return object.population;
+      return object.population ?? 0;
     case ObjectType.VariantTag:
       return object.languages.reduce((sum, lang) => sum + (lang.populationEstimate || 0), 0);
   }
@@ -114,7 +114,7 @@ export function getObjectPopulationOfDescendents(
         ? (object.sourceSpecific[languageSource].populationOfDescendents ?? 0)
         : (object.populationOfDescendents ?? 0);
     case ObjectType.WritingSystem:
-      return object.populationOfDescendents;
+      return object.populationOfDescendents ?? 0;
     default:
       return 0;
   }

--- a/src/views/locale/LocaleDetails.tsx
+++ b/src/views/locale/LocaleDetails.tsx
@@ -143,7 +143,7 @@ const LocalePopulationSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
         </DetailsField>
       )}
 
-      {censusRecords?.length > 0 && (
+      {censusRecords && censusRecords.length > 0 && (
         <DetailsField title="Other Censuses:">
           <table style={{ marginLeft: '2em', borderSpacing: '1em 0' }}>
             <thead>

--- a/src/views/locale/LocaleHierarchy.tsx
+++ b/src/views/locale/LocaleHierarchy.tsx
@@ -116,6 +116,7 @@ function getTerritoryNodesForWritingSystem(
   sortFunction: (a: ObjectData, b: ObjectData) => number,
   filterFunction: (a: ObjectData) => boolean,
 ): TreeNodeData[] {
+  if (!writingSystem.localesWhereExplicit) return [];
   return writingSystem.localesWhereExplicit
     .filter((locale) => locale.languageCode === languageID)
     .filter(filterFunction)

--- a/src/views/locale/PotentialLocales.tsx
+++ b/src/views/locale/PotentialLocales.tsx
@@ -211,6 +211,7 @@ function getPotentialLocales(
               missing[localeID].populationSpeakingPercent = populationPercent;
               missing[localeID].populationCensus = census;
             }
+            if (missing[localeID].censusRecords == null) missing[localeID].censusRecords = [];
             missing[localeID].censusRecords.push({
               census,
               populationEstimate,

--- a/src/views/territory/TerritoryCard.tsx
+++ b/src/views/territory/TerritoryCard.tsx
@@ -28,7 +28,7 @@ const TerritoryCard: React.FC<Props> = ({ territory }) => {
         {population.toLocaleString()}
       </div>
 
-      {locales.length > 0 && (
+      {locales && locales.length > 0 && (
         <div>
           <h4>Languages:</h4>
           <CommaSeparated>

--- a/src/views/territory/TerritoryDetails.tsx
+++ b/src/views/territory/TerritoryDetails.tsx
@@ -42,7 +42,7 @@ const TerritoryDetails: React.FC<Props> = ({ territory }) => {
       </DetailsSection>
 
       <DetailsSection title="Connections">
-        {locales.length > 0 && (
+        {locales && locales.length > 0 && (
           <DetailsField title="Languages:">
             <CommaSeparated>
               {Object.values(locales).map((locale) => (
@@ -57,7 +57,7 @@ const TerritoryDetails: React.FC<Props> = ({ territory }) => {
             <HoverableObjectName object={parentUNRegion} />
           </DetailsField>
         )}
-        {containsTerritories.length > 0 && (
+        {containsTerritories && containsTerritories.length > 0 && (
           <DetailsField title="Contains:">
             <CommaSeparated>
               {containsTerritories.sort(getSortFunction()).map((territory) => (
@@ -72,7 +72,7 @@ const TerritoryDetails: React.FC<Props> = ({ territory }) => {
             <HoverableObjectName object={sovereign} />
           </DetailsField>
         )}
-        {dependentTerritories.length > 0 && (
+        {dependentTerritories && dependentTerritories.length > 0 && (
           <DetailsField title="Administers:">
             <CommaSeparated>
               {dependentTerritories.sort(getSortFunction()).map((territory) => (
@@ -82,7 +82,7 @@ const TerritoryDetails: React.FC<Props> = ({ territory }) => {
           </DetailsField>
         )}
 
-        {censuses.length > 0 && (
+        {censuses && censuses.length > 0 && (
           <DetailsField title="Census Tables:">
             <CommaSeparated>
               {censuses.sort(getSortFunction()).map((census) => (

--- a/src/views/territory/TerritoryHierarchy.tsx
+++ b/src/views/territory/TerritoryHierarchy.tsx
@@ -51,7 +51,9 @@ function getTerritoryTreeNode(
   return {
     type: ObjectType.Language,
     object: territory,
-    children: getTerritoryTreeNodes(territory.containsTerritories, sortFunction, filterByScope),
+    children: territory.containsTerritories
+      ? getTerritoryTreeNodes(territory.containsTerritories, sortFunction, filterByScope)
+      : [],
     labelStyle: {
       fontWeight: territory.scope === TerritoryScope.Country ? 'bold' : 'normal',
       fontStyle: territory.scope === TerritoryScope.Dependency ? 'italic' : 'normal',

--- a/src/views/territory/TerritoryTable.tsx
+++ b/src/views/territory/TerritoryTable.tsx
@@ -32,17 +32,19 @@ const TerritoryTable: React.FC = () => {
         },
         {
           key: 'Languages',
-          render: (object) => (
-            <HoverableEnumeration
-              items={object.locales.map((l) => l.language?.nameDisplay ?? l.nameDisplay)}
-            />
-          ),
+          render: (object) =>
+            object.locales && (
+              <HoverableEnumeration
+                items={object.locales.map((l) => l.language?.nameDisplay ?? l.nameDisplay)}
+              />
+            ),
           isNumeric: true,
           sortParam: SortBy.CountOfLanguages,
         },
         {
           key: 'Biggest Language',
           render: (object) =>
+            object.locales &&
             object.locales.length > 0 && (
               <HoverableObjectName
                 labelSource="language"
@@ -54,9 +56,10 @@ const TerritoryTable: React.FC = () => {
         },
         {
           key: 'Contains Territories',
-          render: (object) => (
-            <HoverableEnumeration items={object.containsTerritories.map((t) => t.nameDisplay)} />
-          ),
+          render: (object) =>
+            object.containsTerritories && (
+              <HoverableEnumeration items={object.containsTerritories.map((t) => t.nameDisplay)} />
+            ),
           isInitiallyVisible: false,
           isNumeric: true,
           sortParam: SortBy.CountOfTerritories,

--- a/src/views/writingsystem/WritingSystemCard.tsx
+++ b/src/views/writingsystem/WritingSystemCard.tsx
@@ -42,7 +42,7 @@ const WritingSystemCard: React.FC<Props> = ({ writingSystem }) => {
           {sample}
         </div>
       )}
-      {Object.values(languages).length > 0 && (
+      {languages && Object.values(languages).length > 0 && (
         <div>
           <label>Languages:</label>
           <CommaSeparated>
@@ -54,14 +54,14 @@ const WritingSystemCard: React.FC<Props> = ({ writingSystem }) => {
           </CommaSeparated>
         </div>
       )}
-      {populationUpperBound > 100 && ( // Values less than 100 are suspcious and probably spurious
+      {(populationUpperBound ?? 0) > 100 && ( // Values less than 100 are suspcious and probably spurious
         <div>
           <label>
             Population (Upper bound
             <PopulationWarning />
             {'):'}
           </label>
-          {populationUpperBound.toLocaleString()}
+          {populationUpperBound?.toLocaleString()}
         </div>
       )}
       {scope === WritingSystemScope.Variation && parentWritingSystem && (
@@ -70,16 +70,18 @@ const WritingSystemCard: React.FC<Props> = ({ writingSystem }) => {
           <HoverableObjectName object={parentWritingSystem} />
         </div>
       )}
-      {scope == WritingSystemScope.Group && containsWritingSystems.length > 0 && (
-        <div>
-          <label>Contains:</label>
-          <CommaSeparated>
-            {containsWritingSystems.map((w) => (
-              <HoverableObjectName key={w.ID} object={w} />
-            ))}
-          </CommaSeparated>
-        </div>
-      )}
+      {scope == WritingSystemScope.Group &&
+        containsWritingSystems &&
+        containsWritingSystems.length > 0 && (
+          <div>
+            <label>Contains:</label>
+            <CommaSeparated>
+              {containsWritingSystems.map((w) => (
+                <HoverableObjectName key={w.ID} object={w} />
+              ))}
+            </CommaSeparated>
+          </div>
+        )}
     </div>
   );
 };

--- a/src/views/writingsystem/WritingSystemDetails.tsx
+++ b/src/views/writingsystem/WritingSystemDetails.tsx
@@ -46,7 +46,7 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
             <em>Not supported by Unicode</em>
           )}
         </DetailsField>
-        {populationUpperBound > 100 && ( // Values less than 100 are suspcious and probably spurious
+        {(populationUpperBound ?? 0) > 100 && ( // Values less than 100 are suspcious and probably spurious
           <DetailsField
             title={
               <>
@@ -56,7 +56,7 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
               </>
             }
           >
-            {populationUpperBound.toLocaleString()}
+            {populationUpperBound?.toLocaleString()}
           </DetailsField>
         )}
       </DetailsSection>
@@ -71,7 +71,7 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
             )}
           </DetailsField>
         )}
-        {Object.values(languages).length > 0 && (
+        {languages && Object.values(languages).length > 0 && (
           <DetailsField title="Languages:">
             <CommaSeparated>
               {Object.values(languages)
@@ -89,7 +89,7 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
           </DetailsField>
         )}
 
-        {localesWhereExplicit.length > 0 && (
+        {localesWhereExplicit && localesWhereExplicit.length > 0 && (
           <DetailsField title="Locales (where writing system is explicit):">
             <CommaSeparated>
               {localesWhereExplicit.sort(getSortFunction()).map((locale) => (
@@ -104,7 +104,7 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
             <HoverableObjectName object={parentWritingSystem} />
           </DetailsField>
         )}
-        {childWritingSystems.length > 0 && (
+        {childWritingSystems && childWritingSystems.length > 0 && (
           <DetailsField title="Inspired:">
             <CommaSeparated>
               {childWritingSystems.sort(getSortFunction()).map((writingSystem) => (
@@ -113,7 +113,7 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
             </CommaSeparated>
           </DetailsField>
         )}
-        {containsWritingSystems.length > 0 && (
+        {containsWritingSystems && containsWritingSystems.length > 0 && (
           <DetailsField title="Contains:">
             <CommaSeparated>
               {containsWritingSystems.sort(getSortFunction()).map((writingSystem) => (

--- a/src/views/writingsystem/WritingSystemHierarchy.tsx
+++ b/src/views/writingsystem/WritingSystemHierarchy.tsx
@@ -54,14 +54,12 @@ function getWritingSystemTreeNode(
   return {
     type: ObjectType.WritingSystem,
     object: writingSystem,
-    children: getWritingSystemTreeNodes(
-      writingSystem.childWritingSystems,
-      sortFunction,
-      filterFunction,
-    ),
+    children: writingSystem.childWritingSystems
+      ? getWritingSystemTreeNodes(writingSystem.childWritingSystems, sortFunction, filterFunction)
+      : [],
     labelStyle: {
-      fontWeight: writingSystem.populationOfDescendents > 100 ? 'bold' : 'normal',
-      fontStyle: writingSystem.populationUpperBound <= 100 ? 'italic' : 'normal',
+      fontWeight: (writingSystem?.populationOfDescendents ?? 0) > 100 ? 'bold' : 'normal',
+      fontStyle: (writingSystem?.populationUpperBound ?? 0) <= 100 ? 'italic' : 'normal',
     },
   };
 }

--- a/src/views/writingsystem/WritingSystemTable.tsx
+++ b/src/views/writingsystem/WritingSystemTable.tsx
@@ -33,11 +33,12 @@ const WritingSystemTable: React.FC = () => {
         },
         {
           key: 'Languages',
-          render: (object) => (
-            <HoverableEnumeration
-              items={Object.values(object.languages).map((l) => l.nameDisplay)}
-            />
-          ),
+          render: (object) =>
+            object.languages && (
+              <HoverableEnumeration
+                items={Object.values(object.languages).map((l) => l.nameDisplay)}
+              />
+            ),
           isNumeric: true,
           sortParam: SortBy.CountOfLanguages,
         },


### PR DESCRIPTION
In a separate branch I am adding unit tests but I noticed the code to mock objects is pretty big because of the amount of fields. Fortunately we can set most of those fields to be optional and save us needing to declare so many.

Tested by `npm run build` and also using the website to make sure it still works fine.