### PR TITLE
Testing: Enable manually running the autoformat/test coverage workflow.

### DIFF
--- a/.github/workflows/autoformat.yml
+++ b/.github/workflows/autoformat.yml
@@ -3,6 +3,7 @@ name: Auto-format code and update test coverage
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
If there's a merge conflict on test coverage, it would be nice to re-run it. I believe this change enables us to manually rerun it.