### PR TITLE
Sorting: Review getApplicableSortBy values

### DIFF
--- a/public/data/wiki/territory_names.tsv
+++ b/public/data/wiki/territory_names.tsv
@@ -82,7 +82,7 @@ FM	Micronesia	Federated States of Micronesia	[1]
 FO	Faroe Islands	Føroyar	[1]	Færøerne	
 FR	France	France	[1]		
 GA	Gabon	Gabon	[1]		
-GB	United Kingdom	United Kingdom	[1]	Britain; Y Deyrnas Unedig; Unitit Kinrick; Rìoghachd Aonaichte; Ríocht Aontaithe; An Rywvaneth Unys	Great Britian; UK; GB
+GB	United Kingdom	United Kingdom	[1]	Britain; Y Deyrnas Unedig; Unitit Kinrick; Rìoghachd Aonaichte; Ríocht Aontaithe; An Rywvaneth Unys	Great Britain & Northern Ireland; UK
 GD	Grenada	Grenada	[1]		
 GE	Georgia	საქართველო	[1]	Sak'art'velo	
 GF	French Guiana	Guyane	[1]		
@@ -127,8 +127,8 @@ KH	Cambodia	កម្ពុជា	[1]	Kămpŭchéa
 KI	Kiribati	Kiribati	[1]		
 KM	Comoros	جزر القمر	[1]	Komori; Juzur al-Qumur; Comores	
 KN	St. Kitts & Nevis	Saint Kitts and Nevis	[1]		
-KP	North Korea	조선	[1]	Chosŏn; 朝鮮; Bukchosŏn; 북조선	
-KR	South Korea	한국	https://en.wikipedia.org/wiki/South_Korea	Hanguk; 대한민국; 韓國; Namhan; 남한	
+KP	North Korea	조선	[1]	Chosŏn; 朝鮮; Bukchosŏn; 북조선	Democratic People’s Republic of Korea; DPRK
+KR	South Korea	한국	https://en.wikipedia.org/wiki/South_Korea	Hanguk; 대한민국; 韓國; Namhan; 남한	Republic of Korea; ROK
 KW	Kuwait	دولة الكويت	[1]	Dawlat ul-Kuwayt; il-ikwet; الكويت	
 KY	Cayman Islands	Cayman Islands	[1]		
 KZ	Kazakhstan	Қазақстан	[1]	Qazaqstan; Kazakhstán; Казахстан	
@@ -172,7 +172,7 @@ NE	Niger	Nijar	[1]	Niger
 NF	Norfolk Island	Norfolk Island	[1]	Norf'k Ailen	
 NG	Nigeria	Nigeria	[1]	Nijeriya; Naìjíríyà; Nàìjíríà	
 NI	Nicaragua	Nicaragua	[1]		
-NL	Netherlands	Nederland	[1]	Nederlân	
+NL	Netherlands	Nederland	[1]	Nederlân	Holland; The Netherlands
 NO	Norway	Norge	[1]	Noreg; Norga; Vuodna; Nöörje	
 NP	Nepal	नेपाल	[1]	Nepāl	
 NR	Nauru	Nauru	[1]	Naoero	
@@ -197,7 +197,7 @@ QA	Qatar	قطر	[1]	Qaṭar
 RE	Réunion	La Réunion	[1]		
 RO	Romania	România	[1]		
 RS	Serbia	Србија	[1]	Srbija	
-RU	Russia	Россия	[1]	Rossiya; Rossiâ	
+RU	Russia	Россия	[1]	Rossiya; Rossiâ	Russian Federation
 RW	Rwanda	Rwanda	[1]		
 SA	Saudi Arabia	المملكة العربية السعودية	[1]	Al-Mamlaka Al-‘Arabiyyah as Sa‘ūdiyyah	
 SB	Solomon Islands	Solomon Islands	[1]	Solomon Aelan	
@@ -236,14 +236,14 @@ TR	Turkey	Türkiye	[1]
 TT	Trinidad & Tobago	Trinidad and Tobago	[1]		
 TV	Tuvalu	Tuvalu	[1]		
 TW	Taiwan	中華民國	[1]	Zhōnghuá Mínguó; Táiwān; 臺灣; 台灣	Republic of China
-TZ	Tanzania	Tanzania	[1]		
+TZ	Tanzania	Tanzania	[1]		United Republic of Tanzania
 UA	Ukraine	Україна	[1]	Ukrajina	
 UG	Uganda	Uganda	[1]		
 UM	U.S. Outlying Islands				
-US	United States	United States	[1]	Estados Unidos; États-Unis; ‘Amelika Hui Pū ‘ia	United States of America
+US	United States	United States	[1]	Estados Unidos; États-Unis; ‘Amelika Hui Pū ‘ia	United States of America; USA; U.S.
 UY	Uruguay	Uruguay	[1]		
 UZ	Uzbekistan	O‘zbekiston	[1]	Ўзбекистон	
-VA	Vatican City	Civitas Vaticana	[1]	Città del Vaticano	
+VA	Vatican City	Civitas Vaticana	[1]	Città del Vaticano	Holy See
 VC	St. Vincent & Grenadines	Saint Vincent and the Grenadines	[1]		
 VE	Venezuela	Venezuela	[1]		
 VG	British Virgin Islands	British Virgin Islands	[1]		

--- a/src/features/table/CommonColumns.tsx
+++ b/src/features/table/CommonColumns.tsx
@@ -25,6 +25,7 @@ export const NameColumn: TableColumn<ObjectData> = {
       <ObjectFieldHighlightedByPageSearch object={object} field={SearchableField.NameDisplay} />
     </HoverableObject>
   ),
+  exportValue: (object) => object.nameDisplay, // avoid html escapes like &amp;
   sortParam: SortBy.Name,
   columnGroup: 'Names',
 };

--- a/src/features/transforms/sorting/__tests__/getSortBysApplicableToObjectType.test.ts
+++ b/src/features/transforms/sorting/__tests__/getSortBysApplicableToObjectType.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { getFullyInstantiatedMockedObjects } from '@features/__tests__/MockObjects';
+import { ObjectType } from '@features/params/PageParamTypes';
+import { getSortField } from '@features/transforms/fields/getField';
+
+import getSortBysApplicableToObjectType from '../getSortBysApplicableToObjectType';
+import { SortBy } from '../SortTypes';
+
+describe('getSortBysApplicableToObjectType', () => {
+  it('should not return duplicate SortBy values for any ObjectType', () => {
+    Object.values(ObjectType).forEach((objectType) => {
+      const sortBys = getSortBysApplicableToObjectType(objectType);
+      const uniqueSortBys = new Set(sortBys);
+      expect(uniqueSortBys.size).toBe(sortBys.length);
+    });
+  });
+
+  it('Check that all possible SortBys are returned for each object type. Literally, if a sortBy is not returned by getSortBysApplicableToObjectType, then getSortField should not return a truthy value for it.', () => {
+    const mockedObjects = getFullyInstantiatedMockedObjects();
+
+    Object.values(ObjectType).forEach((objectType) => {
+      const objectsInType = Object.values(mockedObjects).filter((obj) => obj.type === objectType);
+      const sortBysForType = getSortBysApplicableToObjectType(objectType);
+
+      Object.values(SortBy).forEach((sortBy) => {
+        objectsInType.forEach((obj) => {
+          const sortField = getSortField(obj, sortBy);
+          if (!sortBysForType.includes(sortBy)) {
+            // The value is not supposed to be applicable
+            expect(
+              sortField,
+              `ObjectType (${objectType}) shouldn't be sorted by ${sortBy} but it has a getSortField value so it should be sortable. Failed on object: ${obj.nameDisplay} [${obj.ID}]`,
+            ).toBeFalsy();
+          }
+        });
+      });
+    });
+  });
+});

--- a/src/features/transforms/sorting/getSortBysApplicableToObjectType.ts
+++ b/src/features/transforms/sorting/getSortBysApplicableToObjectType.ts
@@ -2,18 +2,22 @@ import { ObjectType } from '@features/params/PageParamTypes';
 
 import { SortBy } from './SortTypes';
 
+const COMMON_SORT_BYS = [SortBy.Code, SortBy.Name, SortBy.Population];
+
 /** Not necessarily exhaustive, just the ones that will appear in the sidebar */
 export default function getSortBysApplicableToObjectType(objectType: ObjectType): SortBy[] {
+  return [...COMMON_SORT_BYS, ...getSortBysSpecificToObjectType(objectType)];
+}
+
+function getSortBysSpecificToObjectType(objectType: ObjectType): SortBy[] {
   switch (objectType) {
     case ObjectType.Locale:
       return [
-        SortBy.Code,
-        SortBy.Name,
         SortBy.Endonym,
-        SortBy.Population,
         SortBy.PopulationDirectlySourced,
         SortBy.Literacy,
         SortBy.PercentOfOverallLanguageSpeakers,
+        SortBy.PercentOfTerritoryPopulation,
         SortBy.CountOfLanguages,
         SortBy.Language,
         SortBy.WritingSystem,
@@ -21,28 +25,32 @@ export default function getSortBysApplicableToObjectType(objectType: ObjectType)
       ];
     case ObjectType.Territory:
       return [
-        SortBy.Code,
-        SortBy.Name,
-        SortBy.Population,
+        SortBy.Endonym,
         SortBy.Literacy,
         SortBy.CountOfLanguages,
         SortBy.CountOfTerritories,
         SortBy.Latitude,
         SortBy.Longitude,
         SortBy.Area,
+        SortBy.Language,
+        SortBy.WritingSystem,
+        SortBy.Territory, // Equivalent to DisplayName for territories
+        SortBy.PopulationDirectlySourced,
+        SortBy.PercentOfTerritoryPopulation,
+        SortBy.PopulationPercentInBiggestDescendantLanguage,
       ];
     case ObjectType.Language:
       return [
-        SortBy.Code,
-        SortBy.Name,
         SortBy.Endonym,
-        SortBy.Population,
         SortBy.Literacy,
         SortBy.CountOfTerritories,
         SortBy.CountOfLanguages,
+        SortBy.Language, // Equivalent to DisplayName for languages
         SortBy.WritingSystem,
         SortBy.Territory,
         SortBy.PopulationDirectlySourced,
+        SortBy.PopulationOfDescendants,
+        SortBy.PercentOfOverallLanguageSpeakers,
         SortBy.VitalityMetascore,
         SortBy.ISOStatus,
         SortBy.VitalityEthnologue2013,
@@ -53,24 +61,22 @@ export default function getSortBysApplicableToObjectType(objectType: ObjectType)
     case ObjectType.Census:
       return [
         SortBy.Date,
-        SortBy.Code,
-        SortBy.Name,
-        SortBy.Population,
+        SortBy.PopulationDirectlySourced,
+        SortBy.PercentOfTerritoryPopulation,
         SortBy.Territory,
         SortBy.CountOfLanguages,
       ];
     case ObjectType.WritingSystem:
       return [
-        SortBy.Code,
-        SortBy.Name,
         SortBy.Endonym,
-        SortBy.Population,
         // SortBy.Literacy, Data not available yet
         SortBy.Language,
         SortBy.CountOfLanguages,
         SortBy.PopulationOfDescendants,
+        SortBy.Territory,
+        SortBy.WritingSystem, // Equivalent to DisplayName for writing systems
       ];
     case ObjectType.VariantTag:
-      return [SortBy.Date, SortBy.Code, SortBy.Name, SortBy.Population, SortBy.CountOfLanguages];
+      return [SortBy.Date, SortBy.CountOfLanguages, SortBy.Language];
   }
 }


### PR DESCRIPTION
While I was talking with @cchandram about ScaleBy values and re-organizing how the "getApplicable..." methods work, I wanted to try poking holes in `getSortBysApplicableToObjectType`.

1) We can set a few common sortBys for all objects: Name, Code & Population. Unfortunately not object types support endonyms since we don't have data for endonyms for Variant Tags or Censuses.
2) Added a test for the function -- most interestingly revealing the objects we had truthy values for that weren't listed in the SortBy.
3) Added some more territory names from my previous change adding territory endonyms -- oof I wanted to add this to that change but I committed them to the wrong branch.