### PR TITLE
Refactor: Moved largest descendant computation to data loading

### DIFF
--- a/src/features/data/compute/computeLargestDescendants.ts
+++ b/src/features/data/compute/computeLargestDescendants.ts
@@ -1,0 +1,45 @@
+import { LanguageData, LanguagesBySource } from '@entities/language/LanguageTypes';
+
+export function computeLargestDescendants(languagesBySource: LanguagesBySource): void {
+  const languages = Object.values(languagesBySource.Combined);
+
+  // Clear first in case schema changes affect descendants.
+  languages.forEach((lang) => {
+    lang.largestDescendant = undefined;
+  });
+
+  // Compute the largest descendant for each language using Combined lineage.
+  languages.forEach((lang) => {
+    lang.largestDescendant = getLargestDescendant(lang);
+  });
+}
+
+function getLargestDescendant(language: LanguageData): LanguageData | undefined {
+  // If already computed, return memorized value.
+  if (language.largestDescendant !== undefined) {
+    return language.largestDescendant;
+  }
+
+  const children = language.Combined.childLanguages ?? [];
+  if (children.length === 0) {
+    return undefined;
+  }
+
+  // We are using populationRough because we want to only use descendants that have a directly
+  // sourced population (aka no language families). Dialects rarely but sometimes have directly
+  // sourced populations.
+  return children.reduce<LanguageData | undefined>((largest, child) => {
+    const childsLargest = getLargestDescendant(child);
+    const candidateLargest =
+      (childsLargest?.populationRough || 0) > (child.populationRough || 0) ? childsLargest : child;
+    if (
+      candidateLargest != null &&
+      candidateLargest.populationRough != null &&
+      candidateLargest.populationRough > 0 &&
+      (largest == null || candidateLargest.populationRough > (largest?.populationRough || 0))
+    ) {
+      return candidateLargest;
+    }
+    return largest;
+  }, undefined);
+}

--- a/src/features/data/load/CoreData.tsx
+++ b/src/features/data/load/CoreData.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react';
 
 import {
-  loadIANAVariants,
   addIANAVariantLocales,
   connectVariantTags,
+  loadIANAVariants,
 } from '@features/data/load/extra_entities/IANAData';
 import { ObjectType } from '@features/params/PageParamTypes';
 
-import { CensusID, CensusData } from '@entities/census/CensusTypes';
+import { CensusData, CensusID } from '@entities/census/CensusTypes';
 import { LanguageData, LanguagesBySource } from '@entities/language/LanguageTypes';
 import {
   LocaleData,
@@ -18,6 +18,7 @@ import {
 } from '@entities/types/DataTypes';
 
 import { computeDescendantPopulation } from '../compute/computeDescendantPopulation';
+import { computeLargestDescendants } from '../compute/computeLargestDescendants';
 import { groupLanguagesBySource } from '../connect/connectLanguages';
 import { connectLanguagesToParent } from '../connect/connectLanguagesToParent';
 import connectLocales from '../connect/connectLocales';
@@ -138,6 +139,7 @@ export function useCoreData(): {
     connectVariantTags(variantTags, languagesBySource.BCP, locales);
     createRegionalLocales(territories, locales); // create them after connecting them
     computeDescendantPopulation(languagesBySource, writingSystems);
+    computeLargestDescendants(languagesBySource);
 
     setCensuses({}); // Censuses are not loaded here, but this is needed to enable the page updates.
     setAllLanguoids(Object.values(languagesBySource.Combined));

--- a/src/widgets/reports/LanguagesLargestDescendant.tsx
+++ b/src/widgets/reports/LanguagesLargestDescendant.tsx
@@ -17,19 +17,6 @@ import CollapsibleReport from '@shared/containers/CollapsibleReport';
 const LanguagesLargestDescendant: React.FC = () => {
   const { languagesInSelectedSource } = useDataContext();
 
-  // TODO move this algorithm earlier in the data processing pipeline so it doesn't need to be
-  // recomputed every time the component renders.
-
-  // Clear the largest descendants first since it may change a lot if the schema changes.
-  languagesInSelectedSource.forEach((lang) => {
-    lang.largestDescendant = undefined;
-  });
-
-  // Compute the largest descendants for each language
-  languagesInSelectedSource.forEach((lang) => {
-    lang.largestDescendant = getLargestDescendant(lang);
-  });
-
   const [minimumPercentThreshold, setMinimumPercentThreshold] = React.useState(0);
   const [maximumPercentThreshold, setMaximumPercentThreshold] = React.useState(100);
 
@@ -115,33 +102,5 @@ const LanguagesLargestDescendant: React.FC = () => {
     </CollapsibleReport>
   );
 };
-
-function getLargestDescendant(language: LanguageData): LanguageData | undefined {
-  // If it has already been computed, return it.
-  if (language.largestDescendant !== undefined) {
-    return language.largestDescendant;
-  }
-  if (language.childLanguages.length === 0) {
-    return undefined;
-  }
-
-  // We are using populationRough because we want to only use descendants that have a directly
-  // sourced population (aka no language families). Dialects rarely but sometimes have directly
-  // sourced populations.
-  return language.childLanguages.reduce<LanguageData | undefined>((largest, child) => {
-    const childsLargest = getLargestDescendant(child);
-    const candidateLargest =
-      (childsLargest?.populationRough || 0) > (child.populationRough || 0) ? childsLargest : child;
-    if (
-      candidateLargest != null &&
-      candidateLargest.populationRough != null &&
-      candidateLargest.populationRough > 0 &&
-      (largest == null || candidateLargest.populationRough > (largest?.populationRough || 0))
-    ) {
-      return candidateLargest;
-    }
-    return largest;
-  }, undefined);
-}
 
 export default LanguagesLargestDescendant;


### PR DESCRIPTION
This pull request refactors how the "largest descendant language" is computed and stored, moving the computation out of the UI layer and into the data processing pipeline. This improves performance and code organization by ensuring these calculations are done once during data loading rather than on every component render.

### Data processing improvements

* Moved the algorithm into `src/features/data/compute/computeLargestDescendants.ts`
* Integrated it in `CoreData.tsx`
* Removed the redundant computation from the `LanguagesLargestDescendant` report component

Closes #241. 