### PR TITLE
Table: Add column groups

### DIFF
--- a/src/views/common/HoverableObject.tsx
+++ b/src/views/common/HoverableObject.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { usePageParams } from '../../controls/PageParamsContext';
 import Hoverable from '../../generic/Hoverable';
 import { ObjectData } from '../../types/DataTypes';
-import { ObjectType, View } from '../../types/PageParamTypes';
+import { ObjectType, PageParamsOptional, View } from '../../types/PageParamTypes';
 import CensusCard from '../census/CensusCard';
 import LanguageCard from '../language/LanguageCard';
 import LocaleCard from '../locale/LocaleCard';
@@ -39,6 +39,11 @@ const HoverableObject: React.FC<Props> = ({ object, children, style }) => {
         return <VariantTagCard data={object} />;
     }
   };
+  const onClick = useCallback(() => {
+    const params: PageParamsOptional = { objectID: object.ID };
+    if (view === View.Details) params.objectType = object.type;
+    updatePageParams(params);
+  }, [object, updatePageParams, view]);
 
   return (
     <Hoverable
@@ -54,12 +59,7 @@ const HoverableObject: React.FC<Props> = ({ object, children, style }) => {
           {getHoverContent()}
         </>
       }
-      onClick={() =>
-        updatePageParams({
-          objectType: view === View.Details ? object.type : undefined,
-          objectID: object.ID,
-        })
-      }
+      onClick={onClick}
       style={style}
     >
       {children}

--- a/src/views/common/table/CommonColumns.tsx
+++ b/src/views/common/table/CommonColumns.tsx
@@ -13,6 +13,7 @@ export const CodeColumn: TableColumn<ObjectData> = {
     <ObjectFieldHighlightedByPageSearch object={object} field={SearchableField.Code} />
   ),
   sortParam: SortBy.Code,
+  columnGroup: 'Codes',
 };
 
 export const NameColumn: TableColumn<ObjectData> = {
@@ -23,6 +24,7 @@ export const NameColumn: TableColumn<ObjectData> = {
     </HoverableObject>
   ),
   sortParam: SortBy.Name,
+  columnGroup: 'Names',
 };
 
 export const EndonymColumn: TableColumn<ObjectData> = {
@@ -32,4 +34,5 @@ export const EndonymColumn: TableColumn<ObjectData> = {
   ),
   sortParam: SortBy.Endonym,
   isInitiallyVisible: false,
+  columnGroup: 'Names',
 };

--- a/src/views/common/table/ObjectTable.tsx
+++ b/src/views/common/table/ObjectTable.tsx
@@ -16,9 +16,11 @@ import { DetailsContainer } from '../details/ObjectDetailsPage';
 import ObjectTitle from '../ObjectTitle';
 
 import './tableStyles.css';
+import TableColumnSelector from './TableColumnSelector';
 import TableSortButton from './TableSortButton';
 
 export interface TableColumn<T> {
+  columnGroup?: string; // "Key" for the parent column
   isInitiallyVisible?: boolean;
   isNumeric?: boolean;
   key: string;
@@ -48,10 +50,10 @@ function ObjectTable<T extends ObjectData>({
     Object.fromEntries(columns.map((col) => [col.key, col.isInitiallyVisible ?? true])),
   );
 
-  const toggleColumn = useCallback((columnKey: string) => {
+  const toggleColumn = useCallback((columnKey: string, isVisible?: boolean) => {
     setVisibleColumns((prev) => ({
       ...prev,
-      [columnKey]: !prev[columnKey],
+      [columnKey]: isVisible ?? !prev[columnKey],
     }));
   }, []);
 
@@ -76,24 +78,12 @@ function ObjectTable<T extends ObjectData>({
         objects={objects}
         shouldFilterUsingSearchBar={shouldFilterUsingSearchBar}
       />
-      <details style={{ margin: '.5em 0 1em 0', gap: '.5em 1em' }}>
-        <summary style={{ cursor: 'pointer' }}>
-          {currentlyVisibleColumns.length}/{columns.length} columns visible, click here to toggle.
-        </summary>
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '.5em' }}>
-          {columns.map((column) => (
-            <label key={column.key} style={{ cursor: 'pointer' }}>
-              <input
-                type="checkbox"
-                checked={visibleColumns[column.key] || false}
-                onChange={() => toggleColumn(column.key)}
-                style={{ marginRight: '0.5rem' }}
-              />
-              {column.label ?? column.key}
-            </label>
-          ))}
-        </div>
-      </details>
+      <TableColumnSelector
+        columns={columns}
+        currentlyVisibleColumns={currentlyVisibleColumns}
+        visibleColumns={visibleColumns}
+        toggleColumn={toggleColumn}
+      />
 
       <table className="ObjectTable">
         <thead>

--- a/src/views/common/table/TableColumnSelector.tsx
+++ b/src/views/common/table/TableColumnSelector.tsx
@@ -1,0 +1,147 @@
+import { SquareCheckIcon, SquareIcon, SquareMinusIcon } from 'lucide-react';
+import React, { useCallback } from 'react';
+
+import Hoverable from '../../../generic/Hoverable';
+import { ObjectData } from '../../../types/DataTypes';
+
+import { TableColumn } from './ObjectTable';
+
+function TableColumnSelector<T extends ObjectData>({
+  columns,
+  currentlyVisibleColumns,
+  visibleColumns,
+  toggleColumn,
+}: {
+  columns: TableColumn<T>[];
+  currentlyVisibleColumns: TableColumn<T>[];
+  visibleColumns: Record<string, boolean>;
+  toggleColumn: (key: string, isVisible?: boolean) => void;
+}): React.ReactNode {
+  const columnsByGroup = getColumnsByGroup(columns);
+
+  return (
+    <details style={{ margin: '.5em 0 1em 0', gap: '.5em 1em' }}>
+      <summary style={{ cursor: 'pointer' }}>
+        {currentlyVisibleColumns.length}/{columns.length} columns visible, click here to toggle.
+      </summary>
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: '.5em',
+          backgroundColor: 'var(--color-button-secondary)',
+          padding: '0.5em',
+          borderRadius: '.5em',
+        }}
+      >
+        {Object.entries(columnsByGroup).map(([group, columns]) => (
+          <ColumnGroup
+            key={group}
+            group={group}
+            columns={columns}
+            visibleColumns={visibleColumns}
+            toggleColumn={toggleColumn}
+          />
+        ))}
+      </div>
+    </details>
+  );
+}
+
+function getColumnsByGroup<T extends ObjectData>(
+  columns: TableColumn<T>[],
+): Record<string, TableColumn<T>[]> {
+  return columns.reduce(
+    (groups, column) => {
+      const group = column.columnGroup || column.key;
+      if (!groups[group]) groups[group] = [];
+      groups[group].push(column);
+      return groups;
+    },
+    {} as Record<string, TableColumn<T>[]>,
+  );
+}
+
+function ColumnGroup<T extends ObjectData>({
+  group,
+  columns,
+  visibleColumns,
+  toggleColumn,
+}: {
+  group: string;
+  columns: TableColumn<T>[];
+  visibleColumns: Record<string, boolean>;
+  toggleColumn: (key: string, isVisible?: boolean) => void;
+}): React.ReactNode {
+  // If all columns are visible, this function will turn them all off
+  // If no columns are visible, this function will turn them all on
+  // If some columns are visible, this function will turn them all on
+  const allVisible = columns.every((col) => visibleColumns[col.key]);
+  const someVisible = columns.some((col) => visibleColumns[col.key]);
+  const toggleSelectAll = useCallback(() => {
+    columns.forEach((col) => toggleColumn(col.key, !allVisible));
+  }, [columns, toggleColumn, allVisible]);
+  const toggleSelectHoverContent = allVisible
+    ? 'All columns visible. Click to hide all columns in this group.'
+    : someVisible
+      ? 'Some columns visible. Click to show all columns in this group.'
+      : 'No columns visible. Click to show all columns in this group.';
+
+  return (
+    <div
+      key={group}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        marginRight: '1em',
+        alignItems: 'flex-start',
+      }}
+    >
+      {columns.length > 1 && (
+        <strong>
+          {group}
+          <Hoverable
+            hoverContent={toggleSelectHoverContent}
+            onClick={toggleSelectAll}
+            style={{ marginLeft: '0.125em' }}
+          >
+            {allVisible ? (
+              <SquareCheckIcon size="1em" />
+            ) : someVisible ? (
+              <SquareMinusIcon size="1em" />
+            ) : (
+              <SquareIcon size="1em" />
+            )}
+          </Hoverable>
+        </strong>
+      )}
+      {columns.map((column) => (
+        <ColumnCheckbox
+          key={column.key}
+          column={column}
+          isChecked={visibleColumns[column.key] || false}
+          toggleColumn={toggleColumn}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ColumnCheckbox<T extends ObjectData>({
+  column,
+  isChecked,
+  toggleColumn,
+}: {
+  column: TableColumn<T>;
+  isChecked: boolean;
+  toggleColumn: (key: string) => void;
+}): React.ReactNode {
+  return (
+    <label key={column.key} style={{ cursor: 'pointer', fontWeight: 'normal' }}>
+      <input type="checkbox" checked={isChecked} onChange={() => toggleColumn(column.key)} />
+      {column.label ?? column.key}
+    </label>
+  );
+}
+
+export default TableColumnSelector;

--- a/src/views/language/LanguageTable.tsx
+++ b/src/views/language/LanguageTable.tsx
@@ -22,14 +22,7 @@ const LanguageTable: React.FC = () => {
     render: (lang: LanguageData): ReactNode => (
       <div style={{ display: 'flex', alignItems: 'center' }}>
         {lang.codeDisplay}
-        {lang.warnings && lang.warnings[LanguageField.isoCode] && (
-          <Hoverable
-            hoverContent={lang.warnings[LanguageField.isoCode]}
-            style={{ marginLeft: '0.125em' }}
-          >
-            <TriangleAlertIcon size="1em" display="block" color="var(--color-text-yellow)" />
-          </Hoverable>
-        )}
+        {<MaybeISOWarning lang={lang} />}
       </div>
     ),
   };
@@ -39,6 +32,23 @@ const LanguageTable: React.FC = () => {
       objects={languagesInSelectedSource}
       columns={[
         codeColumn,
+        {
+          key: 'ISO 639-3',
+          render: (lang) => (
+            <div style={{ display: 'flex', alignItems: 'center' }}>
+              {lang.sourceSpecific.ISO.code}
+              {<MaybeISOWarning lang={lang} />}
+            </div>
+          ),
+          isInitiallyVisible: false,
+          columnGroup: 'Codes',
+        },
+        {
+          key: 'Glottocode',
+          render: (lang) => lang.sourceSpecific.Glottolog.code,
+          isInitiallyVisible: false,
+          columnGroup: 'Codes',
+        },
         NameColumn,
         endonymColumn,
         {
@@ -57,6 +67,7 @@ const LanguageTable: React.FC = () => {
           render: (lang) => lang.populationEstimate,
           isNumeric: true,
           sortParam: SortBy.Population,
+          columnGroup: 'Population',
         },
         {
           key: 'Population Attested',
@@ -74,6 +85,7 @@ const LanguageTable: React.FC = () => {
           isNumeric: true,
           isInitiallyVisible: false,
           sortParam: SortBy.PopulationAttested,
+          columnGroup: 'Population',
         },
         {
           key: 'Population of Descendents',
@@ -98,18 +110,21 @@ const LanguageTable: React.FC = () => {
           isNumeric: true,
           isInitiallyVisible: false,
           sortParam: SortBy.PopulationOfDescendents,
+          columnGroup: 'Population',
         },
         {
           key: 'CLDR Coverage',
           label: 'CLDR Coverage',
           render: (lang) => <CLDRCoverageText object={lang} />,
           isInitiallyVisible: false,
+          columnGroup: 'Digital Support',
         },
         {
           key: 'ICU Support',
           label: 'ICU Support',
           render: (lang) => <ICUSupportStatus object={lang} />,
           isInitiallyVisible: false,
+          columnGroup: 'Digital Support',
         },
         {
           key: 'Parent Language',
@@ -140,10 +155,22 @@ const LanguageTable: React.FC = () => {
           key: 'Wikipedia',
           render: (object) => <ObjectWikipediaInfo object={object} size="compact" />,
           isInitiallyVisible: false,
+          columnGroup: 'Digital Support',
         },
       ]}
     />
   );
 };
+
+function MaybeISOWarning({ lang }: { lang: LanguageData }): React.ReactNode | null {
+  return lang.warnings && lang.warnings[LanguageField.isoCode] ? (
+    <Hoverable
+      hoverContent={lang.warnings[LanguageField.isoCode]}
+      style={{ marginLeft: '0.125em' }}
+    >
+      <TriangleAlertIcon size="1em" display="block" color="var(--color-text-yellow)" />
+    </Hoverable>
+  ) : null;
+}
 
 export default LanguageTable;

--- a/src/views/locale/LocaleTable.tsx
+++ b/src/views/locale/LocaleTable.tsx
@@ -38,6 +38,7 @@ const LocaleTable: React.FC = () => {
           render: (object) => object.populationSpeaking,
           isNumeric: true,
           sortParam: SortBy.Population,
+          columnGroup: 'Demographics',
         },
         {
           key: 'Literacy',
@@ -48,6 +49,7 @@ const LocaleTable: React.FC = () => {
           isInitiallyVisible: false,
           isNumeric: true,
           sortParam: SortBy.Literacy,
+          columnGroup: 'Demographics',
         },
         {
           key: '% in Territory',
@@ -63,10 +65,12 @@ const LocaleTable: React.FC = () => {
             ),
           isNumeric: true,
           sortParam: SortBy.RelativePopulation,
+          columnGroup: 'Demographics',
         },
         {
           key: 'Population Source',
           render: (object) => <LocaleCensusCitation locale={object} size="short" />,
+          columnGroup: 'Demographics',
         },
         {
           key: 'Contained Locales',


### PR DESCRIPTION
This change adds column groups. Since we're adding more and more data it gets hard to maintain. Fortunately we can group columns.

|What|Before|After|
|--|--|--|
|[Language Table](https://translation-commons.github.io/lang-nav/data?view=Table&languageScopes=Macrolanguage%2CLanguage&objectType=Language)|<img width="748" height="371" alt="Screenshot 2025-10-02 at 10 56 46" src="https://github.com/user-attachments/assets/ae4193d7-2c2c-40d6-afe7-0d8f313b40ff" />|<img width="747" height="428" alt="Screenshot 2025-10-02 at 10 53 28" src="https://github.com/user-attachments/assets/490f423c-c22a-44e4-9cfc-bf548b42d7b3" />
|[Locale Table](https://translation-commons.github.io/lang-nav/data?view=Table&languageScopes=Macrolanguage%2CLanguage&objectType=Locale)|<img width="748" height="341" alt="Screenshot 2025-10-02 at 10 57 04" src="https://github.com/user-attachments/assets/e2fa89ef-ee3a-4a8b-83bc-6dfb96600779" />|<img width="742" height="426" alt="Screenshot 2025-10-02 at 10 58 38" src="https://github.com/user-attachments/assets/30116949-b881-478f-90dd-91a3d25a5657" />

