### PR TITLE
Locales: Create locales based on Language Families

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 - [ ] `npm run lint`
 - [ ] `npm run test`
-   - [ ] Tests added or updated for changed logic
+  - [ ] Tests added or updated for changed logic
 - [ ] `npm run build`
 - [ ] Write comments on manual testing how you tested in this PR
 - [ ] Include screenshots in the changes section below

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,30 +1,33 @@
 ## Summary
 
-- [ ] Clear description of what and why (link issues)
+- [ ] Clear description of what and why
 - [ ] Scope kept focused; note follow-ups if any
 - [ ] Set yourself as assignee
-- [ ] Mention the issue https://github.com/Translation-Commons/lang-nav/issues (usually by writing "Fixes #ISSUE_NUMBER" or "Closes #ISSUE_NUMBER")
+- [ ] Mention the issue (usually by writing "Fixes #ISSUE_NUMBER" or "Closes #ISSUE_NUMBER")
+  - [ ] If there is no issue, create one in [the repository issues page](https://github.com/Translation-Commons/lang-nav/issues) and link it here.
 
 ## Testing
 
 - [ ] `npm run lint`
 - [ ] `npm run test`
+   - [ ] Tests added or updated for changed logic
 - [ ] `npm run build`
-- [ ] Write comments on how you tested in this PR
-- [ ] Include screenshots
+- [ ] Write comments on manual testing how you tested in this PR
+- [ ] Include screenshots in the changes section below
 
 ## Changes
 
 ### Visual changes
 
 - [ ] Add before and after screenshots in the table below.
+  - [ ] Drag and drop images in the GitHub PR comment box to upload screenshots
 - [ ] Purely new views can just include the "after" screenshot.
-- [ ] Since more views can be reproduced by just sharing the URL -- add links to the relevant page and/or conditions to reproduce the view.
+- [ ] Since more views can be reproduced by just sharing the URL -- add links (eg. [link](https://translation-commons.github.io/lang-nav/data)) to the relevant page and/or conditions to reproduce the view.
 
-| What                                                                              | Before                                                                  | After                          |
-| --------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------ |
-| [the page and/or conditions](https://translation-commons.github.io/lang-nav/data) | Drag and drop images in the GitHub PR comment box to upload screenshots | Include an after image as well |
-| Add more screenshots as needed                                                    |                                                                         |                                |
+| Page/View | Changes | Before | After |
+| --------- | ------- | ------ | ----- |
+|           |         |        |       |
+|           |         |        |       |
 
 ### Data changes
 

--- a/src/entities/language/LanguagePopulationBreakdownButton.tsx
+++ b/src/entities/language/LanguagePopulationBreakdownButton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import HoverableButton from '@features/layers/hovercard/HoverableButton';
+
+import { PopulationSourceCategory } from '@entities/types/DataTypes';
+
+import { LanguagePopulationBreakdownFromDescendants } from './LanguagePopulationFromDescendants';
+import { LanguagePopulationBreakdownFromLocales } from './LanguagePopulationFromLocales';
+import { LanguageData } from './LanguageTypes';
+
+const LanguagePopulationBreakdownButton: React.FC<{ lang: LanguageData }> = ({ lang }) => {
+  const { populationEstimate, populationEstimateSource } = lang;
+  const [showPopulationBreakdown, setShowPopulationBreakdown] = React.useState(false);
+
+  if (!populationEstimate || !populationEstimateSource) return null;
+
+  let breakdown = null;
+  if (populationEstimateSource === PopulationSourceCategory.AggregatedFromTerritories) {
+    breakdown = <LanguagePopulationBreakdownFromLocales lang={lang} />;
+  } else if (populationEstimateSource === PopulationSourceCategory.AggregatedFromLanguages) {
+    breakdown = <LanguagePopulationBreakdownFromDescendants lang={lang} />;
+  }
+  if (!breakdown) return null;
+
+  return (
+    <>
+      <HoverableButton
+        style={{ marginLeft: '0.5em', padding: '0.25em', fontWeight: 'normal' }}
+        onClick={() => setShowPopulationBreakdown(!showPopulationBreakdown)}
+      >
+        {showPopulationBreakdown ? 'hide' : 'show'} breakdown
+      </HoverableButton>
+      {showPopulationBreakdown && <div style={{ margin: '0em 1em 1em 1em' }}>{breakdown}</div>}
+    </>
+  );
+};
+
+export default LanguagePopulationBreakdownButton;

--- a/src/entities/language/LanguagePopulationFromDescendants.tsx
+++ b/src/entities/language/LanguagePopulationFromDescendants.tsx
@@ -41,20 +41,23 @@ const LanguagePopulationFromDescendants: React.FC<{ lang: LanguageData }> = ({ l
           />
         </Hoverable>
       ) : null}
-      <Hoverable hoverContent={<PopulationOfDescendantsBreakdown lang={lang} />}>
+      <Hoverable hoverContent={<LanguagePopulationBreakdownFromDescendants lang={lang} />}>
         <CountOfPeople count={lang.populationOfDescendants} />
       </Hoverable>
     </>
   );
 };
 
-const PopulationOfDescendantsBreakdown: React.FC<{ lang: LanguageData }> = ({ lang }) => {
+export const LanguagePopulationBreakdownFromDescendants: React.FC<{ lang: LanguageData }> = ({
+  lang,
+}) => {
   const { updatePageParams } = usePageParams();
   if (!lang.populationOfDescendants) return null;
 
   return (
     <>
-      Computed by adding up constituent languages/dialects.
+      Computed by adding up constituent languages/dialects. This algorithm is still a work in
+      progress so numbers may not satisfyingly add up.
       <table>
         <tbody>
           {lang.childLanguages

--- a/src/entities/language/LanguagePopulationFromLocales.tsx
+++ b/src/entities/language/LanguagePopulationFromLocales.tsx
@@ -18,13 +18,15 @@ const LanguagePopulationFromLocales: React.FC<{ lang: LanguageData }> = ({ lang 
   if (!lang.populationFromLocales) return null;
 
   return (
-    <Hoverable hoverContent={<Descendants lang={lang} />}>
+    <Hoverable hoverContent={<LanguagePopulationBreakdownFromLocales lang={lang} />}>
       <CountOfPeople count={lang.populationFromLocales} />
     </Hoverable>
   );
 };
 
-const Descendants: React.FC<{ lang: LanguageData }> = ({ lang }) => {
+export const LanguagePopulationBreakdownFromLocales: React.FC<{ lang: LanguageData }> = ({
+  lang,
+}) => {
   const { updatePageParams } = usePageParams();
 
   const localesFromUniqueTerritories = Object.values(

--- a/src/entities/locale/LocalePopulationBreakdownAggregated.tsx
+++ b/src/entities/locale/LocalePopulationBreakdownAggregated.tsx
@@ -63,12 +63,16 @@ const LocalePopulationBreakdownAggregated: React.FC<{ locale: LocaleData }> = ({
           ))}
         {showAllConstituents ? (
           constituents.length > MAX_CONSTITUENTS_DISPLAYED && (
-            <HoverableButton
-              style={{ padding: '0.25em', marginLeft: '1em' }}
-              onClick={() => setShowAllConstituents(false)}
-            >
-              Show less
-            </HoverableButton>
+            <tr>
+              <td colSpan={3}>
+                <HoverableButton
+                  style={{ padding: '0.25em', marginLeft: '1em' }}
+                  onClick={() => setShowAllConstituents(false)}
+                >
+                  Show less
+                </HoverableButton>
+              </td>
+            </tr>
           )
         ) : (
           <RowOfRemainingConstituents

--- a/src/entities/locale/LocalePopulationBreakdownAggregated.tsx
+++ b/src/entities/locale/LocalePopulationBreakdownAggregated.tsx
@@ -1,5 +1,7 @@
+import { TriangleAlertIcon } from 'lucide-react';
 import React from 'react';
 
+import HoverableButton from '@features/layers/hovercard/HoverableButton';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 
 import { LocaleData, PopulationSourceCategory } from '@entities/types/DataTypes';
@@ -14,17 +16,14 @@ import { getLocaleName } from './LocaleStrings';
 const MAX_CONSTITUENTS_DISPLAYED = 5;
 
 const LocalePopulationBreakdownAggregated: React.FC<{ locale: LocaleData }> = ({ locale }) => {
-  const { populationAdjusted, populationSource } = locale;
+  const { populationAdjusted, populationSource, populationSpeakingPercent } = locale;
   const fromTerritories = populationSource === PopulationSourceCategory.AggregatedFromTerritories;
   const constituents = fromTerritories
     ? uniqueBy(locale.relatedLocales?.childTerritories || [], (l) => l.territoryCode || '')
     : uniqueBy(locale.relatedLocales?.childLanguages || [], (l) => l.languageCode).sort(
         (a, b) => (b.populationAdjusted ?? 0) - (a.populationAdjusted ?? 0),
       );
-  const totalPercent =
-    (sumBy(constituents, (loc) => loc.populationAdjusted) /
-      sumBy(constituents, (loc) => loc.territory?.population || 0)) *
-    100;
+  const [showAllConstituents, setShowAllConstituents] = React.useState(false);
 
   return (
     <table>
@@ -48,19 +47,35 @@ const LocalePopulationBreakdownAggregated: React.FC<{ locale: LocaleData }> = ({
           <LabelTableCell align="right">{getLocaleName(locale, false)} Population</LabelTableCell>
           <LabelTableCell align="right">% of territory</LabelTableCell>
         </tr>
-        {constituents.slice(0, MAX_CONSTITUENTS_DISPLAYED).map((childLocale) => (
-          <tr key={childLocale.ID}>
-            <td style={{ paddingLeft: '1em' }}>
-              <HoverableObjectName
-                object={childLocale}
-                labelSource={fromTerritories ? 'territory' : 'language'}
-              />
-            </td>
-            <CellPopulation population={childLocale.populationAdjusted} />
-            <CellPercent percent={childLocale.populationSpeakingPercent} />
-          </tr>
-        ))}
-        <RowOfRemainingConstituents locales={constituents.slice(MAX_CONSTITUENTS_DISPLAYED)} />
+        {constituents
+          .slice(0, showAllConstituents ? constituents.length : MAX_CONSTITUENTS_DISPLAYED)
+          .map((childLocale) => (
+            <tr key={childLocale.ID}>
+              <td style={{ paddingLeft: '1em' }}>
+                <HoverableObjectName
+                  object={childLocale}
+                  labelSource={fromTerritories ? 'territory' : 'language'}
+                />
+              </td>
+              <CellPopulation population={childLocale.populationAdjusted} />
+              <CellPercent percent={childLocale.populationSpeakingPercent} />
+            </tr>
+          ))}
+        {showAllConstituents ? (
+          constituents.length > MAX_CONSTITUENTS_DISPLAYED && (
+            <HoverableButton
+              style={{ padding: '0.25em', marginLeft: '1em' }}
+              onClick={() => setShowAllConstituents(false)}
+            >
+              Show less
+            </HoverableButton>
+          )
+        ) : (
+          <RowOfRemainingConstituents
+            locales={constituents.slice(MAX_CONSTITUENTS_DISPLAYED)}
+            setShowAllConstituents={setShowAllConstituents}
+          />
+        )}
         <tr>
           <LabelTableCell>
             <HoverableObjectName
@@ -69,8 +84,26 @@ const LocalePopulationBreakdownAggregated: React.FC<{ locale: LocaleData }> = ({
             />
           </LabelTableCell>
           <CellPopulation population={populationAdjusted} />
-          <CellPercent percent={totalPercent > 100 ? 100 : totalPercent} />
+          <CellPercent
+            leftContent={
+              (populationSpeakingPercent ?? 0) >= 99.9 && (
+                <TriangleAlertIcon size="1em" style={{ color: 'var(--color-text-yellow)' }} />
+              )
+            }
+            percent={populationSpeakingPercent}
+          />
         </tr>
+        {(populationSpeakingPercent ?? 0) >= 99.9 && (
+          <tr>
+            <td colSpan={3}>
+              The population of this locale{' '}
+              {(populationSpeakingPercent ?? 0) > 100 ? 'exceeds' : 'is'} 100% of the territory
+              population, which is likely not an accurate reflection of the people in the area.
+              Rather, constituents may be double-counted but without specific data this is the best
+              aggregate.
+            </td>
+          </tr>
+        )}
       </tbody>
     </table>
   );
@@ -78,7 +111,8 @@ const LocalePopulationBreakdownAggregated: React.FC<{ locale: LocaleData }> = ({
 
 const RowOfRemainingConstituents: React.FC<{
   locales: LocaleData[];
-}> = ({ locales }) => {
+  setShowAllConstituents: (show: boolean) => void;
+}> = ({ locales, setShowAllConstituents }) => {
   if (locales.length === 0) return null;
   const totalInRemainder = sumBy(locales, (locale) => locale.populationAdjusted ?? 0);
   const percentInRemainder =
@@ -87,7 +121,12 @@ const RowOfRemainingConstituents: React.FC<{
   return (
     <tr>
       <td style={{ paddingLeft: '1em' }}>
-        +{locales.length} other{locales.length > 1 && 's'}
+        <HoverableButton
+          style={{ padding: '0.25em', fontWeight: 'normal' }}
+          onClick={() => setShowAllConstituents(true)}
+        >
+          +{locales.length} other{locales.length > 1 && 's'}
+        </HoverableButton>
       </td>
       <CellPopulation population={totalInRemainder} />
       <CellPercent percent={percentInRemainder} />

--- a/src/entities/types/DataTypes.tsx
+++ b/src/entities/types/DataTypes.tsx
@@ -167,6 +167,7 @@ export enum LocaleSource {
   IANA = 'IANA', // created when importing IANA variant tags
   Census = 'census', // created when importing census data
   CreateRegionalLocales = 'createRegionalLocales', // created when generating aggregated regional locales
+  CreateFamilyLocales = 'createFamilyLocales', // created when generating locales for language families
 }
 
 export interface LocaleData extends ObjectBase {
@@ -202,6 +203,9 @@ export interface LocaleData extends ObjectBase {
     moreSpecific?: LocaleData[]; // Locales that are more specific forms of this locale (eg. zh_SG -> zh_Hant_SG, zh_Hans_SG)
     childTerritories?: LocaleData[]; // Locales that represent subdivisions of this locale's territory
     childLanguages?: LocaleData[]; // Locales that represent child/descendant languages of this locale's language
+
+    sumOfPopulationFromChildTerritories?: number;
+    sumOfPopulationFromChildLanguages?: number;
   };
 
   // Data computed from other references, particularly territories.tsv and censuses

--- a/src/features/data/compute/__tests__/computeLocalesPopulationFromCensuses.test.ts
+++ b/src/features/data/compute/__tests__/computeLocalesPopulationFromCensuses.test.ts
@@ -11,8 +11,8 @@ import { ObjectType } from '@features/params/PageParamTypes';
 import { CensusCollectorType, CensusData } from '@entities/census/CensusTypes';
 import { LocaleData, LocaleSource, ObjectDictionary } from '@entities/types/DataTypes';
 
+import { computeRegionalLocalesPopulation } from '../computeAggregatedLocalesPopulation';
 import { computeLocalesPopulationFromCensuses } from '../computeLocalesPopulationFromCensuses';
-import { computeRegionalLocalesPopulation } from '../computeRegionalLocalesPopulation';
 import { updateLanguagesPopulationFromLocale, updatePopulations } from '../updatePopulations';
 
 describe('computeLocalePopulationFromCensuses', () => {

--- a/src/features/data/compute/computeAggregatedLocalesPopulation.ts
+++ b/src/features/data/compute/computeAggregatedLocalesPopulation.ts
@@ -1,3 +1,4 @@
+import { LanguageData } from '@entities/language/LanguageTypes';
 import {
   isTerritoryGroup,
   LocaleData,
@@ -92,3 +93,5 @@ function getLanguageFamilyLocalePopulation(locale: LocaleData): void {
     }
   }
 }
+
+export function computeIntermediateLanguageFamilyPopulations(languages: LanguageData[]): void {}

--- a/src/features/data/compute/computeAggregatedLocalesPopulation.ts
+++ b/src/features/data/compute/computeAggregatedLocalesPopulation.ts
@@ -34,7 +34,7 @@ export function computeRegionalLocalesPopulation(territory: TerritoryData | unde
     ).filter((loc) => loc.territoryCode !== '');
 
     // Add up the adjusted population of unique contained locales (eg don't double count
-    // zh_Hans_SG and zh_Hant_SG). The adjust population is corrected to the current year
+    // zh_Hans_SG and zh_Hant_SG). The adjusted population is corrected to the current year
     // to smooth out population growth between data collected in different years.
     relatedLocales.sumOfPopulationFromChildTerritories =
       sumBy(uniqueContainedLocales, (loc) => loc.populationAdjusted) || undefined;
@@ -59,7 +59,7 @@ export function computeLanguageFamilyLocalePopulations(locales: LocaleData[]): v
 }
 
 function getLanguageFamilyLocalePopulation(locale: LocaleData): void {
-  // Re-compute the estimate for the contained territories first.
+  // Re-compute the estimate for the child languages first.
   const relatedLocales = locale.relatedLocales || {};
   if (!relatedLocales.childLanguages) return;
   const { childLanguages } = relatedLocales;

--- a/src/features/data/compute/computeAggregatedLocalesPopulation.ts
+++ b/src/features/data/compute/computeAggregatedLocalesPopulation.ts
@@ -1,4 +1,3 @@
-import { LanguageData } from '@entities/language/LanguageTypes';
 import {
   isTerritoryGroup,
   LocaleData,
@@ -93,5 +92,3 @@ function getLanguageFamilyLocalePopulation(locale: LocaleData): void {
     }
   }
 }
-
-export function computeIntermediateLanguageFamilyPopulations(languages: LanguageData[]): void {}

--- a/src/features/data/compute/computeAggregatedLocalesPopulation.ts
+++ b/src/features/data/compute/computeAggregatedLocalesPopulation.ts
@@ -75,12 +75,20 @@ function getLanguageFamilyLocalePopulation(locale: LocaleData): void {
   relatedLocales.sumOfPopulationFromChildLanguages =
     sumBy(uniqueChildLocales, (childLocale) => childLocale.populationAdjusted) || undefined;
 
-  // Recompute the population of family locales first
-  if (locale.localeSource === LocaleSource.CreateFamilyLocales) {
-    locale.populationAdjusted = relatedLocales.sumOfPopulationFromChildLanguages;
-    locale.populationSpeaking =
-      sumBy(uniqueChildLocales, (childLocale) => childLocale.populationSpeaking) || undefined;
-    if (locale.populationAdjusted && locale.territory?.population)
-      locale.populationSpeakingPercent = locale.populationAdjusted / locale.territory.population;
+  // If the locale is for a language family, set its population to the sum of its children's populations
+  if (
+    locale.localeSource === LocaleSource.CreateFamilyLocales &&
+    relatedLocales.sumOfPopulationFromChildLanguages
+  ) {
+    const percentOfTerritory =
+      (relatedLocales.sumOfPopulationFromChildLanguages * 100) /
+      (locale.territory?.population || 1);
+    if (percentOfTerritory > 100) {
+      locale.populationAdjusted = locale.territory?.population;
+      locale.populationSpeakingPercent = 100;
+    } else {
+      locale.populationAdjusted = relatedLocales.sumOfPopulationFromChildLanguages;
+      locale.populationSpeakingPercent = percentOfTerritory;
+    }
   }
 }

--- a/src/features/data/compute/connectObjects.ts
+++ b/src/features/data/compute/connectObjects.ts
@@ -10,6 +10,7 @@ import { connectLanguagesToParent } from '../connect/connectLanguagesToParent';
 import connectLocales from '../connect/connectLocales';
 import { connectTerritoriesToParent } from '../connect/connectTerritoriesToParent';
 import { connectWritingSystems } from '../connect/connectWritingSystems';
+import { createFamilyLocales } from '../connect/createFamilyLocales';
 import { createRegionalLocales } from '../connect/createRegionalLocales';
 import { connectVariantTags } from '../load/extra_entities/IANAData';
 
@@ -33,6 +34,7 @@ export function connectObjectsAndCreateDerivedData(
   connectWritingSystems(languagesBySource.Combined, territories, writingSystems);
   connectLocales(languagesBySource.Combined, territories, writingSystems, locales);
   connectVariantTags(variantTags, languagesBySource.BCP, locales);
+  createFamilyLocales(languagesBySource.Combined, locales); // create them before regional locales
   createRegionalLocales(territories, locales); // create them after connecting them
   searchLocalesForMissingLinks(locales); // try to find missing links after creating new locales
   computeDescendantPopulation(languagesBySource, writingSystems);

--- a/src/features/data/compute/updatePopulations.ts
+++ b/src/features/data/compute/updatePopulations.ts
@@ -4,7 +4,10 @@ import { LocaleData, PopulationSourceCategory, TerritoryData } from '@entities/t
 import { sumBy } from '@shared/lib/setUtils';
 
 import { computeLocalesPopulationFromCensuses } from './computeLocalesPopulationFromCensuses';
-import { computeRegionalLocalesPopulation } from './computeRegionalLocalesPopulation';
+import {
+  computeLanguageFamilyLocalePopulations,
+  computeRegionalLocalesPopulation,
+} from './computeRegionalLocalesPopulation';
 
 export function updatePopulations(
   languages: LanguageData[],
@@ -16,6 +19,7 @@ export function updatePopulations(
   // Start with the world territory (001) and then go down to groups
   // This will update regional locales AND the languages themselves
   computeRegionalLocalesPopulation(world);
+  computeLanguageFamilyLocalePopulations(locales);
 
   updateLanguagesPopulationFromLocale(world);
 

--- a/src/features/data/compute/updatePopulations.ts
+++ b/src/features/data/compute/updatePopulations.ts
@@ -3,11 +3,11 @@ import { LocaleData, PopulationSourceCategory, TerritoryData } from '@entities/t
 
 import { sumBy } from '@shared/lib/setUtils';
 
-import { computeLocalesPopulationFromCensuses } from './computeLocalesPopulationFromCensuses';
 import {
   computeLanguageFamilyLocalePopulations,
   computeRegionalLocalesPopulation,
-} from './computeRegionalLocalesPopulation';
+} from './computeAggregatedLocalesPopulation';
+import { computeLocalesPopulationFromCensuses } from './computeLocalesPopulationFromCensuses';
 
 export function updatePopulations(
   languages: LanguageData[],
@@ -19,6 +19,7 @@ export function updatePopulations(
   // Start with the world territory (001) and then go down to groups
   // This will update regional locales AND the languages themselves
   computeRegionalLocalesPopulation(world);
+
   computeLanguageFamilyLocalePopulations(locales);
 
   updateLanguagesPopulationFromLocale(world);

--- a/src/features/data/connect/__tests__/createFamilyLocales.test.ts
+++ b/src/features/data/connect/__tests__/createFamilyLocales.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getDisconnectedMockedObjects,
+  getFullyInstantiatedMockedObjects,
+} from '@features/__tests__/MockObjects';
+import { ObjectType } from '@features/params/PageParamTypes';
+
+import { getBaseLanguageData, LanguageData } from '@entities/language/LanguageTypes';
+import { ObjectDictionary } from '@entities/types/DataTypes';
+
+describe('createFamilyLocales', () => {
+  function getLocaleIDs(objects: ObjectDictionary): string {
+    return Object.values(objects)
+      .filter((obj) => obj.type === ObjectType.Locale)
+      .map((locale) => locale.ID)
+      .join(' ');
+  }
+
+  it('should create family locales correctly', () => {
+    const inputObjects = getDisconnectedMockedObjects();
+    const elv: LanguageData = {
+      ...getBaseLanguageData('elv', 'Elvish'), // fictional language family code
+      nameEndonym: 'ɛlvɪʃ',
+      names: ['Elvish', 'Elven Languages', 'ɛlvɪʃ'],
+      populationRough: 50000,
+    };
+    inputObjects['elv'] = elv;
+    expect(getLocaleIDs(inputObjects)).toBe('sjn_BE sjn_ER dori0123_ER sjn_Teng_BE');
+
+    // getFullyInstantiatedMockedObjects will run connectMockedObjects which runs
+    // connectObjectsAndCreateDerivedData which includes createFamilyLocales
+    const objects = getFullyInstantiatedMockedObjects(inputObjects);
+
+    // Now check that the family locales were created along with the regional locales
+    expect(objects['elv_001'].nameDisplay).toBe('Elvish (Arda)');
+    expect(getLocaleIDs(inputObjects)).toBe(
+      'sjn_BE sjn_ER dori0123_ER sjn_Teng_BE elv_BE elv_ER sjn_123 elv_123 sjn_Teng_123 dori0123_123 sjn_001 elv_001 sjn_Teng_001 dori0123_001',
+    );
+  });
+});

--- a/src/features/data/connect/createFamilyLocales.ts
+++ b/src/features/data/connect/createFamilyLocales.ts
@@ -16,13 +16,20 @@ export function createFamilyLocales(
   languages: LanguageDictionary,
   locales: Record<string, LocaleData>,
 ): void {
+  console.log('Creating family locales:', Object.keys(locales));
   Object.values(languages).forEach((language) => {
+    console.log(
+      language.ID,
+      language[SOURCE]?.parentLanguage?.ID,
+      language[SOURCE]?.childLanguages?.map((cl) => cl.ID),
+    );
     // Only start recursively creating family locales for top-level languages
     if (language[SOURCE].parentLanguage != null || language[SOURCE].childLanguages?.length === 0)
       return;
     // Create locales for all the territories the language is used in
     createLocalesForLanguageFamily(language, locales);
   });
+  console.log('Created family locales:', Object.keys(locales));
 }
 
 function createLocalesForLanguageFamily(

--- a/src/features/data/connect/createFamilyLocales.ts
+++ b/src/features/data/connect/createFamilyLocales.ts
@@ -97,6 +97,8 @@ function createLocalesForLanguageFamily(
         childLocale.populationSpeaking != null &&
         newLocale.localeSource === LocaleSource.CreateFamilyLocales
       ) {
+        // Most of this will be re-done in computeLanguageFamilyLocalePopulations after census data is added
+
         if (newLocale.populationSpeaking == null) newLocale.populationSpeaking = 0;
         // Note this may double count populations when people speak multiple languages in the family
         newLocale.populationSpeaking += childLocale.populationSpeaking || 0;

--- a/src/features/data/connect/createFamilyLocales.ts
+++ b/src/features/data/connect/createFamilyLocales.ts
@@ -44,7 +44,7 @@ function createLocalesForLanguageFamily(
 
   // For each childLocale, make a new locale for the language family or add the data to that language family
   childLocales.forEach((childLocale) => {
-    // Filter our exceptional locales, we don't want to worry about those right now
+    // Filter out exceptional locales, we don't want to worry about those right now
     if (childLocale.variantTagCodes && childLocale.variantTagCodes.length > 0) return; // Skip variant locales
     if (childLocale.scriptCode) return; // Skip script-specific locales
 

--- a/src/features/data/connect/createFamilyLocales.ts
+++ b/src/features/data/connect/createFamilyLocales.ts
@@ -1,0 +1,116 @@
+import { ObjectType } from '@features/params/PageParamTypes';
+
+import { LanguageData, LanguageDictionary, LanguageSource } from '@entities/language/LanguageTypes';
+import { LocaleData, LocaleSource, PopulationSourceCategory } from '@entities/types/DataTypes';
+
+// SOURCE is a constant to pick what source to use when creating family locales.
+// Ideally we'd do this for all sources or the Combined source -- but because it can create so
+// many locales (also compounded with regional locales), we limit it for now to just ISO
+// Comparison          Locales   Heap Memory
+// No family locales    32,415        98 MB
+// ISO:                 36,149      ~103 MB
+// Combined:            69,250      ~125 MB
+const SOURCE = LanguageSource.ISO;
+
+export function createFamilyLocales(
+  languages: LanguageDictionary,
+  locales: Record<string, LocaleData>,
+): void {
+  Object.values(languages).forEach((language) => {
+    // Only start recursively creating family locales for top-level languages
+    if (language[SOURCE].parentLanguage != null || language[SOURCE].childLanguages?.length === 0)
+      return;
+    // Create locales for all the territories the language is used in
+    createLocalesForLanguageFamily(language, locales);
+  });
+}
+
+function createLocalesForLanguageFamily(
+  language: LanguageData,
+  allLocales: Record<string, LocaleData>,
+): LocaleData[] {
+  // Find the child locales for this language
+  const childLocales =
+    language[SOURCE].childLanguages?.flatMap((childLang) =>
+      createLocalesForLanguageFamily(childLang, allLocales),
+    ) || [];
+
+  // For each childLocale, make a new locale for the language family or add the data to that language family
+  childLocales.forEach((childLocale) => {
+    // Filter our exceptional locales, we don't want to worry about those right now
+    if (childLocale.variantTagCodes && childLocale.variantTagCodes.length > 0) return; // Skip variant locales
+    if (childLocale.scriptCode) return; // Skip script-specific locales
+
+    const { territory, territoryCode } = childLocale;
+    if (!territory) return;
+
+    // Create a new locale or update an existing family
+    const newLocaleCode = `${language.ID}_${territoryCode}`;
+    let newLocale = allLocales[newLocaleCode];
+
+    if (newLocale == null) {
+      const population =
+        Math.min(childLocale.populationSpeaking || 0, territory.population) || undefined;
+
+      // It isn't found yet, create it
+      newLocale = {
+        // Set a new locale code and territory code
+        type: ObjectType.Locale,
+        ID: newLocaleCode,
+        codeDisplay: newLocaleCode,
+        localeSource: LocaleSource.CreateFamilyLocales,
+
+        // Add other parts of the locale code
+        languageCode: language.ID,
+        language,
+        territoryCode: territory.ID,
+        territory,
+
+        // Other references that are undefined by definition but included in case the code is changed to allow them
+        scriptCode: childLocale.scriptCode, // should be undefined
+        writingSystem: childLocale.writingSystem, // should be undefined
+        variantTagCodes:
+          childLocale.variantTagCodes != null ? [...childLocale.variantTagCodes] : [], // dereference the array
+        variantTags: childLocale.variantTags != null ? [...childLocale.variantTags] : [], // dereference the array
+
+        // Initialize the population
+        populationSpeaking: population,
+        populationSpeakingPercent:
+          population != null ? (population * 100) / territory.population : undefined,
+        populationSource: PopulationSourceCategory.AggregatedFromLanguages,
+
+        // Add stubs for required fields
+        names: [],
+        nameDisplay: newLocaleCode, // Will be computed later
+      };
+
+      // Add edges
+      allLocales[newLocaleCode] = newLocale;
+      if (!language.locales) language.locales = [];
+      language.locales.push(newLocale);
+      if (!territory.locales) territory.locales = [];
+      territory.locales.push(newLocale);
+    } else {
+      // Add up population estimates
+      // But only for locales that were created in this function
+      if (
+        childLocale.populationSpeaking != null &&
+        newLocale.localeSource === LocaleSource.CreateFamilyLocales
+      ) {
+        if (newLocale.populationSpeaking == null) newLocale.populationSpeaking = 0;
+        // Note this may double count populations when people speak multiple languages in the family
+        newLocale.populationSpeaking += childLocale.populationSpeaking || 0;
+        newLocale.populationSpeakingPercent =
+          (newLocale.populationSpeaking * 100) / territory.population;
+
+        // At least we can max out the percentage at 100%
+        if (newLocale.populationSpeakingPercent > 100) {
+          newLocale.populationSpeakingPercent = 100;
+          newLocale.populationSpeaking = territory.population;
+        }
+      }
+    }
+  });
+
+  return language.locales || [];
+}

--- a/src/shared/lib/setUtils.ts
+++ b/src/shared/lib/setUtils.ts
@@ -38,7 +38,7 @@ export function toDictionary<T, K extends string | number>(
   return items.reduce(
     (dict, item) => {
       const key = keyFn(item);
-      dict[key] = item;
+      if (!dict[key]) dict[key] = item;
       return dict;
     },
     {} as Record<K, T>,

--- a/src/strings/LanguageScopeStrings.ts
+++ b/src/strings/LanguageScopeStrings.ts
@@ -1,0 +1,20 @@
+import { LanguageScope } from '@entities/language/LanguageTypes';
+
+export function getLanguageScopeLabel(scope?: LanguageScope): string {
+  if (scope == null) return 'Language';
+
+  switch (scope) {
+    case LanguageScope.Family:
+      return 'Language Family';
+    case LanguageScope.Macrolanguage:
+      return 'Macrolanguage';
+    case LanguageScope.Language:
+      return 'Language';
+    case LanguageScope.Dialect:
+      return 'Dialect';
+    case LanguageScope.SpecialCode:
+      return 'Special Code';
+    default:
+      return 'Unknown Scope';
+  }
+}

--- a/src/widgets/details/LanguageDetails.tsx
+++ b/src/widgets/details/LanguageDetails.tsx
@@ -6,6 +6,7 @@ import { getScopeFilter } from '@features/transforms/filtering/filter';
 import { getSortFunction } from '@features/transforms/sorting/sort';
 import TreeListRoot from '@features/treelist/TreeListRoot';
 
+import LanguagePopulationBreakdownButton from '@entities/language/LanguagePopulationBreakdownButton';
 import { LanguagePopulationEstimate } from '@entities/language/LanguagePopulationEstimate';
 import LanguagePopulationOfDescendants from '@entities/language/LanguagePopulationFromDescendants';
 import LanguagePopulationFromLocales from '@entities/language/LanguagePopulationFromLocales';
@@ -46,6 +47,7 @@ const LanguageDetails: React.FC<Props> = ({ lang }) => {
 const LanguageAttributes: React.FC<{ lang: LanguageData }> = ({ lang }) => {
   const {
     populationEstimate,
+    populationEstimateSource,
     modality,
     primaryWritingSystem,
     writingSystems,
@@ -58,7 +60,11 @@ const LanguageAttributes: React.FC<{ lang: LanguageData }> = ({ lang }) => {
       {populationEstimate && (
         <DetailsField title="Population Estimate:">
           <LanguagePopulationEstimate lang={lang} />
+          <LanguagePopulationBreakdownButton lang={lang} />
         </DetailsField>
+      )}
+      {populationEstimateSource && (
+        <DetailsField title="Population Estimate Source:">{populationEstimateSource}</DetailsField>
       )}
       {populationOfDescendants && (
         <DetailsField title="Population of Descendants:">

--- a/src/widgets/details/LocaleDetails.tsx
+++ b/src/widgets/details/LocaleDetails.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 import TerritoryDataYear from '@features/data/context/TerritoryDataYear';
 import Hoverable from '@features/layers/hovercard/Hoverable';
+import HoverableButton from '@features/layers/hovercard/HoverableButton';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 
 import LocaleCensusCitation from '@entities/locale/LocaleCensusCitation';
 import LocalePopulationAdjusted from '@entities/locale/LocalePopulationAdjusted';
+import LocalePopulationBreakdown from '@entities/locale/LocalePopulationBreakdown';
 import { getOfficialLabel } from '@entities/locale/LocaleStrings';
 import { LocaleData, LocaleSource } from '@entities/types/DataTypes';
 import ObjectWikipediaInfo from '@entities/ui/ObjectWikipediaInfo';
@@ -125,6 +127,7 @@ const LocalePopulationSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
     populationWritingPercent,
     territory,
   } = locale;
+  const [showPopulationBreakdown, setShowPopulationBreakdown] = React.useState(false);
 
   return (
     <DetailsSection title="Population">
@@ -133,11 +136,22 @@ const LocalePopulationSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
       {populationAdjusted && (
         <DetailsField title={`Population Adjusted to ${TerritoryDataYear}:`}>
           <LocalePopulationAdjusted locale={locale} />
+          <HoverableButton
+            style={{ marginLeft: '0.5em', padding: '0.25em', fontWeight: 'normal' }}
+            onClick={() => setShowPopulationBreakdown(!showPopulationBreakdown)}
+          >
+            {showPopulationBreakdown ? 'hide' : 'show'} breakdown
+          </HoverableButton>
+          {showPopulationBreakdown && (
+            <div style={{ margin: '0em 1em 1em 1em' }}>
+              <LocalePopulationBreakdown locale={locale} />
+            </div>
+          )}
         </DetailsField>
       )}
 
       {populationSpeaking != null && (
-        <DetailsField title="Speakers:">
+        <DetailsField title="Speakers (from best cited source(s)):">
           <CountOfPeople count={populationSpeaking} />
           {' ['}
           <LocaleCensusCitation locale={locale} />

--- a/src/widgets/details/sections/LanguageLocation.tsx
+++ b/src/widgets/details/sections/LanguageLocation.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 
+import { getObjectFullDescendants } from '@widgets/pathnav/getParentsAndDescendants';
+
+import HoverableButton from '@features/layers/hovercard/HoverableButton';
 import ObjectMap from '@features/map/ObjectMap';
+import { ObjectType, View } from '@features/params/PageParamTypes';
+import usePageParams from '@features/params/usePageParams';
+import { getSortFunction } from '@features/transforms/sorting/sort';
 
 import { LanguageData } from '@entities/language/LanguageTypes';
 
@@ -9,7 +15,15 @@ import DetailsSection from '@shared/containers/DetailsSection';
 import Deemphasized from '@shared/ui/Deemphasized';
 import Pill from '@shared/ui/Pill';
 
+import { getLanguageScopeLabel } from '@strings/LanguageScopeStrings';
+
 const LanguageLocation: React.FC<{ lang: LanguageData }> = ({ lang }) => {
+  const { updatePageParams, limit } = usePageParams();
+  const sortFunction = getSortFunction();
+  const descendants = getObjectFullDescendants(lang)
+    .filter((l) => l.type === ObjectType.Language && l.latitude != null && l.longitude != null)
+    .sort(sortFunction) as LanguageData[];
+
   return (
     <DetailsSection title="Location">
       <DetailsField title="Coordinates:">
@@ -18,7 +32,9 @@ const LanguageLocation: React.FC<{ lang: LanguageData }> = ({ lang }) => {
             {lang.latitude.toFixed(4)}°, {lang.longitude.toFixed(4)}° <Pill>Glottolog</Pill>
           </>
         ) : (
-          <Deemphasized>No coordinate data available.</Deemphasized>
+          <Deemphasized>
+            No coordinate data for this {getLanguageScopeLabel(lang.scope).toLowerCase()} available.
+          </Deemphasized>
         )}
       </DetailsField>
 
@@ -31,6 +47,29 @@ const LanguageLocation: React.FC<{ lang: LanguageData }> = ({ lang }) => {
           <ObjectMap objects={[lang]} maxWidth={400} />
         </>
       ) : null}
+      {descendants.length > 0 && (
+        <>
+          These are the locations of descendant languages/dialects.
+          {descendants.length > limit && (
+            <Deemphasized>
+              {' '}
+              Showing first {limit} of {descendants.length}.
+            </Deemphasized>
+          )}
+          <ObjectMap objects={descendants} maxWidth={400} />
+          <HoverableButton
+            onClick={() =>
+              updatePageParams({
+                view: View.Map,
+                languageFilter: lang.nameCanonical + ' [' + lang.ID + ']',
+                objectID: undefined,
+              })
+            }
+          >
+            See more in Map view
+          </HoverableButton>
+        </>
+      )}
     </DetailsSection>
   );
 };

--- a/src/widgets/pathnav/getParentsAndDescendants.tsx
+++ b/src/widgets/pathnav/getParentsAndDescendants.tsx
@@ -49,6 +49,13 @@ export function getObjectChildren(object?: ObjectData): (ObjectData | undefined)
   }
 }
 
+export function getObjectFullDescendants(object: ObjectData): ObjectData[] {
+  return getObjectChildren(object).reduce<ObjectData[]>(
+    (all, child) => (child ? all.concat([child], getObjectFullDescendants(child)) : all),
+    [],
+  );
+}
+
 export function getDescendantsName(object: ObjectData, count: number): string {
   switch (object.type) {
     case ObjectType.Census:


### PR DESCRIPTION
This PR creates locales based on language families. While I would have loved to create ones based on the Glottolog families as well -- that was all too much data generated. So this focuses on the smaller groupings based on ISO. All in all, this helps producing better language family total counts.

The primary change is adding a new step to create these around the same time we create regional locales (eg. eng_US + eng_CA = eng_021)

## Summary

- [x] Clear description of what and why
- [x] Scope kept focused; note follow-ups if any
- [x] Set yourself as assignee
- [x] closes #349 

## Testing

- [x] `npm run lint`
- [x] `npm run test`
   - [ ] Tests added or updated
- [x] `npm run build`
- [x] Write comments on how you tested in this PR
- [ ] Include screenshots

Tested by checking various languages and locales, watching out for how many there are and their population breakdowns.

## Changes

### Visual changes

- [x] Add before and after screenshots in the table below.
  - [x] Drag and drop images in the GitHub PR comment box to upload screenshots
- [x] Purely new views can just include the "after" screenshot.
- [x] Since more views can be reproduced by just sharing the URL -- add links (eg. [link](https://translation-commons.github.io/lang-nav/data)) to the relevant page and/or conditions to reproduce the view.

| Page/View | Changes | Before | After |
| ---- | ------ | ------ | ----- |
|[Table of all languoids](https://translation-commons.github.io/lang-nav/data?view=Table&languageScopes=Macrolanguage%2CLanguage%2CFamily)|Numbers aren't as high since double counting is decreased, countries listed for ISO-based language families|<img width="883" height="793" alt="Screenshot 2026-01-04 at 13 07 11" src="https://github.com/user-attachments/assets/4036024d-503b-4f03-bdec-75e2b06ecd0e" />|<img width="885" height="788" alt="Screenshot 2026-01-04 at 13 07 00" src="https://github.com/user-attachments/assets/4b895df1-e8d7-4dae-b560-56389356eb29" />|
|[Pre-existing language family locale: Nahuatl in Mexico](https://translation-commons.github.io/lang-nav/data?view=Table&languageScopes=Family&objectType=Locale&objectID=nah_MX)|The data hasn't changed since this family was added by prior data already -- but there are more details visible like |<img width="537" height="497" alt="Screenshot 2026-01-04 at 13 46 12" src="https://github.com/user-attachments/assets/6ef06445-aa6f-465d-9153-15f0f38faa3a" />|<img width="552" height="743" alt="Screenshot 2026-01-04 at 13 46 08" src="https://github.com/user-attachments/assets/98ec86bd-06f2-49ed-9b8d-0c4ee3f3f9b8" />
|[New language family locale: Uto-Aztecan in Mexico](http://translation-commons.github.io/lang-nav/data?view=Table&languageScopes=Macrolanguage%2CLanguage%2CFamily&objectType=Locale&searchString=nah&objectID=azc_MX)|This data is brand new, creates and shows the descendants from it, you can also see the parent locale nai_MX|n/a|<img width="659" height="849" alt="Screenshot 2026-01-04 at 13 48 01" src="https://github.com/user-attachments/assets/101ceb99-87e0-44d6-a69f-ae2b12b8cdf3" />
|[New language family regional locale: Uto-Aztecan in Central America](http://translation-commons.github.io/lang-nav/data?view=Table&languageScopes=Macrolanguage%2CLanguage%2CFamily&objectType=Locale&searchString=nah&objectID=azc_013)|We even can see regional groupings for locales as well|n/a|<img width="627" height="731" alt="Screenshot 2026-01-04 at 13 52 03" src="https://github.com/user-attachments/assets/d3c4d321-e21f-40c4-bf12-b035ad18ebb3" />


### Data changes

- [-] TSV edits in `public/data/`
- [-] Load/connect/compute updates in `src/features/data/`

### Internal changes

- [x] Logical changes
- [-] Refactors, moving files around
- [x] If you notice any changes that require explanations, make sure to include the explanations in the code as well.

## Docs

- [-] Updated markdown readme files documenting how the code behaves or how to develop in case there are any relevant changes to make.
