### PR TITLE
Refactor: Moved largest descendant computation to data loading (new)

### DIFF
--- a/src/entities/lib/__tests__/getObjectPopulation.test.tsx
+++ b/src/entities/lib/__tests__/getObjectPopulation.test.tsx
@@ -178,7 +178,7 @@ describe('getObjectPopulationPercentInBiggestDescendantLanguage', () => {
       sjn_Teng_001: undefined,
       sjn_Teng_123: undefined,
       sjn_Teng_BE: undefined,
-      sjn: undefined,
+      sjn: '16.0', // dori0123 (1800) is 16% of sjn speakers (11220)
       Teng: undefined,
       tolkorth: undefined,
     });

--- a/src/features/__tests__/MockObjects.tsx
+++ b/src/features/__tests__/MockObjects.tsx
@@ -3,7 +3,7 @@ import { computeLocalesPopulationFromCensuses } from '@features/data/compute/com
 import { computeLocalesWritingPopulation } from '@features/data/compute/computeLocalesWritingPopulation';
 import { computeContainedTerritoryStats } from '@features/data/compute/computeTerritoryStats';
 import { connectObjectsAndCreateDerivedData } from '@features/data/compute/connectObjects';
-import { updateObjectCodesNameAndPopulation } from '@features/data/compute/updateObjectCodesNameAndPopulation';
+import { updateObjectsBasedOnDataParams } from '@features/data/compute/updateObjectsBasedOnDataParams';
 import { addCensusData } from '@features/data/connect/connectCensuses';
 import { DataContextType } from '@features/data/context/useDataContext';
 import { CoreDataArrays } from '@features/data/load/CoreData';
@@ -394,7 +394,7 @@ export function getFullyInstantiatedMockedObjects(
 
   // From DataContext
   const world = objects['001'] as TerritoryData;
-  updateObjectCodesNameAndPopulation(
+  updateObjectsBasedOnDataParams(
     Object.values(languagesBySource.Combined) as LanguageData[],
     Object.values(locales),
     world,

--- a/src/features/data/compute/__tests__/updateObjectsBasedOnDataParams.test.ts
+++ b/src/features/data/compute/__tests__/updateObjectsBasedOnDataParams.test.ts
@@ -10,9 +10,9 @@ import { LocaleSeparator, ObjectType } from '@features/params/PageParamTypes';
 import { LanguageSource } from '@entities/language/LanguageTypes';
 import { LocaleData, LocaleSource } from '@entities/locale/LocaleTypes';
 
-import { updateObjectCodesNameAndPopulation } from '../updateObjectCodesNameAndPopulation';
+import { updateObjectsBasedOnDataParams } from '../updateObjectsBasedOnDataParams';
 
-describe('updateObjectCodesNameAndPopulation', () => {
+describe('updateObjectsBasedOnDataParams', () => {
   it('updates language population estimates based on locales', () => {
     const mockedObjects = getDisconnectedMockedObjects();
     connectMockedObjects(mockedObjects); // Connect but do not compute population yet
@@ -35,7 +35,7 @@ describe('updateObjectCodesNameAndPopulation', () => {
     expect(sjn_001.nameDisplay).toBe('sjn_001'); // A readable name has not been computed yet
 
     // Perform the update
-    updateObjectCodesNameAndPopulation(
+    updateObjectsBasedOnDataParams(
       [sjn, dori0123],
       Object.values(mockedDictionaries.locales),
       mockedDictionaries.territories['001'],
@@ -71,7 +71,7 @@ describe('updateObjectCodesNameAndPopulation', () => {
     mockedObjects[newLocale.ID] = newLocale;
     connectMockedObjects(mockedObjects); // Re-connect objects
 
-    updateObjectCodesNameAndPopulation(
+    updateObjectsBasedOnDataParams(
       [sjn, dori0123],
       [...Object.values(mockedDictionaries.locales), newLocale], // Include the new locale
       mockedDictionaries.territories['001'],

--- a/src/features/data/compute/computeLargestDescendant.ts
+++ b/src/features/data/compute/computeLargestDescendant.ts
@@ -1,0 +1,41 @@
+import { LanguageData } from '@entities/language/LanguageTypes';
+
+export function computeLargestDescendant(languages: LanguageData[]): void {
+  // Clear the largest descendants first since it may change a lot if the schema changes.
+  languages.forEach((lang) => {
+    lang.largestDescendant = undefined;
+  });
+
+  // Compute the largest descendants for each language
+  languages.forEach((lang) => {
+    lang.largestDescendant = getLargestDescendant(lang);
+  });
+}
+
+function getLargestDescendant(language: LanguageData): LanguageData | undefined {
+  // If it has already been computed, return it.
+  if (language.largestDescendant !== undefined) {
+    return language.largestDescendant;
+  }
+  if (language.childLanguages.length === 0) {
+    return undefined;
+  }
+
+  // We are using populationRough because we want to only use descendants that have a directly
+  // sourced population (aka no language families). Dialects rarely but sometimes have directly
+  // sourced populations.
+  return language.childLanguages.reduce<LanguageData | undefined>((largest, child) => {
+    const childsLargest = getLargestDescendant(child);
+    const candidateLargest =
+      (childsLargest?.populationRough || 0) > (child.populationRough || 0) ? childsLargest : child;
+    if (
+      candidateLargest != null &&
+      candidateLargest.populationRough != null &&
+      candidateLargest.populationRough > 0 &&
+      (largest == null || candidateLargest.populationRough > (largest?.populationRough || 0))
+    ) {
+      return candidateLargest;
+    }
+    return largest;
+  }, undefined);
+}

--- a/src/features/data/compute/computeLargestDescendant.ts
+++ b/src/features/data/compute/computeLargestDescendant.ts
@@ -19,14 +19,15 @@ function getLargestDescendant(language: LanguageData): LanguageData | undefined 
   if (language.largestDescendant !== undefined) {
     return language.largestDescendant;
   }
-  if (language.childLanguages.length === 0) {
+  const children = language.Combined.childLanguages ?? [];
+  if (children.length === 0) {
     return undefined;
   }
 
   // We are using populationRough because we want to only use descendants that have a directly
   // sourced population (aka no language families). Dialects rarely but sometimes have directly
   // sourced populations.
-  return language.childLanguages.reduce<LanguageData | undefined>((largest, child) => {
+  return children.reduce<LanguageData | undefined>((largest, child) => {
     const childsLargest = getLargestDescendant(child);
     const candidateLargest =
       (childsLargest?.populationRough || 0) > (child.populationRough || 0) ? childsLargest : child;

--- a/src/features/data/compute/computeLargestDescendant.ts
+++ b/src/features/data/compute/computeLargestDescendant.ts
@@ -1,6 +1,8 @@
-import { LanguageData } from '@entities/language/LanguageTypes';
+import { LanguageData, LanguagesBySource } from '@entities/language/LanguageTypes';
 
-export function computeLargestDescendant(languages: LanguageData[]): void {
+export function computeLargestDescendant(languagesBySource: LanguagesBySource): void {
+  const languages = Object.values(languagesBySource.Combined);
+
   // Clear the largest descendants first since it may change a lot if the schema changes.
   languages.forEach((lang) => {
     lang.largestDescendant = undefined;

--- a/src/features/data/compute/computeLargestDescendant.ts
+++ b/src/features/data/compute/computeLargestDescendant.ts
@@ -1,8 +1,9 @@
-import { LanguageData, LanguagesBySource } from '@entities/language/LanguageTypes';
+import { LanguageData, LanguageSource } from '@entities/language/LanguageTypes';
 
-export function computeLargestDescendant(languagesBySource: LanguagesBySource): void {
-  const languages = Object.values(languagesBySource.Combined);
-
+export function computeLargestDescendant(
+  languages: LanguageData[],
+  languageSource: LanguageSource,
+): void {
   // Clear the largest descendants first since it may change a lot if the schema changes.
   languages.forEach((lang) => {
     lang.largestDescendant = undefined;
@@ -10,32 +11,50 @@ export function computeLargestDescendant(languagesBySource: LanguagesBySource): 
 
   // Compute the largest descendants for each language
   languages.forEach((lang) => {
-    lang.largestDescendant = getLargestDescendant(lang);
+    lang.largestDescendant = getLargestDescendant(lang, languageSource);
   });
 }
 
-function getLargestDescendant(language: LanguageData): LanguageData | undefined {
+function getLargestDescendant(
+  language: LanguageData,
+  languageSource: LanguageSource,
+): LanguageData | undefined {
   // If it has already been computed, return it.
   if (language.largestDescendant !== undefined) {
     return language.largestDescendant;
   }
-  const children = language.Combined.childLanguages ?? [];
+  const children = language[languageSource].childLanguages ?? [];
   if (children.length === 0) {
     return undefined;
   }
 
-  // We are using populationRough because we want to only use descendants that have a directly
-  // sourced population (aka no language families). Dialects rarely but sometimes have directly
-  // sourced populations.
+  // Skip language families and use populationEstimate
   return children.reduce<LanguageData | undefined>((largest, child) => {
-    const childsLargest = getLargestDescendant(child);
-    const candidateLargest =
-      (childsLargest?.populationRough || 0) > (child.populationRough || 0) ? childsLargest : child;
+    const childsLargest = getLargestDescendant(child, languageSource);
+
+    // Skip language families and only consider languages with population
+    const isChildValid = child.scope !== 'Family' && (child.populationEstimate || 0) > 0;
+    const isChildsLargestValid =
+      childsLargest?.scope !== 'Family' && (childsLargest?.populationEstimate || 0) > 0;
+
+    // Pick the better candidate: prefer the one with larger population
+    let candidateLargest: LanguageData | undefined;
+    if (isChildsLargestValid && isChildValid) {
+      candidateLargest =
+        (childsLargest?.populationEstimate || 0) > (child.populationEstimate || 0)
+          ? childsLargest
+          : child;
+    } else if (isChildsLargestValid) {
+      candidateLargest = childsLargest;
+    } else if (isChildValid) {
+      candidateLargest = child;
+    }
+
+    // Update largest if we found a better candidate
     if (
-      candidateLargest != null &&
-      candidateLargest.populationRough != null &&
-      candidateLargest.populationRough > 0 &&
-      (largest == null || candidateLargest.populationRough > (largest?.populationRough || 0))
+      candidateLargest &&
+      (largest == null ||
+        (candidateLargest.populationEstimate || 0) > (largest.populationEstimate || 0))
     ) {
       return candidateLargest;
     }

--- a/src/features/data/compute/computeLargestDescendant.ts
+++ b/src/features/data/compute/computeLargestDescendant.ts
@@ -1,4 +1,4 @@
-import { LanguageData, LanguageSource } from '@entities/language/LanguageTypes';
+import { LanguageData, LanguageScope, LanguageSource } from '@entities/language/LanguageTypes';
 
 export function computeLargestDescendant(
   languages: LanguageData[],
@@ -33,9 +33,10 @@ function getLargestDescendant(
     const childsLargest = getLargestDescendant(child, languageSource);
 
     // Skip language families and only consider languages with population
-    const isChildValid = child.scope !== 'Family' && (child.populationEstimate || 0) > 0;
+    const isChildValid =
+      child.scope !== LanguageScope.Family && (child.populationEstimate || 0) > 0;
     const isChildsLargestValid =
-      childsLargest?.scope !== 'Family' && (childsLargest?.populationEstimate || 0) > 0;
+      childsLargest?.scope !== LanguageScope.Family && (childsLargest?.populationEstimate || 0) > 0;
 
     // Pick the better candidate: prefer the one with larger population
     let candidateLargest: LanguageData | undefined;

--- a/src/features/data/compute/connectObjects.ts
+++ b/src/features/data/compute/connectObjects.ts
@@ -15,6 +15,7 @@ import { createRegionalLocales } from '../connect/createRegionalLocales';
 import { connectVariantTags } from '../load/extra_entities/IANAData';
 
 import { computeDescendantPopulation } from './computeDescendantPopulation';
+import { computeLargestDescendant } from './computeLargestDescendant';
 import { searchLocalesForMissingLinks } from './searchLocalesForMissingLinks';
 
 /**
@@ -40,4 +41,5 @@ export function connectObjectsAndCreateDerivedData(
   searchLocalesForMissingLinks(locales); // try to find missing links after creating new locales
   computeDescendantPopulation(languagesBySource, writingSystems);
   connectKeyboards(keyboards, languagesBySource.Combined, territories, writingSystems, variantTags);
+  computeLargestDescendant(Object.values(languagesBySource.Combined));
 }

--- a/src/features/data/compute/connectObjects.ts
+++ b/src/features/data/compute/connectObjects.ts
@@ -41,5 +41,5 @@ export function connectObjectsAndCreateDerivedData(
   searchLocalesForMissingLinks(locales); // try to find missing links after creating new locales
   computeDescendantPopulation(languagesBySource, writingSystems);
   connectKeyboards(keyboards, languagesBySource.Combined, territories, writingSystems, variantTags);
-  computeLargestDescendant(Object.values(languagesBySource.Combined));
+  computeLargestDescendant(languagesBySource);
 }

--- a/src/features/data/compute/connectObjects.ts
+++ b/src/features/data/compute/connectObjects.ts
@@ -15,7 +15,6 @@ import { createRegionalLocales } from '../connect/createRegionalLocales';
 import { connectVariantTags } from '../load/extra_entities/IANAData';
 
 import { computeDescendantPopulation } from './computeDescendantPopulation';
-import { computeLargestDescendant } from './computeLargestDescendant';
 import { searchLocalesForMissingLinks } from './searchLocalesForMissingLinks';
 
 /**

--- a/src/features/data/compute/connectObjects.ts
+++ b/src/features/data/compute/connectObjects.ts
@@ -40,5 +40,4 @@ export function connectObjectsAndCreateDerivedData(
   searchLocalesForMissingLinks(locales); // try to find missing links after creating new locales
   computeDescendantPopulation(languagesBySource, writingSystems);
   connectKeyboards(keyboards, languagesBySource.Combined, territories, writingSystems, variantTags);
-  computeLargestDescendant(languagesBySource);
 }

--- a/src/features/data/compute/updateObjectsBasedOnDataParams.ts
+++ b/src/features/data/compute/updateObjectsBasedOnDataParams.ts
@@ -38,7 +38,6 @@ export function updateObjectsBasedOnDataParams(
   updatePopulations(languages, locales, world);
   updateObjectNamesAndCodes(languages, locales, languageSource, localeSeparator);
   computeRecursiveLanguageData(languages);
-  precomputeLanguageVitality(languages);
   computeLargestDescendant(languages, languageSource);
 }
 

--- a/src/features/data/compute/updateObjectsBasedOnDataParams.ts
+++ b/src/features/data/compute/updateObjectsBasedOnDataParams.ts
@@ -6,6 +6,7 @@ import { getLocaleName } from '@entities/locale/LocaleStrings';
 import { LocaleData } from '@entities/locale/LocaleTypes';
 import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
+import { computeLargestDescendant } from './computeLargestDescendant';
 import computeRecursiveLanguageData from './computeRecursiveLanguageData';
 import { updatePopulations } from './updatePopulations';
 
@@ -26,7 +27,7 @@ import { updatePopulations } from './updatePopulations';
  *
  * This function recomputes those dependent values based on the current source selections.
  */
-export function updateObjectCodesNameAndPopulation(
+export function updateObjectsBasedOnDataParams(
   languages: LanguageData[],
   locales: LocaleData[],
   world: TerritoryData,
@@ -37,6 +38,8 @@ export function updateObjectCodesNameAndPopulation(
   updatePopulations(languages, locales, world);
   updateObjectNamesAndCodes(languages, locales, languageSource, localeSeparator);
   computeRecursiveLanguageData(languages);
+  precomputeLanguageVitality(languages);
+  computeLargestDescendant(languages, languageSource);
 }
 
 // Update parent/child relationships

--- a/src/features/data/context/DataProvider.tsx
+++ b/src/features/data/context/DataProvider.tsx
@@ -10,7 +10,7 @@ import { ObjectData } from '@entities/types/DataTypes';
 import { VariantTagData } from '@entities/varianttag/VariantTagTypes';
 import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
-import { updateObjectCodesNameAndPopulation } from '../compute/updateObjectCodesNameAndPopulation';
+import { updateObjectsBasedOnDataParams } from '../compute/updateObjectsBasedOnDataParams';
 import { useCoreData } from '../load/CoreData';
 import { loadSupplementalData } from '../load/SupplementalData';
 
@@ -86,7 +86,7 @@ const DataProvider: React.FC<{
   );
   const languagesInSelectedSource = useMemo(() => {
     // Update dependent fields whenever language source or locale separator changes
-    updateObjectCodesNameAndPopulation(
+    updateObjectsBasedOnDataParams(
       coreData.allLanguoids,
       coreData.locales,
       coreData.objects['001'] as TerritoryData, // The world territory

--- a/src/features/transforms/fields/FieldApplicability.ts
+++ b/src/features/transforms/fields/FieldApplicability.ts
@@ -67,6 +67,7 @@ function getSpecificFieldsForObjectType(objectType: ObjectType): Field[] {
         Field.Territory,
         Field.PopulationDirectlySourced,
         Field.PopulationOfDescendants,
+        Field.PopulationPercentInBiggestDescendantLanguage,
         Field.PercentOfOverallLanguageSpeakers,
         Field.VitalityMetascore,
         Field.ISOStatus,

--- a/src/widgets/reports/__tests__/LanguagePathsReport.test.tsx
+++ b/src/widgets/reports/__tests__/LanguagePathsReport.test.tsx
@@ -5,7 +5,7 @@ import {
   getFullyInstantiatedMockedObjects,
   getMockedDataContext,
 } from '@features/__tests__/MockObjects';
-import { updateObjectCodesNameAndPopulation } from '@features/data/compute/updateObjectCodesNameAndPopulation';
+import { updateObjectsBasedOnDataParams } from '@features/data/compute/updateObjectsBasedOnDataParams';
 import { LocaleSeparator, ObjectType } from '@features/params/PageParamTypes';
 
 import {
@@ -71,7 +71,7 @@ describe('LanguagePathsReport', () => {
 
     Object.values(LanguageSource).forEach((languageSource) => {
       // This shouldn't throw an error even in the presence of cycles
-      updateObjectCodesNameAndPopulation(
+      updateObjectsBasedOnDataParams(
         allLanguoids,
         locales,
         getTerritory('001')!,


### PR DESCRIPTION
This pull request refactors how the "largest descendant language" is computed and stored, moving the computation out of the UI layer and into the data processing pipeline. This improves performance and code organization by ensuring these calculations are done once during data loading rather than on every component render.

(New version of now deleted PR #342 after #337 introduced changes to `CoreData.tsx`, which I found easier to deal with in a new branch instead of handling merge conflicts and having a slightly messy PR)

### Changes: Data processing improvement

   * Moved the algorithm into `src/features/data/compute/computeLargestDescendant.ts`
   * Integrated it in `connectObjects.ts` 
   * Removed the redundant computation from the LanguagesLargestDescendant report component

Closes #241.