### PR TITLE
Tables: Column selection page param

### DIFF
--- a/src/features/page-params/getNewURLSearchParams.ts
+++ b/src/features/page-params/getNewURLSearchParams.ts
@@ -54,7 +54,5 @@ export function getNewURLSearchParams(
     }
   });
 
-  // When changing the object type, some parameters may be too different (eg. the table columns selected)
-
   return next;
 }

--- a/src/features/stored-params/useStoredParams.tsx
+++ b/src/features/stored-params/useStoredParams.tsx
@@ -45,24 +45,25 @@ export default function useStoredParams<T>(
     }
   }, [key, value]);
 
-  // listen for storage events to sync across tabs
-  useEffect(() => {
-    const handle = (e: StorageEvent) => {
-      if (e.storageArea !== sessionStorage) return;
-      if (e.key !== key) return;
-      try {
-        if (e.newValue == null) {
-          setValueState(resolveDefault());
-        } else {
-          setValueState(JSON.parse(e.newValue) as T);
-        }
-      } catch {
-        setValueState(resolveDefault());
-      }
-    };
-    window.addEventListener('storage', handle);
-    return () => window.removeEventListener('storage', handle);
-  }, [key, resolveDefault]);
+  // Commented out, only applicable to `localStorage`
+  // // listen for storage events to sync across tabs
+  // useEffect(() => {
+  //   const handle = (e: StorageEvent) => {
+  //     if (e.storageArea !== sessionStorage) return;
+  //     if (e.key !== key) return;
+  //     try {
+  //       if (e.newValue == null) {
+  //         setValueState(resolveDefault());
+  //       } else {
+  //         setValueState(JSON.parse(e.newValue) as T);
+  //       }
+  //     } catch {
+  //       setValueState(resolveDefault());
+  //     }
+  //   };
+  //   window.addEventListener('storage', handle);
+  //   return () => window.removeEventListener('storage', handle);
+  // }, [key, resolveDefault]);
 
   const setValue = useCallback(
     (updater: Updater<T>) => {

--- a/src/features/table/ObjectTable.tsx
+++ b/src/features/table/ObjectTable.tsx
@@ -52,7 +52,8 @@ function ObjectTable<T extends ObjectData>({
   const scopeFilter = getScopeFilter();
   const sliceFunction = getSliceFunction<T>();
 
-  const { visibleColumns, toggleColumn, columnVisibility } = useColumnVisibility(columns);
+  const { visibleColumns, toggleColumn, columnVisibility, resetColumnVisibility } =
+    useColumnVisibility(columns);
 
   // TODO don't filter objects for an unrelated page search on a different object type
   const objectsFilteredAndSorted = useMemo(() => {
@@ -72,6 +73,7 @@ function ObjectTable<T extends ObjectData>({
       <TableColumnSelector
         columns={columns}
         columnVisibility={columnVisibility}
+        resetColumnVisibility={resetColumnVisibility}
         toggleColumn={toggleColumn}
       />
 

--- a/src/features/table/TableColumnSelector.test.tsx
+++ b/src/features/table/TableColumnSelector.test.tsx
@@ -34,6 +34,7 @@ describe('TableColumnSelector', () => {
         <TableColumnSelector
           columns={columns}
           columnVisibility={columnVisibility}
+          resetColumnVisibility={vi.fn()}
           toggleColumn={toggleMock}
         />
       </HoverCardProvider>,
@@ -57,6 +58,7 @@ describe('TableColumnSelector', () => {
         <TableColumnSelector
           columns={columns}
           columnVisibility={columnVisibility}
+          resetColumnVisibility={vi.fn()}
           toggleColumn={toggleMock}
         />
       </HoverCardProvider>,
@@ -87,6 +89,7 @@ describe('TableColumnSelector', () => {
         <TableColumnSelector
           columns={columns}
           columnVisibility={columnVisibility}
+          resetColumnVisibility={vi.fn()}
           toggleColumn={toggleMock}
         />
       </HoverCardProvider>,

--- a/src/features/table/TableColumnSelector.tsx
+++ b/src/features/table/TableColumnSelector.tsx
@@ -7,6 +7,7 @@ import { ObjectData } from '@entities/types/DataTypes';
 
 import { groupBy } from '@shared/lib/setUtils';
 import Hoverable from '@shared/ui/Hoverable';
+import HoverableButton from '@shared/ui/HoverableButton';
 
 import { TableColumn } from './ObjectTable';
 import TableSortButton from './TableSortButton';
@@ -14,10 +15,12 @@ import TableSortButton from './TableSortButton';
 function TableColumnSelector<T extends ObjectData>({
   columns,
   columnVisibility,
+  resetColumnVisibility,
   toggleColumn,
 }: {
   columns: TableColumn<T>[];
   columnVisibility: Record<string, boolean>;
+  resetColumnVisibility: () => void;
   toggleColumn: (key: string, isVisible?: boolean) => void;
 }): React.ReactNode {
   const columnsByGroup = groupBy(columns, (column) => column.columnGroup || column.key);
@@ -47,6 +50,13 @@ function TableColumnSelector<T extends ObjectData>({
             toggleColumn={toggleColumn}
           />
         ))}
+        <HoverableButton
+          onClick={resetColumnVisibility}
+          style={{ height: 'fit-content', justifySelf: 'end', alignSelf: 'end' }}
+          hoverContent="Reset to default column visibility"
+        >
+          Reset
+        </HoverableButton>
       </div>
     </details>
   );
@@ -128,7 +138,7 @@ function ColumnCheckbox<T extends ObjectData>({
 }): React.ReactNode {
   const { sortBy } = usePageParams();
   return (
-    <label key={column.key} style={{ cursor: 'pointer', fontWeight: 'normal' }}>
+    <label key={column.key} style={{ cursor: 'pointer', fontWeight: 'normal', textAlign: 'start' }}>
       <input
         type="checkbox"
         checked={isChecked || sortBy === column.sortParam}

--- a/src/features/table/useColumnVisibility.tsx
+++ b/src/features/table/useColumnVisibility.tsx
@@ -13,6 +13,7 @@ function useColumnVisibility<T extends ObjectData>(
   toggleColumn: (columnKey: string, isVisible?: boolean) => void;
   visibleColumns: TableColumn<T>[];
   columnVisibility: Record<string, boolean>;
+  resetColumnVisibility: () => void;
 } {
   const { sortBy } = usePageParams();
 
@@ -24,9 +25,11 @@ function useColumnVisibility<T extends ObjectData>(
   // allColumnVisibility maps column keys to whether they are visible, persisted in stored params
   // Column keys that are reused (like ID, Name) are reused so if you turn on/off an ID column
   // then switch table views the state will remain.
-  const { value: allColumnVisibility, setValue: setAllColumnVisibility } = useStoredParams<
-    Record<string, boolean>
-  >('column-visibility', defaultColumnVisibility);
+  const {
+    value: allColumnVisibility,
+    setValue: setAllColumnVisibility,
+    clear: resetColumnVisibility,
+  } = useStoredParams<Record<string, boolean>>('column-visibility', defaultColumnVisibility);
 
   const toggleColumn = useCallback(
     (columnKey: string, isVisible?: boolean) => {
@@ -50,14 +53,14 @@ function useColumnVisibility<T extends ObjectData>(
         defaultColumnVisibility[col.key];
       return acc;
     }, {});
-  }, [allColumnVisibility, columns]);
+  }, [allColumnVisibility, columns, defaultColumnVisibility, sortBy]);
 
   const visibleColumns = useMemo(
     () => columns.filter((column) => columnVisibility[column.key]),
-    [columns, columnVisibility, sortBy],
+    [columns, columnVisibility],
   );
 
-  return { visibleColumns, toggleColumn, columnVisibility };
+  return { visibleColumns, toggleColumn, columnVisibility, resetColumnVisibility };
 }
 
 export default useColumnVisibility;

--- a/test-coverage.md
+++ b/test-coverage.md
@@ -50,7 +50,7 @@
 | `      writingsystem`                    |     0   |   100.0 |   100.0 |     0   |
 | `        WritingSystemCard.tsx`          |     0   |   100.0 |   100.0 |     0   |
 | `        WritingSystemSuggestions.tsx`   |     0   |   100.0 |   100.0 |     0   |
-| `    features`                           |    26.9 |    75.3 |    28.8 |    26.9 |
+| `    features`                           |    27.2 |    75.3 |    28.8 |    27.2 |
 | `      data-loading`                     |    28.8 |    75.0 |    25.7 |    28.8 |
 | `        CensusData.tsx`                 |     2.7 |   100.0 |     0   |     2.7 |
 | `        CoreData.tsx`                   |    17.6 |   100.0 |     0   |    17.6 |
@@ -88,10 +88,10 @@
 | `        SortTypes.tsx`                  |   100.0 |   100.0 |   100.0 |   100.0 |
 | `      stored-params`                    |     0   |     0   |     0   |     0   |
 | `        useStoredParams.tsx`            |     0   |     0   |     0   |     0   |
-| `      table`                            |    47.9 |    79.4 |    60.0 |    47.9 |
+| `      table`                            |    48.5 |    79.4 |    60.0 |    48.5 |
 | `        CommonColumns.tsx`              |     0   |     0   |     0   |     0   |
 | `        ObjectTable.tsx`                |     0   |     0   |     0   |     0   |
-| `        TableColumnSelector.tsx`        |    96.4 |    90.5 |   100.0 |    96.4 |
+| `        TableColumnSelector.tsx`        |    96.6 |    90.5 |   100.0 |    96.6 |
 | `        TableSortButton.tsx`            |    77.2 |    80.0 |    66.7 |    77.2 |
 | `        useColumnVisibility.tsx`        |     0   |     0   |     0   |     0   |
 | `      treelist`                         |     0   |    40.0 |    40.0 |     0   |


### PR DESCRIPTION
While developing I was getting annoyed that column selection was not persisting. This PR makes the column selection persist for your session (for your particular tab)

# Background 
I considered making column selection a URL parameter but it was a bit difficult to scale. The most first successful change was to make column selection a binary number (each digit corresponds to if a column is off or on) & put the binary number in the URL (converted to decimal, but we could have done alphanumeric). This has the benefits of being stored in the URL and part of the page history.

Unfortunately I realized it controlled columns in all tables, so if you selected column 1, 2, and 5 in the LanguageTable and opened a TerritoryTable, then it stayed with 1,2,5 selected. I considered making the page parameters reset if you change ObjectType -- but the Table view can be opened for multiple table types, even multiple table for the same object type. Scaling this sounded impossible inside a URL.

Another thing I considered was encoding the columnVisibility array using encoding functions -- but I similarily didn't think it would scale.

Thereby, I gave up on using the URL parameters and, instead, am using sessionStorage. localStorage and sessionStorage are almost the same thing -- but localStorage persists across tabs, sessionStorage is only in the same tab.

# Changes

* Moved column visibility functions to `useColumnVisibility` hook.
* Added `useStoredParams` hook
* Changed the storage parameter from `useState` to `useStoredParams`
* Added a button to reset visibility.

# Testing

I added some vitest tests and I also used the website:
* Go to Table view http://localhost:5173/lang-nav/data?view=Table
* Open column selection, click on/off some columns, including common ones like Name
* Changed object type to see the unique ones not change
* Refresh page, verified its persistent
* Open new tabs, verified changes don't affect those tabs