### PR TITLE
Add Vitality columns to LanguageTable

### DIFF
--- a/src/views/language/LanguageTable.tsx
+++ b/src/views/language/LanguageTable.tsx
@@ -1,4 +1,4 @@
-import { InfoIcon, TriangleAlertIcon } from 'lucide-react';
+import { InfoIcon, TriangleAlertIcon, Wifi, WifiHigh, WifiLow, WifiOff } from 'lucide-react';
 import React, { ReactNode } from 'react';
 
 import { getUniqueTerritoriesForLanguage } from '../../controls/sort';
@@ -7,6 +7,12 @@ import Hoverable from '../../generic/Hoverable';
 import HoverableEnumeration from '../../generic/HoverableEnumeration';
 import { LanguageData, LanguageField } from '../../types/LanguageTypes';
 import { SortBy } from '../../types/PageParamTypes';
+import {
+  computeVitalityMetascore,
+  getAllVitalityScores,
+  getVitalityExplanation,
+  VitalityMeterType,
+} from './LanguageVitalityComputation';
 import { CLDRCoverageText, ICUSupportStatus } from '../common/CLDRCoverageInfo';
 import HoverableObjectName from '../common/HoverableObjectName';
 import ObjectWikipediaInfo from '../common/ObjectWikipediaInfo';
@@ -16,6 +22,38 @@ import ObjectTable from '../common/table/ObjectTable';
 
 const LanguageTable: React.FC = () => {
   const { languagesInSelectedSource } = useDataContext();
+
+  // Helper functions for vitality display
+  function scoreBucket(score: number | null): 0 | 1 | 2 | 3 {
+    if (score === null) return 0;
+    if (score >= 7) return 3;     // strong
+    if (score >= 4) return 2;     // medium
+    if (score >= 1) return 1;     // low
+    return 0;                     // none/extinct
+  }
+
+  function bucketIcon(bucket: 0 | 1 | 2 | 3) {
+    switch (bucket) {
+      case 3: return <WifiHigh size="1em" />;
+      case 2: return <Wifi size="1em" />;
+      case 1: return <WifiLow size="1em" />;
+      default: return <WifiOff size="1em" />;
+    }
+  }
+
+  function bucketColor(bucket: 0 | 1 | 2 | 3): string {
+    switch (bucket) {
+      case 3: return 'var(--color-text-green)';
+      case 2: return 'var(--color-text-yellow)';
+      case 1: return 'var(--color-text-orange)';
+      default: return 'var(--color-text-red)';
+    }
+  }
+
+  function scoreLabel(score: number | null): string {
+    if (score === null) return '—';
+    return String(score);
+  }
   const endonymColumn = { ...EndonymColumn, isInitiallyVisible: true };
   const codeColumn = {
     ...CodeColumn,
@@ -111,6 +149,84 @@ const LanguageTable: React.FC = () => {
           isInitiallyVisible: false,
           sortParam: SortBy.PopulationOfDescendents,
           columnGroup: 'Population',
+        },
+        {
+          key: 'Vitality (Meta)',
+          label: 'Vitality (Meta)',
+          render: (lang) => {
+            const { score, explanation } = computeVitalityMetascore(lang);
+            const b = scoreBucket(score);
+            return (
+              <Hoverable hoverContent={explanation}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.35em', color: bucketColor(b) }}>
+                  {bucketIcon(b)}
+                  <span style={{ fontVariantNumeric: 'tabular-nums' }}>{scoreLabel(score)}</span>
+                </div>
+              </Hoverable>
+            );
+          },
+          isNumeric: true,
+          columnGroup: 'Vitality',
+        },
+        {
+          key: 'Vitality (ISO)',
+          label: 'Vitality (ISO)',
+          render: (lang) => {
+            const all = getAllVitalityScores(lang);
+            const s = all[VitalityMeterType.ISO].score;
+            const b = scoreBucket(s);
+            return (
+              <Hoverable hoverContent={getVitalityExplanation(VitalityMeterType.ISO, lang, s)}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.35em', color: bucketColor(b) }}>
+                  {bucketIcon(b)}
+                  <span style={{ fontVariantNumeric: 'tabular-nums' }}>{scoreLabel(s)}</span>
+                </div>
+              </Hoverable>
+            );
+          },
+          isNumeric: true,
+          isInitiallyVisible: false,
+          columnGroup: 'Vitality',
+        },
+        {
+          key: 'Vitality (Eth 2013)',
+          label: 'Vitality (Eth 2013)',
+          render: (lang) => {
+            const all = getAllVitalityScores(lang);
+            const s = all[VitalityMeterType.Eth2013].score;
+            const b = scoreBucket(s);
+            return (
+              <Hoverable hoverContent={getVitalityExplanation(VitalityMeterType.Eth2013, lang, s)}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.35em', color: bucketColor(b) }}>
+                  {bucketIcon(b)}
+                  <span style={{ fontVariantNumeric: 'tabular-nums' }}>{scoreLabel(s)}</span>
+                </div>
+              </Hoverable>
+            );
+          },
+          isNumeric: true,
+          isInitiallyVisible: false,
+          columnGroup: 'Vitality',
+        },
+        {
+          key: 'Vitality (Eth 2025)',
+          label: 'Vitality (Eth 2025)',
+          render: (lang) => {
+            const all = getAllVitalityScores(lang);
+            const s = all[VitalityMeterType.Eth2025].score;
+            const b = scoreBucket(s);
+            return (
+              <Hoverable hoverContent={getVitalityExplanation(VitalityMeterType.Eth2025, lang, s)}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.35em', color: bucketColor(b) }}>
+                  {bucketIcon(b)}
+                  <span style={{ fontVariantNumeric: 'tabular-nums' }}>{scoreLabel(s)}</span>
+                </div>
+              </Hoverable>
+            );
+          },
+          isNumeric: true,
+          isInitiallyVisible: false,
+          columnGroup: 'Vitality',
         },
         {
           key: 'CLDR Coverage',


### PR DESCRIPTION
- Add 4 new vitality columns: Meta, ISO, Eth 2013, Eth 2025
- Use wifi icons (WifiHigh/Wifi/WifiLow/WifiOff) for visual indicators
- Color code scores: green (strong), yellow (medium), orange (low), red (extinct)
- Show numeric scores (0-9) with hover explanations
- Group columns under 'Vitality' category
- Metascore column visible by default, others hidden initially"

<img width="1260" height="471" alt="Screenshot 2025-10-03 at 12 05 02 PM" src="https://github.com/user-attachments/assets/a2c6bda1-ac41-4c48-9a28-f255cef6a39d" />
