### PR TITLE
Refactor: Rename PopulationAttested -> PopulationDirectly Sourced

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,7 +29,7 @@ export default defineConfig([
       },
     },
     files: ['**/*.ts', '**/*.tsx'],
-    plugins: { 
+    plugins: {
       'react-hooks': reactHooks,
       '@typescript-eslint': typescript,
       prettier: prettierPlugin,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,6 +30,7 @@ export default defineConfig([
     },
     files: ['**/*.ts', '**/*.tsx'],
     plugins: {
+      react: pluginReact,
       'react-hooks': reactHooks,
       '@typescript-eslint': typescript,
       prettier: prettierPlugin,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,19 +1,22 @@
 import js from '@eslint/js';
 import typescript from '@typescript-eslint/eslint-plugin';
 import parser from '@typescript-eslint/parser';
-import { defineConfig } from 'eslint/config';
 import prettierConfig from 'eslint-config-prettier';
 import importPlugin from 'eslint-plugin-import';
 import prettierPlugin from 'eslint-plugin-prettier';
-import react from 'eslint-plugin-react';
 import pluginReact from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
+import { defineConfig } from 'eslint/config';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
 export default defineConfig([
-  { files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'], plugins: { js }, extends: ['js/recommended'] },
-  { files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'], languageOptions: { globals: globals.browser } },
+  {
+    files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'],
+    plugins: { js },
+    extends: [js.configs.recommended],
+    languageOptions: { globals: globals.browser },
+  },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
   {
@@ -26,8 +29,7 @@ export default defineConfig([
       },
     },
     files: ['**/*.ts', '**/*.tsx'],
-    plugins: {
-      react,
+    plugins: { 
       'react-hooks': reactHooks,
       '@typescript-eslint': typescript,
       prettier: prettierPlugin,
@@ -43,6 +45,7 @@ export default defineConfig([
     },
   },
   {
+    files: ['**/*.{ts,tsx}'],
     plugins: {
       import: importPlugin,
     },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "singleQuote": true,
     "trailingComma": "all",
     "semi": true,
-    "printWidth": 100
+    "printWidth": 100,
+    "tabWidth": 2
   }
 }

--- a/src/entities/language/LanguageTypes.ts
+++ b/src/entities/language/LanguageTypes.ts
@@ -23,9 +23,9 @@ import {
 } from '../types/DataTypes';
 
 import {
+  LanguageISOStatus,
   VitalityEthnologueCoarse,
   VitalityEthnologueFine,
-  LanguageISOStatus,
 } from './vitality/VitalityTypes';
 
 export type LanguageDictionary = Record<LanguageCode, LanguageData>;
@@ -105,7 +105,7 @@ export interface LanguageData extends ObjectBase {
 
   populationAdjusted?: number;
   populationEstimate?: number;
-  populationCited?: number; // from languages.tsv
+  populationRough?: number; // from languages.tsv
   populationOfDescendants?: number; // computed from child languages
   populationFromLocales?: number; // aggregated from locale data
 

--- a/src/entities/lib/__tests__/getObjectPopulation.test.tsx
+++ b/src/entities/lib/__tests__/getObjectPopulation.test.tsx
@@ -47,7 +47,7 @@ describe('getObjectPopulation', () => {
 });
 
 describe('getObjectPopulationDirectlySourced', () => {
-  it('returns attested population for objects', () => {
+  it('returns the directly sourced population for objects', () => {
     const results = Object.fromEntries(
       Object.values(mockedObjects).map((obj) => [
         obj.ID,
@@ -61,7 +61,7 @@ describe('getObjectPopulationDirectlySourced', () => {
       BE: 12000,
       ER: 2400,
       HA: 15600,
-      Teng: undefined, // not attested, derived from sjn_Teng_BE
+      Teng: undefined, // not directly sourced, derived from sjn_Teng_BE
       dori0123: 2500,
       be0590: 12000,
       sjn: 24000,

--- a/src/entities/lib/__tests__/getObjectPopulation.test.tsx
+++ b/src/entities/lib/__tests__/getObjectPopulation.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { getFullyInstantiatedMockedObjects } from '@features/__tests__/MockObjects';
 
@@ -6,7 +6,7 @@ import { LanguageSource } from '@entities/language/LanguageTypes';
 import {
   getObjectPercentOfTerritoryPopulation,
   getObjectPopulation,
-  getObjectPopulationAttested,
+  getObjectPopulationDirectlySourced,
   getObjectPopulationOfDescendants,
   getObjectPopulationPercentInBiggestDescendantLanguage,
   getObjectPopulationRelativeToOverallLanguageSpeakers,
@@ -46,12 +46,12 @@ describe('getObjectPopulation', () => {
   });
 });
 
-describe('getObjectPopulationAttested', () => {
+describe('getObjectPopulationDirectlySourced', () => {
   it('returns attested population for objects', () => {
     const results = Object.fromEntries(
       Object.values(mockedObjects).map((obj) => [
         obj.ID,
-        getObjectPopulationAttested(obj as ObjectData),
+        getObjectPopulationDirectlySourced(obj as ObjectData),
       ]),
     );
     expect(results).toEqual({

--- a/src/entities/lib/getObjectPopulation.ts
+++ b/src/entities/lib/getObjectPopulation.ts
@@ -28,11 +28,11 @@ export function getObjectPopulation(object: ObjectData): number | undefined {
   }
 }
 
-// SortBy.PopulationAttested
-export function getObjectPopulationAttested(object: ObjectData): number | undefined {
+// SortBy.PopulationDirectlySourced
+export function getObjectPopulationDirectlySourced(object: ObjectData): number | undefined {
   switch (object.type) {
     case ObjectType.Language:
-      return object.populationCited;
+      return object.populationRough;
     case ObjectType.Locale:
       return object.populationSpeaking;
     case ObjectType.Territory:

--- a/src/features/__tests__/MockObjects.tsx
+++ b/src/features/__tests__/MockObjects.tsx
@@ -38,7 +38,7 @@ export function getDisconnectedMockedObjects(): ObjectDictionary {
     nameEndonym: 'sɪndarɪn', // using IPA because Tengwar letters aren't usually supported
     names: ['Sindarin', 'sɪndarɪn', '', 'Elvish', 'Elven Tongue', 'Edhellen'],
     populationEstimate: 14400,
-    populationCited: 24000,
+    populationRough: 24000,
     primaryScriptCode: 'Teng',
   };
   const dori0123: LanguageData = {
@@ -46,7 +46,7 @@ export function getDisconnectedMockedObjects(): ObjectDictionary {
     nameEndonym: 'dorjaθɪn', // using IPA because Tengwar letters aren't usually supported
     names: ['Central Sindarin', 'Doriathrin', '', 'dorjaθɪn'],
     populationEstimate: 2500,
-    populationCited: 2500,
+    populationRough: 2500,
     primaryScriptCode: 'Teng',
     Combined: { parentLanguageCode: 'sjn' },
   };

--- a/src/features/data/compute/__tests__/computeLocalePopulationFromCensuses.test.ts
+++ b/src/features/data/compute/__tests__/computeLocalePopulationFromCensuses.test.ts
@@ -81,7 +81,7 @@ describe('computeLocalePopulationFromCensuses', () => {
     // Finally check if the sjn language was updated
     const langRaw = mockRaw.allLanguoids.find((l) => l.ID === 'sjn');
     expect(langRaw?.populationEstimate, 'populationEstimate').toBe(14400);
-    expect(langRaw?.populationCited, 'populationCited').toBe(24000);
+    expect(langRaw?.populationRough, 'populationRough').toBe(24000);
     expect(langRaw?.populationFromLocales, 'populationFromLocales').toBe(undefined);
     expect(langRaw?.populationOfDescendants, 'populationOfDescendants').toBe(undefined);
     expect(langRaw?.populationAdjusted, 'populationAdjusted').toBe(undefined);
@@ -89,7 +89,7 @@ describe('computeLocalePopulationFromCensuses', () => {
     // Finally check if the sjn language was updated
     const langUpdated = mockUpdated.allLanguoids.find((l) => l.ID === 'sjn');
     expect(langUpdated?.populationEstimate, 'populationEstimate').toBe(14400);
-    expect(langUpdated?.populationCited, 'populationCited').toBe(24000);
+    expect(langUpdated?.populationRough, 'populationRough').toBe(24000);
     expect(langUpdated?.populationFromLocales, 'populationFromLocales').toBe(undefined); // Not updated
     expect(langUpdated?.populationOfDescendants, 'populationOfDescendants').toBe(undefined);
     expect(langUpdated?.populationAdjusted, 'populationAdjusted').toBe(undefined);
@@ -127,7 +127,7 @@ describe('computeLocalePopulationFromCensuses', () => {
     // Finally check if the sjn language was updated
     const langRaw = mockRaw.allLanguoids.find((l) => l.ID === 'sjn');
     expect(langRaw?.populationEstimate, 'populationEstimate').toBe(14400);
-    expect(langRaw?.populationCited, 'populationCited').toBe(24000);
+    expect(langRaw?.populationRough, 'populationRough').toBe(24000);
     expect(langRaw?.populationFromLocales, 'populationFromLocales').toBe(undefined);
     expect(langRaw?.populationOfDescendants, 'populationOfDescendants').toBe(undefined);
     expect(langRaw?.populationAdjusted, 'populationAdjusted').toBe(undefined);
@@ -135,7 +135,7 @@ describe('computeLocalePopulationFromCensuses', () => {
     // Finally check if the sjn language was updated
     const langUpdated = mockUpdated.allLanguoids.find((l) => l.ID === 'sjn');
     expect(langUpdated?.populationEstimate, 'populationEstimate').toBe(14400);
-    expect(langUpdated?.populationCited, 'populationCited').toBe(24000);
+    expect(langUpdated?.populationRough, 'populationRough').toBe(24000);
     expect(langUpdated?.populationFromLocales, 'populationFromLocales').toBe(11220); // <-- UPDATED VALUE
     expect(langUpdated?.populationOfDescendants, 'populationOfDescendants').toBe(undefined);
     expect(langUpdated?.populationAdjusted, 'populationAdjusted').toBe(undefined);
@@ -180,12 +180,12 @@ describe('computeLocalePopulationFromCensuses', () => {
     // Check the Language sjn
     const langRaw = mockRaw.allLanguoids.find((l) => l.ID === 'sjn');
     expect(langRaw?.populationEstimate, 'populationEstimate').toBe(14400);
-    expect(langRaw?.populationCited, 'populationCited').toBe(24000);
+    expect(langRaw?.populationRough, 'populationRough').toBe(24000);
     expect(langRaw?.populationFromLocales, 'populationFromLocales').toBe(undefined);
 
     const langUpdated = mockUpdated.allLanguoids.find((l) => l.ID === 'sjn');
     expect(langUpdated?.populationEstimate, 'populationEstimate').toBe(14400);
-    expect(langUpdated?.populationCited, 'populationCited').toBe(24000);
+    expect(langUpdated?.populationRough, 'populationRough').toBe(24000);
     expect(langUpdated?.populationFromLocales, 'populationFromLocales').toBe(13920); // <-- UPDATED VALUE
   });
 
@@ -247,10 +247,10 @@ describe('computeLocalePopulationFromCensuses', () => {
     const langBothNewEntities = mockBothNewEntities.allLanguoids.find((l) => l.ID === 'sjn');
 
     // Population Cited will all stay to the original entry
-    expect(langOriginal?.populationCited, 'langOriginal?.populationCited').toBe(24000);
-    expect(langOnlyCensus?.populationCited, 'langOnlyCensus?.populationCited').toBe(24000);
-    expect(langOnlyLocale?.populationCited, 'langOnlyLocale?.populationCited').toBe(24000);
-    expect(langBothNewEntities?.populationCited, 'langBothNewEntities?.populationCited').toBe(
+    expect(langOriginal?.populationRough, 'langOriginal?.populationRough').toBe(24000);
+    expect(langOnlyCensus?.populationRough, 'langOnlyCensus?.populationRough').toBe(24000);
+    expect(langOnlyLocale?.populationRough, 'langOnlyLocale?.populationRough').toBe(24000);
+    expect(langBothNewEntities?.populationRough, 'langBothNewEntities?.populationRough').toBe(
       24000,
     );
 

--- a/src/features/data/compute/__tests__/updateObjectCodesNameAndPopulation.test.ts
+++ b/src/features/data/compute/__tests__/updateObjectCodesNameAndPopulation.test.ts
@@ -18,7 +18,7 @@ describe('updateObjectCodesNameAndPopulation', () => {
     connectMockedObjects(mockedObjects); // Connect but do not compute population yet
     const mockedDictionaries = getMockedObjectDictionaries(mockedObjects);
 
-    // Before update, populationEstimate should be based on cited or descendants only
+    // Before update, populationEstimate should be based on the rough input or descendants only
     const sjn = mockedDictionaries.languages.sjn;
     const dori0123 = mockedDictionaries.languages.dori0123;
     const sjn_001 = mockedDictionaries.locales.sjn_001;
@@ -44,7 +44,7 @@ describe('updateObjectCodesNameAndPopulation', () => {
     );
 
     // After update, populationEstimate should consider populationFromLocales
-    expect(sjn.populationEstimate).toBe(24000); // corrected to match populationCited
+    expect(sjn.populationEstimate).toBe(24000); // corrected to match populationRough
     expect(dori0123.populationEstimate).toBe(2500); // unchanged
     expect(sjn_001.populationSpeaking).toBe(11220); // updated since locales updated from census data
 

--- a/src/features/data/compute/computeDescendantPopulation.ts
+++ b/src/features/data/compute/computeDescendantPopulation.ts
@@ -40,5 +40,5 @@ function computeLanguageDescendantPopulation(lang: LanguageData, source: Languag
     0.01,
   );
   lang[source].populationOfDescendants = descendantPopulation;
-  return Math.max(lang.populationCited || 0, descendantPopulation) + 0.01; // Tiebreaker = number of child nodes
+  return Math.max(lang.populationRough || 0, descendantPopulation) + 0.01; // Tiebreaker = number of child nodes
 }

--- a/src/features/data/compute/updateObjectCodesNameAndPopulation.ts
+++ b/src/features/data/compute/updateObjectCodesNameAndPopulation.ts
@@ -58,7 +58,7 @@ function updateParentsAndDescendants(
     lang.populationOfDescendants = specific.populationOfDescendants ?? undefined;
     lang.populationEstimate =
       Math.max(
-        lang.populationCited ?? specific.populationOfDescendants ?? 0,
+        lang.populationRough ?? specific.populationOfDescendants ?? 0,
         lang.populationFromLocales ?? 0,
       ) || undefined;
     lang.parentLanguage = specific.parentLanguage ?? undefined;

--- a/src/features/data/connect/connectWritingSystems.ts
+++ b/src/features/data/connect/connectWritingSystems.ts
@@ -56,7 +56,7 @@ export function connectWritingSystems(
         primaryWritingSystem.languages[language.ID] = language;
         if (!primaryWritingSystem.populationUpperBound)
           primaryWritingSystem.populationUpperBound = 0;
-        primaryWritingSystem.populationUpperBound += language.populationCited || 0;
+        primaryWritingSystem.populationUpperBound += language.populationRough || 0;
         language.primaryWritingSystem = primaryWritingSystem;
         language.writingSystems[primaryWritingSystem.ID] = primaryWritingSystem;
       }

--- a/src/features/data/load/entities/loadLanguages.ts
+++ b/src/features/data/load/entities/loadLanguages.ts
@@ -25,7 +25,7 @@ function parseLanguageLine(line: string): LanguageData {
 
   const populationAdjusted =
     parts[9] !== '' ? Number.parseInt(parts[9].replace(/,/g, '')) : undefined;
-  const populationCited =
+  const populationRough =
     parts[10] !== '' ? Number.parseInt(parts[10].replace(/,/g, '')) : undefined;
   const code = parts[0];
   const parentLanguageCode = parts[11] !== '' ? parts[11] : undefined;
@@ -52,7 +52,7 @@ function parseLanguageLine(line: string): LanguageData {
     viabilityExplanation: parts[14] || undefined,
 
     populationAdjusted,
-    populationCited,
+    populationRough,
 
     modality: (parts[4] || undefined) as LanguageModality | undefined,
     primaryScriptCode: parts[5] || undefined,

--- a/src/features/params/Profiles.tsx
+++ b/src/features/params/Profiles.tsx
@@ -152,7 +152,7 @@ function getGradientForColorBy(colorBy: ColorBy): ColorGradient {
 
   switch (colorBy) {
     case SortBy.Population:
-    case SortBy.PopulationAttested:
+    case SortBy.PopulationDirectlySourced:
     case SortBy.PopulationOfDescendants:
     case SortBy.PopulationPercentInBiggestDescendantLanguage:
     case SortBy.PercentOfOverallLanguageSpeakers:

--- a/src/features/transforms/coloring/ColorBySelector.tsx
+++ b/src/features/transforms/coloring/ColorBySelector.tsx
@@ -4,8 +4,9 @@ import { View } from '@features/params/PageParamTypes';
 import Selector from '@features/params/ui/Selector';
 import { SelectorDisplay, useSelectorDisplay } from '@features/params/ui/SelectorDisplayContext';
 import usePageParams from '@features/params/usePageParams';
-import { getSortBysApplicableToObjectType } from '@features/transforms/sorting/sort';
 import { SortBy } from '@features/transforms/sorting/SortTypes';
+
+import getSortBysApplicableToObjectType from '../sorting/getSortBysApplicableToObjectType';
 
 import { ColorBy } from './ColorTypes';
 

--- a/src/features/transforms/coloring/useColors.tsx
+++ b/src/features/transforms/coloring/useColors.tsx
@@ -107,7 +107,7 @@ function getMinimumValue(colorBy: ColorBy): number {
     case SortBy.ISOStatus:
       return -1;
     case SortBy.Population:
-    case SortBy.PopulationAttested:
+    case SortBy.PopulationDirectlySourced:
     case SortBy.PopulationOfDescendants:
     case SortBy.PopulationPercentInBiggestDescendantLanguage:
     case SortBy.PercentOfOverallLanguageSpeakers:
@@ -156,7 +156,7 @@ function getMaximumValue(objects: ObjectData[], colorBy: ColorBy): number {
     case SortBy.CountOfLanguages:
     case SortBy.CountOfTerritories:
     case SortBy.Population:
-    case SortBy.PopulationAttested:
+    case SortBy.PopulationDirectlySourced:
     case SortBy.PopulationOfDescendants:
     case SortBy.PopulationPercentInBiggestDescendantLanguage:
     case SortBy.Area:
@@ -176,7 +176,7 @@ function getMaximumValue(objects: ObjectData[], colorBy: ColorBy): number {
 function shouldUseLogarithmicScale(colorBy: ColorBy): boolean {
   switch (colorBy) {
     case SortBy.Population:
-    case SortBy.PopulationAttested:
+    case SortBy.PopulationDirectlySourced:
     case SortBy.PopulationOfDescendants:
     case SortBy.PopulationPercentInBiggestDescendantLanguage:
     case SortBy.CountOfLanguages:

--- a/src/features/transforms/fields/ObjectFieldDisplay.tsx
+++ b/src/features/transforms/fields/ObjectFieldDisplay.tsx
@@ -24,7 +24,7 @@ const ObjectFieldDisplay: React.FC<Props> = ({ object, field }) => {
   const fieldValue = getSortField(object, field, languageSource);
   switch (field) {
     case SortBy.Population:
-    case SortBy.PopulationAttested:
+    case SortBy.PopulationDirectlySourced:
     case SortBy.PopulationOfDescendants:
     case SortBy.PopulationPercentInBiggestDescendantLanguage:
       if (typeof fieldValue === 'number') return <CountOfPeople count={fieldValue as number} />;

--- a/src/features/transforms/fields/getField.ts
+++ b/src/features/transforms/fields/getField.ts
@@ -11,7 +11,7 @@ import {
 import {
   getObjectPercentOfTerritoryPopulation,
   getObjectPopulation,
-  getObjectPopulationAttested,
+  getObjectPopulationDirectlySourced,
   getObjectPopulationOfDescendants,
   getObjectPopulationPercentInBiggestDescendantLanguage,
   getObjectPopulationRelativeToOverallLanguageSpeakers,
@@ -67,8 +67,8 @@ export function getSortField(
     // Population
     case SortBy.Population:
       return getObjectPopulation(object);
-    case SortBy.PopulationAttested:
-      return getObjectPopulationAttested(object);
+    case SortBy.PopulationDirectlySourced:
+      return getObjectPopulationDirectlySourced(object);
     case SortBy.PopulationOfDescendants:
       return getObjectPopulationOfDescendants(object, effectiveLanguageSource);
     case SortBy.PopulationPercentInBiggestDescendantLanguage:

--- a/src/features/transforms/sorting/SortBySelector.tsx
+++ b/src/features/transforms/sorting/SortBySelector.tsx
@@ -4,7 +4,7 @@ import Selector from '@features/params/ui/Selector';
 import { SelectorDisplay } from '@features/params/ui/SelectorDisplayContext';
 import usePageParams from '@features/params/usePageParams';
 
-import { getSortBysApplicableToObjectType } from './sort';
+import getSortBysApplicableToObjectType from './getSortBysApplicableToObjectType';
 import { SortBy } from './SortTypes';
 
 const SortBySelector: React.FC = () => {

--- a/src/features/transforms/sorting/SortTypes.tsx
+++ b/src/features/transforms/sorting/SortTypes.tsx
@@ -22,7 +22,7 @@ export enum SortBy {
   Territory = 'Territory',
 
   // Extra population metrics
-  PopulationAttested = 'Population Attested',
+  PopulationDirectlySourced = 'Population Directly Sourced',
   PopulationOfDescendants = 'Population of Descendants',
   PercentOfTerritoryPopulation = '% of Territory Population',
   PercentOfOverallLanguageSpeakers = '% of Overall Language Speakers',

--- a/src/features/transforms/sorting/__tests__/sortMocks.test.tsx
+++ b/src/features/transforms/sorting/__tests__/sortMocks.test.tsx
@@ -213,6 +213,40 @@ describe('getSortByParameterized', () => {
   it('sortBy: PopulationDirectlySourced', () => {
     const objects = Object.values(mockedObjects) as ObjectData[];
     const sort = getSortFunctionParameterized(
+      SortBy.PopulationDirectlySourced,
+      LanguageSource.Combined,
+      SortBehavior.Normal,
+    );
+    expect(objects.sort(sort).map((obj) => obj.ID)).toEqual([
+      // These entities were created with a rough population estimate, before it was computed by algorithms
+      '001',
+      '123',
+      'sjn', // sjn was created with a high estimate
+      'AM', // Most countries have a high value
+      'HA',
+      'BE',
+      'be0590',
+      'sjn_123', // sjn locales were created with lower estimates
+      'sjn_001',
+      'sjn_BE',
+      'sjn_Teng_BE',
+      'sjn_Teng_123',
+      'sjn_Teng_001',
+      'dori0123',
+      'ER',
+      'sjn_ER',
+      'dori0123_ER',
+      'dori0123_123',
+      'dori0123_001',
+      // All undefined after this, stable to input order
+      'Teng',
+      'tolkorth',
+    ]);
+  });
+
+  it('sortBy: PopulationOfDescendants', () => {
+    const objects = Object.values(mockedObjects) as ObjectData[];
+    const sort = getSortFunctionParameterized(
       SortBy.PopulationOfDescendants,
       LanguageSource.Combined,
       SortBehavior.Normal,

--- a/src/features/transforms/sorting/__tests__/sortMocks.test.tsx
+++ b/src/features/transforms/sorting/__tests__/sortMocks.test.tsx
@@ -210,7 +210,7 @@ describe('getSortByParameterized', () => {
     ]);
   });
 
-  it('sortBy: PopulationAttested', () => {
+  it('sortBy: PopulationDirectlySourced', () => {
     const objects = Object.values(mockedObjects) as ObjectData[];
     const sort = getSortFunctionParameterized(
       SortBy.PopulationOfDescendants,

--- a/src/features/transforms/sorting/getSortBysApplicableToObjectType.ts
+++ b/src/features/transforms/sorting/getSortBysApplicableToObjectType.ts
@@ -1,0 +1,76 @@
+import { ObjectType } from '@features/params/PageParamTypes';
+
+import { SortBy } from './SortTypes';
+
+/** Not necessarily exhaustive, just the ones that will appear in the sidebar */
+export default function getSortBysApplicableToObjectType(objectType: ObjectType): SortBy[] {
+  switch (objectType) {
+    case ObjectType.Locale:
+      return [
+        SortBy.Code,
+        SortBy.Name,
+        SortBy.Endonym,
+        SortBy.Population,
+        SortBy.PopulationDirectlySourced,
+        SortBy.Literacy,
+        SortBy.PercentOfOverallLanguageSpeakers,
+        SortBy.CountOfLanguages,
+        SortBy.Language,
+        SortBy.WritingSystem,
+        SortBy.Territory,
+      ];
+    case ObjectType.Territory:
+      return [
+        SortBy.Code,
+        SortBy.Name,
+        SortBy.Population,
+        SortBy.Literacy,
+        SortBy.CountOfLanguages,
+        SortBy.CountOfTerritories,
+        SortBy.Latitude,
+        SortBy.Longitude,
+        SortBy.Area,
+      ];
+    case ObjectType.Language:
+      return [
+        SortBy.Code,
+        SortBy.Name,
+        SortBy.Endonym,
+        SortBy.Population,
+        SortBy.Literacy,
+        SortBy.CountOfTerritories,
+        SortBy.CountOfLanguages,
+        SortBy.WritingSystem,
+        SortBy.Territory,
+        SortBy.PopulationDirectlySourced,
+        SortBy.VitalityMetascore,
+        SortBy.ISOStatus,
+        SortBy.VitalityEthnologue2013,
+        SortBy.VitalityEthnologue2025,
+        SortBy.Latitude,
+        SortBy.Longitude,
+      ];
+    case ObjectType.Census:
+      return [
+        SortBy.Date,
+        SortBy.Code,
+        SortBy.Name,
+        SortBy.Population,
+        SortBy.Territory,
+        SortBy.CountOfLanguages,
+      ];
+    case ObjectType.WritingSystem:
+      return [
+        SortBy.Code,
+        SortBy.Name,
+        SortBy.Endonym,
+        SortBy.Population,
+        // SortBy.Literacy, Data not available yet
+        SortBy.Language,
+        SortBy.CountOfLanguages,
+        SortBy.PopulationOfDescendants,
+      ];
+    case ObjectType.VariantTag:
+      return [SortBy.Date, SortBy.Code, SortBy.Name, SortBy.Population, SortBy.CountOfLanguages];
+  }
+}

--- a/src/features/transforms/sorting/sort.tsx
+++ b/src/features/transforms/sorting/sort.tsx
@@ -1,4 +1,3 @@
-import { ObjectType } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 
 import { LanguageSource } from '@entities/language/LanguageTypes';
@@ -47,7 +46,7 @@ export function getNormalSortDirection(sortBy: SortBy): SortDirection {
       return SortDirection.Ascending; // A to Z
     case SortBy.Date:
     case SortBy.Population:
-    case SortBy.PopulationAttested:
+    case SortBy.PopulationDirectlySourced:
     case SortBy.PopulationOfDescendants:
     case SortBy.PopulationPercentInBiggestDescendantLanguage:
     case SortBy.PercentOfTerritoryPopulation:
@@ -61,77 +60,5 @@ export function getNormalSortDirection(sortBy: SortBy): SortDirection {
     case SortBy.VitalityEthnologue2025:
     case SortBy.Area:
       return SortDirection.Descending; // High to Low
-  }
-}
-
-/** Not necessarily exhaustive, just the ones that will appear in the sidebar */
-export function getSortBysApplicableToObjectType(objectType: ObjectType): SortBy[] {
-  switch (objectType) {
-    case ObjectType.Locale:
-      return [
-        SortBy.Code,
-        SortBy.Name,
-        SortBy.Endonym,
-        SortBy.Population,
-        SortBy.Literacy,
-        SortBy.PercentOfOverallLanguageSpeakers,
-        SortBy.CountOfLanguages,
-        SortBy.Language,
-        SortBy.WritingSystem,
-        SortBy.Territory,
-      ];
-    case ObjectType.Territory:
-      return [
-        SortBy.Code,
-        SortBy.Name,
-        SortBy.Population,
-        SortBy.Literacy,
-        SortBy.CountOfLanguages,
-        SortBy.CountOfTerritories,
-        SortBy.Latitude,
-        SortBy.Longitude,
-        SortBy.Area,
-      ];
-    case ObjectType.Language:
-      return [
-        SortBy.Code,
-        SortBy.Name,
-        SortBy.Endonym,
-        SortBy.Population,
-        SortBy.Literacy,
-        SortBy.CountOfTerritories,
-        SortBy.CountOfLanguages,
-        SortBy.WritingSystem,
-        SortBy.Territory,
-        SortBy.PopulationAttested,
-        SortBy.VitalityMetascore,
-        SortBy.ISOStatus,
-        SortBy.VitalityEthnologue2013,
-        SortBy.VitalityEthnologue2025,
-        SortBy.Latitude,
-        SortBy.Longitude,
-      ];
-    case ObjectType.Census:
-      return [
-        SortBy.Date,
-        SortBy.Code,
-        SortBy.Name,
-        SortBy.Population,
-        SortBy.Territory,
-        SortBy.CountOfLanguages,
-      ];
-    case ObjectType.WritingSystem:
-      return [
-        SortBy.Code,
-        SortBy.Name,
-        SortBy.Endonym,
-        SortBy.Population,
-        // SortBy.Literacy, Data not available yet
-        SortBy.Language,
-        SortBy.CountOfLanguages,
-        SortBy.PopulationOfDescendants,
-      ];
-    case ObjectType.VariantTag:
-      return [SortBy.Date, SortBy.Code, SortBy.Name, SortBy.Population, SortBy.CountOfLanguages];
   }
 }

--- a/src/features/treelist/TreeListOptions.tsx
+++ b/src/features/treelist/TreeListOptions.tsx
@@ -4,7 +4,7 @@ import Selector from '@features/params/ui/Selector';
 import { SelectorDisplay } from '@features/params/ui/SelectorDisplayContext';
 import usePageParams from '@features/params/usePageParams';
 import { ColorBy } from '@features/transforms/coloring/ColorTypes';
-import { getSortBysApplicableToObjectType } from '@features/transforms/sorting/sort';
+import getSortBysApplicableToObjectType from '@features/transforms/sorting/getSortBysApplicableToObjectType';
 
 interface TreeListOptions {
   allExpanded: boolean;

--- a/src/widgets/reports/LanguagesLargestDescendant.tsx
+++ b/src/widgets/reports/LanguagesLargestDescendant.tsx
@@ -125,17 +125,18 @@ function getLargestDescendant(language: LanguageData): LanguageData | undefined 
     return undefined;
   }
 
-  // We are using populationCited because we want to only use descendants that have a cited population
-  // numbers (aka no language families). Dialects rarely but sometimes have cited population numbers
+  // We are using populationRough because we want to only use descendants that have a directly
+  // sourced population (aka no language families). Dialects rarely but sometimes have directly
+  // sourced populations.
   return language.childLanguages.reduce<LanguageData | undefined>((largest, child) => {
     const childsLargest = getLargestDescendant(child);
     const candidateLargest =
-      (childsLargest?.populationCited || 0) > (child.populationCited || 0) ? childsLargest : child;
+      (childsLargest?.populationRough || 0) > (child.populationRough || 0) ? childsLargest : child;
     if (
       candidateLargest != null &&
-      candidateLargest.populationCited != null &&
-      candidateLargest.populationCited > 0 &&
-      (largest == null || candidateLargest.populationCited > (largest?.populationCited || 0))
+      candidateLargest.populationRough != null &&
+      candidateLargest.populationRough > 0 &&
+      (largest == null || candidateLargest.populationRough > (largest?.populationRough || 0))
     ) {
       return candidateLargest;
     }

--- a/src/widgets/tables/LanguageTable.tsx
+++ b/src/widgets/tables/LanguageTable.tsx
@@ -102,7 +102,7 @@ const LanguageTable: React.FC = () => {
         render: (lang) => (
           <HoverableEnumeration
             items={lang.childLanguages
-              .sort((a, b) => (b.populationCited ?? 0) - (a.populationCited ?? 0))
+              .sort((a, b) => (b.populationRough ?? 0) - (a.populationRough ?? 0))
               .map((lang) => lang.nameDisplay)}
           />
         ),

--- a/src/widgets/tables/columns/LanguagePopulationColumns.tsx
+++ b/src/widgets/tables/columns/LanguagePopulationColumns.tsx
@@ -53,10 +53,10 @@ export const LanguagePopulationColumns: TableColumn<LanguageData>[] = [
   {
     key: 'Population (Direct)',
     description: 'This comes from other language databases (citations still needed).',
-    render: (lang) => lang.populationCited,
+    render: (lang) => lang.populationRough,
     valueType: TableValueType.Population,
     isInitiallyVisible: false,
-    sortParam: SortBy.PopulationAttested,
+    sortParam: SortBy.PopulationDirectlySourced,
     columnGroup: 'Population',
   },
   {

--- a/src/widgets/tables/columns/LanguagePopulationColumns.tsx
+++ b/src/widgets/tables/columns/LanguagePopulationColumns.tsx
@@ -51,8 +51,9 @@ export const LanguagePopulationColumns: TableColumn<LanguageData>[] = [
     columnGroup: 'Population',
   },
   {
-    key: 'Population (Direct)',
-    description: 'This comes from other language databases (citations still needed).',
+    key: 'Population (Rough)',
+    description:
+      'This is a rough estimate from variable internet databases (citations not available).',
     render: (lang) => lang.populationRough,
     valueType: TableValueType.Population,
     isInitiallyVisible: false,

--- a/src/widgets/tables/columns/LocalePopulationColumns.tsx
+++ b/src/widgets/tables/columns/LocalePopulationColumns.tsx
@@ -26,7 +26,7 @@ export const LocalePopulationColumns: TableColumn<LocaleData>[] = [
     description: 'This is the original population number cited from sourced data.',
     render: (object) => object.populationSpeaking,
     valueType: TableValueType.Population,
-    sortParam: SortBy.PopulationAttested,
+    sortParam: SortBy.PopulationDirectlySourced,
     columnGroup: 'Demographics',
     isInitiallyVisible: false,
   },


### PR DESCRIPTION
I was preparing too big of a change to make language family data. So I am breaking that change up.

The biggest change for this PR is to rename "PopulationAttested" to  PopulationDirectly Sourced. While I was updating files I also broke up some into smaller ones.