### PR TITLE
Tables: Move column definition to separate file

### DIFF
--- a/src/features/table/CommonColumns.tsx
+++ b/src/features/table/CommonColumns.tsx
@@ -5,7 +5,7 @@ import { ObjectData } from '@entities/types/DataTypes';
 import HoverableObject from '@entities/ui/HoverableObject';
 import { ObjectFieldHighlightedByPageSearch } from '@entities/ui/ObjectField';
 
-import { TableColumn } from './ObjectTable';
+import TableColumn from './TableColumn';
 
 const NAME_COLUMN_MAX_WIDTH = '20em';
 

--- a/src/features/table/ObjectTable.tsx
+++ b/src/features/table/ObjectTable.tsx
@@ -1,11 +1,9 @@
 import { InfoIcon } from 'lucide-react';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { DetailsContainer } from '@pages/dataviews/ViewDetails';
 
 import ObjectDetails from '@widgets/details/ObjectDetails';
-
-import { SortBy } from '@features/sorting/SortTypes';
 
 import { ObjectData } from '@entities/types/DataTypes';
 import ObjectTitle from '@entities/ui/ObjectTitle';
@@ -22,30 +20,14 @@ import {
 import VisibleItemsMeter from '../pagination/VisibleItemsMeter';
 import { getSortFunction } from '../sorting/sort';
 
+import TableColumn from './TableColumn';
 import TableColumnSelector from './TableColumnSelector';
 import TableSortButton from './TableSortButton';
 import useColumnVisibility from './useColumnVisibility';
 
 import './tableStyles.css';
 
-export enum ValueType {
-  Numeric = 'numeric',
-  String = 'string',
-  Enum = 'enum',
-}
 const MAX_COLUMN_WIDTH = '10em';
-
-// Readonly, don't mutate the TableColumn definitions
-export interface TableColumn<T> {
-  readonly columnGroup?: string; // "Key" for the parent column
-  readonly isInitiallyVisible?: boolean;
-  readonly valueType?: ValueType;
-  readonly key: string;
-  readonly label?: React.ReactNode;
-  readonly description?: React.ReactNode;
-  readonly render: (object: T) => React.ReactNode;
-  readonly sortParam?: SortBy;
-}
 
 interface Props<T> {
   objects: T[];
@@ -119,7 +101,7 @@ function ObjectTable<T extends ObjectData>({
                 return (
                   <td
                     key={column.key}
-                    className={column.valueType === ValueType.Numeric ? 'numeric' : undefined}
+                    className={column.valueType}
                     style={{ maxWidth: MAX_COLUMN_WIDTH }}
                   >
                     {content}

--- a/src/features/table/TableColumn.tsx
+++ b/src/features/table/TableColumn.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { SortBy } from '@features/sorting/SortTypes';
+
+import TableValueType from './TableValueType';
+
+interface TableColumn<T> {
+  /** Unique key for the column, also used as the plain text header for the column in the export  */
+  readonly key: string;
+  /** Description shown when hovering over an info icon next to the column */
+  readonly description?: React.ReactNode;
+  /**  Label shown in the table; falls back to `key`. Useful to add additional markup */
+  readonly label?: React.ReactNode;
+  /** The group this column belongs to, used to organize columns in the UI */
+  readonly columnGroup?: string;
+
+  /** Function that renders rich React content for a cell */
+  readonly render: (object: T) => React.ReactNode;
+
+  /** Indicate the type of data in the column; influences sorting and alignment */
+  readonly valueType?: TableValueType;
+
+  /**
+   * The sorting page parameter relevant to this column, adding this will
+   * add a sorting icon next to the column header that can be clicked to enable
+   * sorting by the data in this column as defined by `sort.tsx`.
+   */
+  readonly sortParam?: SortBy;
+
+  /** Whether the column is visible by default in the UI */
+  readonly isInitiallyVisible?: boolean;
+}
+
+export default TableColumn;

--- a/src/features/table/TableColumnSelector.tsx
+++ b/src/features/table/TableColumnSelector.tsx
@@ -9,7 +9,7 @@ import { groupBy } from '@shared/lib/setUtils';
 import Hoverable from '@shared/ui/Hoverable';
 import HoverableButton from '@shared/ui/HoverableButton';
 
-import { TableColumn } from './ObjectTable';
+import TableColumn from './TableColumn';
 import TableSortButton from './TableSortButton';
 
 function TableColumnSelector<T extends ObjectData>({

--- a/src/features/table/TableSortButton.tsx
+++ b/src/features/table/TableSortButton.tsx
@@ -15,14 +15,14 @@ import HoverableButton from '@shared/ui/HoverableButton';
 
 import { getNormalSortDirection } from '../sorting/sort';
 
-import { ValueType } from './ObjectTable';
+import TableValueType from './TableValueType';
 
 type Props = {
   columnSortBy?: SortBy;
-  valueType?: ValueType;
+  valueType?: TableValueType;
 };
 
-const TableSortButton: React.FC<Props> = ({ columnSortBy, valueType = ValueType.String }) => {
+const TableSortButton: React.FC<Props> = ({ columnSortBy, valueType = TableValueType.String }) => {
   const { sortBy, updatePageParams, sortBehavior } = usePageParams();
 
   if (!columnSortBy) {
@@ -64,19 +64,19 @@ const TableSortButton: React.FC<Props> = ({ columnSortBy, valueType = ValueType.
 };
 
 type SortButtonIconProps = {
-  valueType?: ValueType;
+  valueType?: TableValueType;
   sortDirection?: SortDirection;
 };
 
 function SortButtonIcon({ valueType, sortDirection }: SortButtonIconProps) {
   switch (valueType) {
-    case ValueType.Numeric:
+    case TableValueType.Numeric:
       return sortDirection === SortDirection.Ascending ? (
         <ArrowDown01 size="1em" display="block" />
       ) : (
         <ArrowDown10 size="1em" display="block" />
       );
-    case ValueType.Enum:
+    case TableValueType.Enum:
       return sortDirection === SortDirection.Ascending ? (
         <ArrowDownNarrowWide size="1em" display="block" />
       ) : (

--- a/src/features/table/TableValueType.ts
+++ b/src/features/table/TableValueType.ts
@@ -1,0 +1,12 @@
+/**
+ * Used by ObjectTable to change
+ * Cell alignment (numeric cells are right-aligned)
+ * Sorting icon style (01, AZ, or wide/narrow bars)
+ */
+enum TableValueType {
+  Numeric = 'numeric',
+  String = 'string',
+  Enum = 'enum',
+}
+
+export default TableValueType;

--- a/src/features/table/__tests__/ObjectTable.test.tsx
+++ b/src/features/table/__tests__/ObjectTable.test.tsx
@@ -11,7 +11,9 @@ import { ObjectData, TerritoryScope } from '@entities/types/DataTypes';
 
 import { createMockUsePageParams } from '@tests/MockPageParams.test';
 
-import ObjectTable, { TableColumn, ValueType } from '../ObjectTable';
+import ObjectTable from '../ObjectTable';
+import TableColumn from '../TableColumn';
+import TableValueType from '../TableValueType';
 
 vi.mock('@widgets/HoverCardContext', () => ({
   useHoverCard: vi.fn().mockReturnValue({}),
@@ -64,7 +66,7 @@ describe('ObjectTable', () => {
       label: 'Name',
       render: (obj) => obj.nameDisplay,
       sortParam: SortBy.Name,
-      valueType: ValueType.String,
+      valueType: TableValueType.String,
     },
     {
       key: 'population',
@@ -76,7 +78,7 @@ describe('ObjectTable', () => {
         return '';
       },
       sortParam: SortBy.Population,
-      valueType: ValueType.Numeric,
+      valueType: TableValueType.Numeric,
     },
   ];
 

--- a/src/features/table/__tests__/TableSortButton.test.tsx
+++ b/src/features/table/__tests__/TableSortButton.test.tsx
@@ -6,8 +6,8 @@ import { SortBy, SortBehavior } from '@features/sorting/SortTypes';
 
 import { createMockUsePageParams } from '@tests/MockPageParams.test';
 
-import { ValueType } from '../ObjectTable';
 import TableSortButton from '../TableSortButton';
+import TableValueType from '../TableValueType';
 
 vi.mock('@features/page-params/usePageParams', () => ({
   default: vi.fn(),
@@ -119,7 +119,7 @@ describe('SortButtonIcon', () => {
       }),
     );
 
-    render(<TableSortButton columnSortBy={SortBy.Population} valueType={ValueType.Numeric} />);
+    render(<TableSortButton columnSortBy={SortBy.Population} valueType={TableValueType.Numeric} />);
 
     // Check for ArrowDown01 icon (numeric ascending)
     const svg = screen.getByRole('button').querySelector('svg');
@@ -137,7 +137,7 @@ describe('SortButtonIcon', () => {
       }),
     );
 
-    render(<TableSortButton columnSortBy={SortBy.Population} valueType={ValueType.Numeric} />);
+    render(<TableSortButton columnSortBy={SortBy.Population} valueType={TableValueType.Numeric} />);
 
     const svg = screen.getByRole('button').querySelector('svg');
     expect(svg).toBeInTheDocument();
@@ -153,7 +153,7 @@ describe('SortButtonIcon', () => {
       }),
     );
 
-    render(<TableSortButton columnSortBy={SortBy.Name} valueType={ValueType.Enum} />);
+    render(<TableSortButton columnSortBy={SortBy.Name} valueType={TableValueType.Enum} />);
 
     const svg = screen.getByRole('button').querySelector('svg');
     expect(svg).toBeInTheDocument();
@@ -166,7 +166,7 @@ describe('SortButtonIcon', () => {
       createMockUsePageParams({ sortBy: SortBy.Name, sortBehavior: SortBehavior.Reverse }),
     );
 
-    render(<TableSortButton columnSortBy={SortBy.Name} valueType={ValueType.Enum} />);
+    render(<TableSortButton columnSortBy={SortBy.Name} valueType={TableValueType.Enum} />);
 
     const svg = screen.getByRole('button').querySelector('svg');
     expect(svg).toBeInTheDocument();
@@ -182,7 +182,7 @@ describe('SortButtonIcon', () => {
       }),
     );
 
-    render(<TableSortButton columnSortBy={SortBy.Name} valueType={ValueType.String} />);
+    render(<TableSortButton columnSortBy={SortBy.Name} valueType={TableValueType.String} />);
 
     const svg = screen.getByRole('button').querySelector('svg');
     expect(svg).toBeInTheDocument();
@@ -198,7 +198,7 @@ describe('SortButtonIcon', () => {
       }),
     );
 
-    render(<TableSortButton columnSortBy={SortBy.Name} valueType={ValueType.String} />);
+    render(<TableSortButton columnSortBy={SortBy.Name} valueType={TableValueType.String} />);
 
     const svg = screen.getByRole('button').querySelector('svg');
     expect(svg).toBeInTheDocument();
@@ -230,7 +230,7 @@ describe('SortButtonIcon', () => {
       }),
     );
 
-    render(<TableSortButton columnSortBy={SortBy.Name} valueType={ValueType.String} />);
+    render(<TableSortButton columnSortBy={SortBy.Name} valueType={TableValueType.String} />);
 
     const svg = screen.getByRole('button').querySelector('svg');
     expect(svg).toBeInTheDocument();

--- a/src/features/table/useColumnVisibility.tsx
+++ b/src/features/table/useColumnVisibility.tsx
@@ -5,7 +5,7 @@ import useStoredParams from '@features/stored-params/useStoredParams';
 
 import { ObjectData } from '@entities/types/DataTypes';
 
-import { TableColumn } from './ObjectTable';
+import TableColumn from './TableColumn';
 
 function useColumnVisibility<T extends ObjectData>(
   columns: TableColumn<T>[],

--- a/src/widgets/reports/LanguagesLargestDescendant.tsx
+++ b/src/widgets/reports/LanguagesLargestDescendant.tsx
@@ -5,7 +5,8 @@ import Selector from '@widgets/controls/components/Selector';
 import { useDataContext } from '@features/data-loading/context/useDataContext';
 import { SortBy } from '@features/sorting/SortTypes';
 import { CodeColumn, NameColumn } from '@features/table/CommonColumns';
-import ObjectTable, { ValueType } from '@features/table/ObjectTable';
+import ObjectTable from '@features/table/ObjectTable';
+import TableValueType from '@features/table/TableValueType';
 
 import { LanguageData } from '@entities/language/LanguageTypes';
 import { getObjectPopulationPercentInBiggestDescendentLanguage } from '@entities/lib/getObjectPopulation';
@@ -76,7 +77,7 @@ const LanguagesLargestDescendant: React.FC = () => {
           {
             key: 'Population',
             render: (lang: LanguageData) => lang.populationEstimate,
-            valueType: ValueType.Numeric,
+            valueType: TableValueType.Numeric,
             sortParam: SortBy.Population,
           },
           {
@@ -88,7 +89,7 @@ const LanguagesLargestDescendant: React.FC = () => {
               </>
             ),
             render: (lang: LanguageData) => lang.populationOfDescendents,
-            valueType: ValueType.Numeric,
+            valueType: TableValueType.Numeric,
             sortParam: SortBy.PopulationOfDescendents,
           },
           {
@@ -104,7 +105,7 @@ const LanguagesLargestDescendant: React.FC = () => {
           {
             key: 'Descendent Population',
             render: (lang: LanguageData) => lang.largestDescendant?.populationEstimate || null,
-            valueType: ValueType.Numeric,
+            valueType: TableValueType.Numeric,
           },
 
           {
@@ -114,7 +115,7 @@ const LanguagesLargestDescendant: React.FC = () => {
                 getObjectPopulationPercentInBiggestDescendentLanguage(lang);
               return relativePopulation ? numberToFixedUnlessSmall(relativePopulation * 100) : null;
             },
-            valueType: ValueType.Numeric,
+            valueType: TableValueType.Numeric,
             sortParam: SortBy.PopulationPercentInBiggestDescendentLanguage,
           },
         ]}

--- a/src/widgets/reports/PotentialLocales.tsx
+++ b/src/widgets/reports/PotentialLocales.tsx
@@ -7,7 +7,8 @@ import { LocaleSeparator, ObjectType } from '@features/page-params/PageParamType
 import usePageParams from '@features/page-params/usePageParams';
 import { getSortFunction } from '@features/sorting/sort';
 import { SortBy } from '@features/sorting/SortTypes';
-import ObjectTable, { ValueType } from '@features/table/ObjectTable';
+import ObjectTable from '@features/table/ObjectTable';
+import TableValueType from '@features/table/TableValueType';
 
 import { CensusData } from '@entities/census/CensusTypes';
 import { LanguageCode, LanguageData } from '@entities/language/LanguageTypes';
@@ -152,7 +153,7 @@ const PotentialLocalesTable: React.FC<{
         {
           key: 'Population',
           render: (object) => object.populationSpeaking,
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.Population,
         },
         {
@@ -160,7 +161,7 @@ const PotentialLocalesTable: React.FC<{
           render: (object) =>
             object.populationSpeakingPercent &&
             numberToFixedUnlessSmall(object.populationSpeakingPercent),
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.PercentOfTerritoryPopulation,
         },
         {
@@ -170,7 +171,7 @@ const PotentialLocalesTable: React.FC<{
             numberToFixedUnlessSmall(
               (object.populationSpeaking * 100) / (object.language?.populationEstimate ?? 1),
             ),
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.PercentOfOverallLanguageSpeakers,
         },
         {

--- a/src/widgets/reports/TableOfCountriesWithCensuses.tsx
+++ b/src/widgets/reports/TableOfCountriesWithCensuses.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { useDataContext } from '@features/data-loading/context/useDataContext';
 import { SortBy } from '@features/sorting/SortTypes';
 import { CodeColumn, NameColumn } from '@features/table/CommonColumns';
-import ObjectTable, { ValueType } from '@features/table/ObjectTable';
+import ObjectTable from '@features/table/ObjectTable';
+import TableValueType from '@features/table/TableValueType';
 
 import { CensusCollectorType } from '@entities/census/CensusTypes';
 import { TerritoryData } from '@entities/types/DataTypes';
@@ -25,7 +26,7 @@ const TableOfCountriesWithCensuses: React.FC = () => {
           {
             key: 'Censuses',
             render: (territory) => territory.censuses?.length,
-            valueType: ValueType.Numeric,
+            valueType: TableValueType.Numeric,
           },
           ...Object.values(CensusCollectorType).map((collectorType) => ({
             key: collectorType,
@@ -46,13 +47,13 @@ const TableOfCountriesWithCensuses: React.FC = () => {
           {
             key: 'Population',
             render: (territory) => territory.population,
-            valueType: ValueType.Numeric,
+            valueType: TableValueType.Numeric,
             sortParam: SortBy.Population,
           },
           {
             key: 'Languages',
             render: (territory) => territory.locales?.length,
-            valueType: ValueType.Numeric,
+            valueType: TableValueType.Numeric,
             sortParam: SortBy.CountOfLanguages,
           },
         ]}

--- a/src/widgets/tables/LanguageTable.tsx
+++ b/src/widgets/tables/LanguageTable.tsx
@@ -4,7 +4,8 @@ import React, { ReactNode } from 'react';
 import { useDataContext } from '@features/data-loading/context/useDataContext';
 import { SortBy } from '@features/sorting/SortTypes';
 import { CodeColumn, EndonymColumn, NameColumn } from '@features/table/CommonColumns';
-import ObjectTable, { ValueType } from '@features/table/ObjectTable';
+import ObjectTable from '@features/table/ObjectTable';
+import TableValueType from '@features/table/TableValueType';
 
 import { LanguageData, LanguageField } from '@entities/language/LanguageTypes';
 import {
@@ -82,7 +83,7 @@ const LanguageTable: React.FC = () => {
                 .map((lang) => lang.nameDisplay)}
             />
           ),
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           isInitiallyVisible: false,
           sortParam: SortBy.CountOfLanguages,
           columnGroup: 'Relations',
@@ -96,7 +97,7 @@ const LanguageTable: React.FC = () => {
               )}
             />
           ),
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.CountOfTerritories,
           columnGroup: 'Relations',
         },
@@ -109,7 +110,7 @@ const LanguageTable: React.FC = () => {
           },
           isInitiallyVisible: false,
           sortParam: SortBy.Literacy,
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
         },
       ]}
     />

--- a/src/widgets/tables/LocaleTable.tsx
+++ b/src/widgets/tables/LocaleTable.tsx
@@ -4,7 +4,8 @@ import { useDataContext } from '@features/data-loading/context/useDataContext';
 import usePageParams from '@features/page-params/usePageParams';
 import { SortBy } from '@features/sorting/SortTypes';
 import { CodeColumn, EndonymColumn, NameColumn } from '@features/table/CommonColumns';
-import ObjectTable, { ValueType } from '@features/table/ObjectTable';
+import ObjectTable from '@features/table/ObjectTable';
+import TableValueType from '@features/table/TableValueType';
 
 import { LocaleData } from '@entities/types/DataTypes';
 import HoverableObjectName from '@entities/ui/HoverableObjectName';
@@ -37,7 +38,7 @@ const LocaleTable: React.FC = () => {
               ? numberToFixedUnlessSmall(object.literacyPercent)
               : null,
           isInitiallyVisible: false,
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.Literacy,
         },
         {
@@ -50,7 +51,7 @@ const LocaleTable: React.FC = () => {
             </CommaSeparated>
           ),
           isInitiallyVisible: false,
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.CountOfLanguages,
           columnGroup: 'Linked Data',
         },

--- a/src/widgets/tables/TableOfAllCensuses.tsx
+++ b/src/widgets/tables/TableOfAllCensuses.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { useDataContext } from '@features/data-loading/context/useDataContext';
 import { SortBy } from '@features/sorting/SortTypes';
 import { CodeColumn, NameColumn } from '@features/table/CommonColumns';
-import ObjectTable, { ValueType } from '@features/table/ObjectTable';
+import ObjectTable from '@features/table/ObjectTable';
+import TableValueType from '@features/table/TableValueType';
 
 import { CensusCollectorType, CensusData } from '@entities/census/CensusTypes';
 import { getObjectPercentOfTerritoryPopulation } from '@entities/lib/getObjectPopulation';
@@ -30,7 +31,7 @@ const TableOfAllCensuses: React.FC = () => {
               )}
             />
           ),
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.CountOfLanguages,
         },
         {
@@ -39,7 +40,7 @@ const TableOfAllCensuses: React.FC = () => {
             census.eligiblePopulation != null
               ? census.eligiblePopulation.toLocaleString()
               : 'Unknown',
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.Population,
           columnGroup: 'Population',
         },
@@ -49,7 +50,7 @@ const TableOfAllCensuses: React.FC = () => {
             census.territory && census.eligiblePopulation != null
               ? getObjectPercentOfTerritoryPopulation(census)?.toFixed(1)
               : 'Unknown',
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           isInitiallyVisible: false,
           sortParam: SortBy.PercentOfTerritoryPopulation,
           columnGroup: 'Population',
@@ -70,7 +71,7 @@ const TableOfAllCensuses: React.FC = () => {
               <Deemphasized>multiple</Deemphasized>
             ),
           isInitiallyVisible: false,
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.Date,
         },
       ]}

--- a/src/widgets/tables/TableOfLanguagesInCensus.tsx
+++ b/src/widgets/tables/TableOfLanguagesInCensus.tsx
@@ -6,7 +6,8 @@ import { ObjectType, SearchableField } from '@features/page-params/PageParamType
 import usePageParams from '@features/page-params/usePageParams';
 import { SortBy } from '@features/sorting/SortTypes';
 import { CodeColumn } from '@features/table/CommonColumns';
-import ObjectTable, { ValueType } from '@features/table/ObjectTable';
+import ObjectTable from '@features/table/ObjectTable';
+import TableValueType from '@features/table/TableValueType';
 
 import { CensusData } from '@entities/census/CensusTypes';
 import { LocaleData } from '@entities/types/DataTypes';
@@ -103,7 +104,7 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
           {
             key: 'Population',
             render: (loc) => loc.populationSpeaking,
-            valueType: ValueType.Numeric,
+            valueType: TableValueType.Numeric,
             sortParam: SortBy.Population,
           },
           {
@@ -112,14 +113,14 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
               loc.populationSpeakingPercent != null
                 ? numberToFixedUnlessSmall(loc.populationSpeakingPercent) + '%'
                 : 'N/A',
-            valueType: ValueType.Numeric,
+            valueType: TableValueType.Numeric,
             sortParam: SortBy.PercentOfTerritoryPopulation,
           },
           {
             key: 'Scope',
             render: (loc) => loc.language?.scope,
             isInitiallyVisible: false,
-            valueType: ValueType.Enum,
+            valueType: TableValueType.Enum,
           },
           {
             key: 'Locale Entry',
@@ -138,7 +139,7 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
               </Hoverable>
             ),
             render: getPopulationDifference,
-            valueType: ValueType.Numeric,
+            valueType: TableValueType.Numeric,
           },
           {
             key: 'Percent of Worldwide in Language',
@@ -147,7 +148,7 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
               numberToFixedUnlessSmall(
                 (object.populationSpeaking * 100) / (object.language?.populationEstimate || 1),
               ) + '%',
-            valueType: ValueType.Numeric,
+            valueType: TableValueType.Numeric,
             isInitiallyVisible: false,
             sortParam: SortBy.PercentOfOverallLanguageSpeakers,
           },

--- a/src/widgets/tables/TableOfLanguagesInTerritory.tsx
+++ b/src/widgets/tables/TableOfLanguagesInTerritory.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import { SortBy } from '@features/sorting/SortTypes';
 import { CodeColumn, EndonymColumn } from '@features/table/CommonColumns';
-import ObjectTable, { ValueType } from '@features/table/ObjectTable';
+import ObjectTable from '@features/table/ObjectTable';
+import TableValueType from '@features/table/TableValueType';
 
 import LocaleCensusCitation from '@entities/locale/LocaleCensusCitation';
 import { getOfficialLabel } from '@entities/locale/LocaleStrings';
@@ -51,13 +52,13 @@ const TableOfLanguagesInTerritory: React.FC<Props> = ({ territory }) => {
         {
           key: 'Population',
           render: (loc) => loc.populationSpeaking?.toLocaleString() ?? '—',
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.Population,
         },
         {
           key: 'Population Source',
           render: (loc) => <LocaleCensusCitation locale={loc} size="short" />,
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           isInitiallyVisible: false,
         },
         {
@@ -73,7 +74,7 @@ const TableOfLanguagesInTerritory: React.FC<Props> = ({ territory }) => {
             ) : (
               'N/A'
             ),
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.PercentOfTerritoryPopulation,
         },
       ]}

--- a/src/widgets/tables/TerritoryTable.tsx
+++ b/src/widgets/tables/TerritoryTable.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { useDataContext } from '@features/data-loading/context/useDataContext';
 import { SortBy } from '@features/sorting/SortTypes';
 import { CodeColumn, NameColumn } from '@features/table/CommonColumns';
-import ObjectTable, { ValueType } from '@features/table/ObjectTable';
+import ObjectTable from '@features/table/ObjectTable';
+import TableValueType from '@features/table/TableValueType';
 
 import { getTerritoryChildren } from '@entities/lib/getObjectMiscFields';
 import { getTerritoryBiggestLocale } from '@entities/lib/getObjectMiscFields';
@@ -25,7 +26,7 @@ const TerritoryTable: React.FC = () => {
         {
           key: 'Population',
           render: (object) => object.population,
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.Population,
           columnGroup: 'Demographics',
         },
@@ -33,7 +34,7 @@ const TerritoryTable: React.FC = () => {
           key: 'Literacy',
           render: (object) =>
             object.literacyPercent != null ? object.literacyPercent.toFixed(1) + '%' : null,
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.Literacy,
           columnGroup: 'Demographics',
         },
@@ -45,7 +46,7 @@ const TerritoryTable: React.FC = () => {
                 items={object.locales.map((l) => l.language?.nameDisplay ?? l.nameDisplay)}
               />
             ),
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.CountOfLanguages,
           columnGroup: 'Language',
         },
@@ -69,7 +70,7 @@ const TerritoryTable: React.FC = () => {
           render: (object) =>
             object.locales ? object.locales[0].populationSpeakingPercent?.toFixed(1) + '%' : null,
           isInitiallyVisible: false,
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.PopulationPercentInBiggestDescendentLanguage,
           columnGroup: 'Language',
         },
@@ -85,7 +86,7 @@ const TerritoryTable: React.FC = () => {
             <HoverableEnumeration items={getTerritoryChildren(object).map((t) => t.nameDisplay)} />
           ),
           isInitiallyVisible: false,
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.CountOfTerritories,
           columnGroup: 'Relations',
         },
@@ -96,14 +97,14 @@ const TerritoryTable: React.FC = () => {
               ? sumBy(object.dependentTerritories, (t) => t.population ?? 0)
               : null,
           isInitiallyVisible: false,
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.PopulationOfDescendents,
           columnGroup: 'Relations',
         },
         {
           key: 'Type',
           render: (object) => object.scope,
-          valueType: ValueType.Enum,
+          valueType: TableValueType.Enum,
         },
       ]}
     />

--- a/src/widgets/tables/VariantTagTable.tsx
+++ b/src/widgets/tables/VariantTagTable.tsx
@@ -4,7 +4,8 @@ import React from 'react';
 import { useDataContext } from '@features/data-loading/context/useDataContext';
 import { SortBy } from '@features/sorting/SortTypes';
 import { CodeColumn, NameColumn } from '@features/table/CommonColumns';
-import ObjectTable, { ValueType } from '@features/table/ObjectTable';
+import ObjectTable from '@features/table/ObjectTable';
+import TableValueType from '@features/table/TableValueType';
 
 import { getObjectPopulation } from '@entities/lib/getObjectPopulation';
 import { VariantTagData } from '@entities/types/DataTypes';
@@ -25,7 +26,7 @@ const VariantTagTable: React.FC = () => {
           key: 'Date Added',
           render: (object) => object.dateAdded?.toLocaleDateString(),
           isInitiallyVisible: false,
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.Date,
         },
         {
@@ -33,7 +34,7 @@ const VariantTagTable: React.FC = () => {
           render: (object) => (
             <HoverableEnumeration items={object.languages.map((lang) => lang.nameDisplay)} />
           ),
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.CountOfLanguages,
         },
         {
@@ -55,7 +56,7 @@ const VariantTagTable: React.FC = () => {
           ),
           render: (object) => getObjectPopulation(object),
           isInitiallyVisible: false,
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.Population,
         },
       ]}

--- a/src/widgets/tables/WritingSystemTable.tsx
+++ b/src/widgets/tables/WritingSystemTable.tsx
@@ -5,7 +5,8 @@ import PopulationWarning from '@widgets/PopulationWarning';
 import { useDataContext } from '@features/data-loading/context/useDataContext';
 import { SortBy } from '@features/sorting/SortTypes';
 import { CodeColumn, EndonymColumn, NameColumn } from '@features/table/CommonColumns';
-import ObjectTable, { ValueType } from '@features/table/ObjectTable';
+import ObjectTable from '@features/table/ObjectTable';
+import TableValueType from '@features/table/TableValueType';
 
 import { WritingSystemData } from '@entities/types/DataTypes';
 
@@ -31,7 +32,7 @@ const WritingSystemTable: React.FC = () => {
           ),
           key: 'Population',
           render: (object) => object.populationUpperBound,
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.Population,
         },
         {
@@ -42,7 +43,7 @@ const WritingSystemTable: React.FC = () => {
                 items={Object.values(object.languages).map((l) => l.nameDisplay)}
               />
             ),
-          valueType: ValueType.Numeric,
+          valueType: TableValueType.Numeric,
           sortParam: SortBy.CountOfLanguages,
         },
       ]}

--- a/src/widgets/tables/columns/LanguageDigitalSupportColumns.tsx
+++ b/src/widgets/tables/columns/LanguageDigitalSupportColumns.tsx
@@ -1,4 +1,4 @@
-import { TableColumn } from '@features/table/ObjectTable';
+import TableColumn from '@features/table/TableColumn';
 
 import { LanguageData } from '@entities/language/LanguageTypes';
 import { CLDRCoverageText, ICUSupportStatus } from '@entities/ui/CLDRCoverageInfo';

--- a/src/widgets/tables/columns/LanguagePopulationColumns.tsx
+++ b/src/widgets/tables/columns/LanguagePopulationColumns.tsx
@@ -1,5 +1,6 @@
 import { SortBy } from '@features/sorting/SortTypes';
-import { TableColumn, ValueType } from '@features/table/ObjectTable';
+import TableColumn from '@features/table/TableColumn';
+import TableValueType from '@features/table/TableValueType';
 
 import { LanguagePopulationEstimate } from '@entities/language/LanguagePopulationEstimate';
 import LanguagePopulationFromDescendents from '@entities/language/LanguagePopulationFromDescendents';
@@ -17,7 +18,7 @@ export const LanguagePopulationColumns: TableColumn<LanguageData>[] = [
       </>
     ),
     render: (lang) => <LanguagePopulationEstimate lang={lang} />,
-    valueType: ValueType.Numeric,
+    valueType: TableValueType.Numeric,
     sortParam: SortBy.Population,
     columnGroup: 'Population',
   },
@@ -25,7 +26,7 @@ export const LanguagePopulationColumns: TableColumn<LanguageData>[] = [
     key: 'Population (Direct)',
     description: 'This comes from other language databases (citations still needed).',
     render: (lang) => lang.populationCited,
-    valueType: ValueType.Numeric,
+    valueType: TableValueType.Numeric,
     isInitiallyVisible: false,
     sortParam: SortBy.PopulationAttested,
     columnGroup: 'Population',
@@ -35,7 +36,7 @@ export const LanguagePopulationColumns: TableColumn<LanguageData>[] = [
     description:
       'Some of these languages may have data from constituent dialects/locales. They have been added up here.',
     render: (lang) => <LanguagePopulationFromDescendents lang={lang} />,
-    valueType: ValueType.Numeric,
+    valueType: TableValueType.Numeric,
     isInitiallyVisible: false,
     sortParam: SortBy.PopulationOfDescendents,
     columnGroup: 'Population',
@@ -49,7 +50,7 @@ export const LanguagePopulationColumns: TableColumn<LanguageData>[] = [
       </>
     ),
     render: (lang) => <LanguagePopulationFromLocales lang={lang} />,
-    valueType: ValueType.Numeric,
+    valueType: TableValueType.Numeric,
     isInitiallyVisible: false,
     columnGroup: 'Population',
   },

--- a/src/widgets/tables/columns/LanguageVitalityColumns.tsx
+++ b/src/widgets/tables/columns/LanguageVitalityColumns.tsx
@@ -1,5 +1,6 @@
 import { SortBy } from '@features/sorting/SortTypes';
-import { TableColumn } from '@features/table/ObjectTable';
+import TableColumn from '@features/table/TableColumn';
+import TableValueType from '@features/table/TableValueType';
 
 import { LanguageData } from '@entities/language/LanguageTypes';
 import LanguageVitalityCell from '@entities/language/vitality/LanguageVitalityCell';
@@ -10,6 +11,7 @@ export const LanguageVitalityColumns: TableColumn<LanguageData>[] = [
     key: 'Vitality: Metascore',
     render: (lang) => <LanguageVitalityCell lang={lang} type={VitalitySource.Metascore} />,
     sortParam: SortBy.VitalityMetascore,
+    valueType: TableValueType.Enum,
     columnGroup: 'Vitality',
   },
   {
@@ -17,12 +19,14 @@ export const LanguageVitalityColumns: TableColumn<LanguageData>[] = [
     render: (lang) => <LanguageVitalityCell lang={lang} type={VitalitySource.ISO} />,
     sortParam: SortBy.VitalityISO,
     isInitiallyVisible: false,
+    valueType: TableValueType.Enum,
     columnGroup: 'Vitality',
   },
   {
     key: 'Vitality: Ethnologue 2013',
     render: (lang) => <LanguageVitalityCell lang={lang} type={VitalitySource.Eth2013} />,
     sortParam: SortBy.VitalityEthnologue2013,
+    valueType: TableValueType.Enum,
     isInitiallyVisible: false,
     columnGroup: 'Vitality',
   },
@@ -30,6 +34,7 @@ export const LanguageVitalityColumns: TableColumn<LanguageData>[] = [
     key: 'Vitality: Ethnologue 2025',
     render: (lang) => <LanguageVitalityCell lang={lang} type={VitalitySource.Eth2025} />,
     sortParam: SortBy.VitalityEthnologue2025,
+    valueType: TableValueType.Enum,
     isInitiallyVisible: false,
     columnGroup: 'Vitality',
   },

--- a/src/widgets/tables/columns/LocalePopulationColumns.tsx
+++ b/src/widgets/tables/columns/LocalePopulationColumns.tsx
@@ -1,5 +1,6 @@
 import { SortBy } from '@features/sorting/SortTypes';
-import { TableColumn, ValueType } from '@features/table/ObjectTable';
+import TableColumn from '@features/table/TableColumn';
+import TableValueType from '@features/table/TableValueType';
 
 import LocaleCensusCitation from '@entities/locale/LocaleCensusCitation';
 import { LocalePopulationAdjusted } from '@entities/locale/LocalePopulationAdjusted';
@@ -18,7 +19,7 @@ export const LocalePopulationColumns: TableColumn<LocaleData>[] = [
       </>
     ),
     render: (object) => <LocalePopulationAdjusted locale={object} />,
-    valueType: ValueType.Numeric,
+    valueType: TableValueType.Numeric,
     sortParam: SortBy.Population,
     columnGroup: 'Demographics',
   },
@@ -26,7 +27,7 @@ export const LocalePopulationColumns: TableColumn<LocaleData>[] = [
     key: 'Population (Direct)',
     description: 'This is the original population number cited from sourced data.',
     render: (object) => object.populationSpeaking,
-    valueType: ValueType.Numeric,
+    valueType: TableValueType.Numeric,
     sortParam: SortBy.PopulationAttested,
     columnGroup: 'Demographics',
   },
@@ -40,7 +41,7 @@ export const LocalePopulationColumns: TableColumn<LocaleData>[] = [
           {object.populationSpeakingPercent > 10 && <span style={{ visibility: 'hidden' }}>0</span>}
         </>
       ),
-    valueType: ValueType.Numeric,
+    valueType: TableValueType.Numeric,
     sortParam: SortBy.PercentOfTerritoryPopulation,
     columnGroup: 'Demographics',
   },
@@ -51,7 +52,7 @@ export const LocalePopulationColumns: TableColumn<LocaleData>[] = [
       numberToFixedUnlessSmall(
         (object.populationSpeaking * 100) / (object.language?.populationEstimate ?? 1),
       ),
-    valueType: ValueType.Numeric,
+    valueType: TableValueType.Numeric,
     isInitiallyVisible: false,
     sortParam: SortBy.PercentOfOverallLanguageSpeakers,
     columnGroup: 'Demographics',

--- a/test-coverage.md
+++ b/test-coverage.md
@@ -2,7 +2,7 @@
 
 | Path                                     |   Lines | Branches |   Funcs |   Stmts |
 | ---------------------------------------- | ------: | ------: | ------: | ------: |
-| `src`                                    |    29.1 |    75.3 |    43.2 |    29.1 |
+| `src`                                    |    29.1 |    75.3 |    43.3 |    29.1 |
 | `  app`                                  |     0   |     0   |     0   |     0   |
 | `    App.tsx`                            |     0   |     0   |     0   |     0   |
 | `    PageRoutes.tsx`                     |     0   |     0   |     0   |     0   |
@@ -50,7 +50,7 @@
 | `      VariantTagCard.tsx`               |    20.0 |   100.0 |     0   |    20.0 |
 | `    writingsystem`                      |    12.3 |   100.0 |     0   |    12.3 |
 | `      WritingSystemCard.tsx`            |    12.3 |   100.0 |     0   |    12.3 |
-| `  features`                             |    38.6 |    77.5 |    30.5 |    38.6 |
+| `  features`                             |    38.7 |    77.4 |    31.1 |    38.7 |
 | `    data-loading`                       |    28.6 |    71.9 |    26.8 |    28.6 |
 | `      CensusData.tsx`                   |     2.7 |   100.0 |     0   |     2.7 |
 | `      context`                          |    11.4 |    50.0 |    11.1 |    11.4 |
@@ -92,11 +92,13 @@
 | `      SortTypes.tsx`                    |   100.0 |   100.0 |   100.0 |   100.0 |
 | `    stored-params`                      |    72.2 |    64.3 |   100.0 |    72.2 |
 | `      useStoredParams.tsx`              |    72.2 |    64.3 |   100.0 |    72.2 |
-| `    table`                              |    94.8 |    88.7 |    76.9 |    94.8 |
+| `    table`                              |    94.9 |    88.6 |    78.6 |    94.9 |
 | `      CommonColumns.tsx`                |    82.8 |   100.0 |     0   |    82.8 |
-| `      ObjectTable.tsx`                  |    94.7 |    75.0 |   100.0 |    94.7 |
+| `      ObjectTable.tsx`                  |    94.5 |    69.2 |   100.0 |    94.5 |
+| `      TableColumn.tsx`                  |   100.0 |   100.0 |   100.0 |   100.0 |
 | `      TableColumnSelector.tsx`          |    94.3 |    87.0 |   100.0 |    94.3 |
 | `      TableSortButton.tsx`              |   100.0 |   100.0 |   100.0 |   100.0 |
+| `      TableValueType.ts`                |   100.0 |   100.0 |   100.0 |   100.0 |
 | `      useColumnVisibility.tsx`          |    97.7 |    90.9 |   100.0 |    97.7 |
 | `    treelist`                           |    16.5 |   100.0 |     0   |    16.5 |
 | `      filterBranch.tsx`                 |     4.2 |   100.0 |     0   |     4.2 |
@@ -210,7 +212,7 @@
 | `      LanguagesWithIdenticalNames.tsx`  |     0   |     0   |     0   |     0   |
 | `      PotentialLocales.tsx`             |     0   |     0   |     0   |     0   |
 | `      TableOfCountriesWithCensuses.tsx` |     0   |   100.0 |   100.0 |     0   |
-| `    tables`                             |     3.4 |    50.0 |    38.5 |     3.4 |
+| `    tables`                             |     3.5 |    50.0 |    38.5 |     3.5 |
 | `      columns`                          |     0   |    25.0 |    25.0 |     0   |
 | `        LanguageDigitalSupportColumns.tsx` |     0   |   100.0 |   100.0 |     0   |
 | `        LanguagePopulationColumns.tsx`  |     0   |     0   |     0   |     0   |
@@ -219,8 +221,8 @@
 | `      LanguageTable.tsx`                |     0   |     0   |     0   |     0   |
 | `      LocaleTable.tsx`                  |     0   |   100.0 |   100.0 |     0   |
 | `      TableOfAllCensuses.tsx`           |     0   |   100.0 |   100.0 |     0   |
-| `      TableOfLanguagesInCensus.tsx`     |    11.7 |   100.0 |     0   |    11.7 |
-| `      TableOfLanguagesInTerritory.tsx`  |    16.4 |   100.0 |     0   |    16.4 |
+| `      TableOfLanguagesInCensus.tsx`     |    12.3 |   100.0 |     0   |    12.3 |
+| `      TableOfLanguagesInTerritory.tsx`  |    17.7 |   100.0 |     0   |    17.7 |
 | `      TerritoryTable.tsx`               |     0   |   100.0 |   100.0 |     0   |
 | `      VariantTagTable.tsx`              |     0   |     0   |     0   |     0   |
 | `      WritingSystemTable.tsx`           |     0   |   100.0 |   100.0 |     0   |


### PR DESCRIPTION
I was running into some road blocks merging some updates that facilitate exporting data from the tables and did this minor refactor to make it easier and reduce individual file length.

I also realized we lost some data when merging some changes so this restores the ValueType.enum to the vitality columns.
http://localhost:5173/lang-nav/data?view=Table&vitalityEth2025=0&sortBy=Vitality%3A+Ethnologue+2025&sortBehavior=-1
<img width="1047" height="234" alt="Screenshot 2025-10-27 at 15 36 11" src="https://github.com/user-attachments/assets/67211f26-ed48-4155-a6fb-6cab07d849e3" />
