### PR TITLE
Bugfix: Fix CLDR data loading, language family chains

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,8 @@
 
 ### Data changes
 
-- [ ] TSV edits in `public/data/`
+- [ ] TSV, SVG, etc. edits in `public/data/`
+- [ ] Corresponding readmes updated in `public/data/`
 - [ ] Load/connect/compute updates in `src/features/data/`
 
 ### Internal changes

--- a/public/data/iso/manualGlottocodeToISO.tsv
+++ b/public/data/iso/manualGlottocodeToISO.tsv
@@ -128,3 +128,5 @@ west2793	gmw	West Germanic
 yupi1267	ypk	Yupik
 zand1246	znd	Zande
 sout2711	ggo	Southern Gondi
+belg1242	bvs	Belgian Sign Language
+arak1255	mhv	Arakanese-Marma

--- a/public/data/languages.tsv
+++ b/public/data/languages.tsv
@@ -8205,5 +8205,5 @@ zrp	zarp1238	Zarphatic			Hebr	Extinct			0			book1242	No	Extinct language
 zsk		Kaskean							0				Probably not	Historical langauge
 zxx		Not applicable	no linguistic content						0				No	Control code
 mol	mold1248	Moldavian		Spoken & Written	Latn							east2865	Probably not	Old ISO system considered it its own language. Now it is just considered a dialect of Romanian by ISO
-bvs	belg1242	Belgian Sign Language		Sign Language							sgn	
-mhv	arak1255	Arakanese-Marma									sgn	
+bvs	belg1242	Belgian Sign Language		Sign Language							sgn	dutc1259	No	Deprecated from ISO
+mhv	arak1255	Arakanese-Marma									sit	nucl1811	No	Deprecated from ISO

--- a/public/data/languages.tsv
+++ b/public/data/languages.tsv
@@ -8205,3 +8205,5 @@ zrp	zarp1238	Zarphatic			Hebr	Extinct			0			book1242	No	Extinct language
 zsk		Kaskean							0				Probably not	Historical langauge
 zxx		Not applicable	no linguistic content						0				No	Control code
 mol	mold1248	Moldavian		Spoken & Written	Latn							east2865	Probably not	Old ISO system considered it its own language. Now it is just considered a dialect of Romanian by ISO
+bvs	belg1242	Belgian Sign Language		Sign Language							sgn	
+mhv	arak1255	Arakanese-Marma									sgn	

--- a/src/entities/language/LanguageTypes.ts
+++ b/src/entities/language/LanguageTypes.ts
@@ -3,10 +3,6 @@
  * It includes types for language codes, glottocodes, and language data.
  */
 
-// LanguageCode is ideally an ISO-639 code, or a BCP047 formatted complex language tag
-// should be formatted like ab or abc. But there are some languoids with different
-// kinds of language codes here as well. This is the main index key for languages and languoids
-
 import React from 'react';
 
 import { RetirementReason } from '@features/data/load/extra_entities/ISORetirements';
@@ -41,12 +37,15 @@ export enum LanguageSource {
   CLDR = 'CLDR', // ISO but with some CLDR-specific aliasing
 }
 
+// LanguageCode is ideally an ISO-639 code, or a BCP047 formatted complex language tag
+// should be formatted like ab or abc. But there are some languoids with different
+// kinds of language codes here as well. This is the main index key for languages and languoids
 // TODO Replace generic strings with some form of validation
-export type ISO6391LanguageCode = string; // eg. en, es
-export type ISO6393LanguageCode = string; // eg. eng, spa
+export type ISO6391LanguageCode = string; // eg. en, es, zh
+export type ISO6393LanguageCode = string; // eg. eng, spa, zho, cmn
 export type ISO6395LanguageCode = string; // eg. ine (Indo-European)
-export type ISO6392LanguageCode = ISO6393LanguageCode | ISO6395LanguageCode; // eg. eng, spa, ine
-export type Glottocode = string; // eg. abcd1234
+export type ISO6392LanguageCode = ISO6393LanguageCode | ISO6395LanguageCode; // eg. eng, spa, zho, cmn, ine
+export type Glottocode = string; // eg. stan1293, stan1288, clas1255, mand1415, indo1319
 export type LanguageCode = ISO6391LanguageCode | ISO6392LanguageCode | Glottocode | string;
 
 export enum LanguageModality {
@@ -172,10 +171,10 @@ export function getBaseLanguageData(code: LanguageCode, name: string): LanguageD
 
 // Since languages can be categorized by ISO, Glottolog, or other source, these values will vary based on the language source
 type LanguageDataInSource = {
-  code?: LanguageCode;
+  code?: LanguageCode; // May be specific language source, eg. `spa` vs `es` or `stan1288`
   name?: string;
   scope?: LanguageScope;
-  parentLanguageCode?: LanguageCode;
+  parentLanguageCode?: LanguageCode; // May be the source-specific one (eg. `es` or the canonical id eg. `spa`)
   parentLanguage?: LanguageData;
   childLanguages?: LanguageData[];
   notes?: React.ReactNode;

--- a/src/entities/language/vitality/LanguageVitalityComputation.ts
+++ b/src/entities/language/vitality/LanguageVitalityComputation.ts
@@ -52,13 +52,18 @@ export function getVitalityScore(source: VitalitySource, lang: LanguageData): nu
  */
 export function precomputeLanguageVitality(languages: LanguageData[]): void {
   // For all language roots, recompute vitality scores
-  languages.filter((lang) => lang.parentLanguage == null).forEach(computeLanguageFamilyVitality);
+  languages
+    .filter((lang) => lang.parentLanguage == null)
+    .forEach((lang) => computeLanguageFamilyVitality(lang));
 }
 
-function computeLanguageFamilyVitality(lang: LanguageData): void {
+function computeLanguageFamilyVitality(lang: LanguageData, depth = 0): void {
+  if (depth > 40) console.debug('Potential infinite recursion for: ', lang.ID, 'depth: ', depth);
+  if (depth > 50) return;
+
   // Recursively compute vitality for all descendants first
   const descendants = lang.childLanguages || [];
-  descendants.forEach((child) => computeLanguageFamilyVitality(child));
+  descendants.forEach((child) => computeLanguageFamilyVitality(child, depth + 1));
 
   // Now compute vitality for this language
   const vitality = lang.vitality || {};

--- a/src/features/data/compute/updateObjectCodesNameAndPopulation.ts
+++ b/src/features/data/compute/updateObjectCodesNameAndPopulation.ts
@@ -46,6 +46,7 @@ function updateParentsAndDescendants(
   languages.forEach((lang) => {
     const specific = lang[languageSource];
     lang.parentLanguage = specific.parentLanguage ?? undefined;
+    // TODO maybe recompute childLanguages from parentLanguage to prevent bad mutations of childLanguages from creating cycles
     lang.childLanguages = specific.childLanguages ?? [];
   });
 }

--- a/src/features/data/compute/updatePopulations.ts
+++ b/src/features/data/compute/updatePopulations.ts
@@ -38,11 +38,13 @@ function computeLanguagesPopulations(languages: LanguageData[]): void {
     });
 }
 
-function getLanguagePopulationFollowingDescendants(lang: LanguageData): number {
+function getLanguagePopulationFollowingDescendants(lang: LanguageData, depth = 0): number {
+  if (depth > 40) console.debug('Potential infinite recursion for: ', lang.ID, 'depth: ', depth);
+  if (depth > 50) return 0;
   // Recompute the population of descendants first
   const descendantPopulation = sumBy(
     lang.childLanguages,
-    (childLang) => getLanguagePopulationFollowingDescendants(childLang) || 0.01, // Using 0.01 as a tiebreaker
+    (childLang) => getLanguagePopulationFollowingDescendants(childLang, depth + 1) || 0.01, // Using 0.01 as a tiebreaker
   );
   lang.populationOfDescendants = descendantPopulation > 0 ? descendantPopulation : undefined;
 

--- a/src/features/data/load/supplemental/UnicodeData.tsx
+++ b/src/features/data/load/supplemental/UnicodeData.tsx
@@ -105,7 +105,7 @@ export function addCLDRLanguageDetails(languagesBySource: LanguagesBySource): vo
         macroLang.CLDR.code = macroLangAltCode; // Distinguish the macrolanguage from the constituent language
         macroLang.CLDR.scope = LanguageScope.Macrolanguage;
         macroLang.CLDR.notes = notes;
-        macroLang.CLDR.name = macroLang?.nameCanonical + ' (macrolanguage)';
+        macroLang.CLDR.name = macroLang.nameCanonical + ' (macrolanguage)';
         // Remove the regular symbolic reference in the CLDR list to the macrolanguage object (since it will be replaced below)
         delete cldrLanguages[macroLangCode];
         cldrLanguages[macroLangAltCode] = macroLang; // But put it back in with the alternative code to distinguish it

--- a/src/features/data/load/supplemental/UnicodeData.tsx
+++ b/src/features/data/load/supplemental/UnicodeData.tsx
@@ -78,7 +78,14 @@ export function addCLDRLanguageDetails(languagesBySource: LanguagesBySource): vo
       // Get the constituent language and the macrolanguage that will be replaced by it
       const constituentLangCode = alias.original; // eg. `cmn`
       const macroLangCode = alias.replacement; // eg. `zh`
-      const macroLangAltCode = macroLangCode + '**';
+      let macroLangAltCode = macroLangCode + '*';
+      if (cldrLanguages[macroLangAltCode] != null) {
+        // If the alternative code already exists (known problem with Mandingo but potentially could happen again)
+        macroLangAltCode = macroLangCode + '**';
+        if (cldrLanguages[macroLangAltCode] != null) {
+          console.warn('Too many macrolanguage alternatives for ', macroLangCode);
+        }
+      }
       const constituentLang = cldrLanguages[alias.original]; // eg. Mandarin Chinese `cmn` in ISO but effective `zh` in CLDR
       const macroLang = cldrLanguages[alias.replacement]; // eg. Chinese (macrolanguage) `zho`/`zh` in ISO
       const notes = (
@@ -97,12 +104,13 @@ export function addCLDRLanguageDetails(languagesBySource: LanguagesBySource): vo
         macroLang.CLDR.dataProvider = constituentLang;
         macroLang.CLDR.code = macroLangAltCode; // Distinguish the macrolanguage from the constituent language
         macroLang.CLDR.scope = LanguageScope.Macrolanguage;
-        macroLang.CLDR.childLanguages = [constituentLang];
         macroLang.CLDR.notes = notes;
         macroLang.CLDR.name = macroLang?.nameCanonical + ' (macrolanguage)';
         // Remove the regular symbolic reference in the CLDR list to the macrolanguage object (since it will be replaced below)
         delete cldrLanguages[macroLangCode];
-        cldrLanguages[macroLangAltCode] = macroLang; // But put it back in with ** to distinguish it
+        cldrLanguages[macroLangAltCode] = macroLang; // But put it back in with the alternative code to distinguish it
+
+        // Note: Don't add references to child languages here -- the parent reference below is sufficient
       }
 
       // Now set the replacement (cmn) as the canonical language for its macrolanguage (zh)

--- a/src/pages/dataviews/ViewReports.tsx
+++ b/src/pages/dataviews/ViewReports.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import DubiousLanguages from '@widgets/reports/DubiousLanguages';
+import LanguagePathsReport from '@widgets/reports/LanguagePathsReport';
 import LanguagesLargestDescendant from '@widgets/reports/LanguagesLargestDescendant';
 import LanguagesWithIdenticalNames from '@widgets/reports/LanguagesWithIdenticalNames';
 import PotentialLocales from '@widgets/reports/PotentialLocales';
@@ -41,6 +42,7 @@ const ReportsForObjectType: React.FC<{ objectType: ObjectType }> = ({ objectType
           <DubiousLanguages />
           <LanguagesWithIdenticalNames />
           <LanguagesLargestDescendant />
+          <LanguagePathsReport />
         </>
       );
     case ObjectType.Census:

--- a/src/widgets/reports/LanguagePathSimple.tsx
+++ b/src/widgets/reports/LanguagePathSimple.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
+
+import { LanguageCode, LanguageData } from '@entities/language/LanguageTypes';
+
+const LanguagePath: React.FC<{
+  path: LanguageCode[];
+  getLanguage: (code: LanguageCode) => LanguageData | undefined;
+}> = ({ path, getLanguage }) => {
+  return (
+    <div>
+      {path.map((langId, positionInCycle) => {
+        const lang = getLanguage(langId);
+        return (
+          <React.Fragment key={positionInCycle}>
+            {positionInCycle > 0 && ' > '}
+            <HoverableObjectName object={lang} />
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+};
+
+export default LanguagePath;

--- a/src/widgets/reports/LanguagePathsReport.tsx
+++ b/src/widgets/reports/LanguagePathsReport.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+
+import { useDataContext } from '@features/data/context/useDataContext';
+import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
+import { View } from '@features/params/PageParamTypes';
+import usePageParams from '@features/params/usePageParams';
+
+import { LanguageCode, LanguageData } from '@entities/language/LanguageTypes';
+
+import CollapsibleReport from '@shared/containers/CollapsibleReport';
+import { uniqueBy } from '@shared/lib/setUtils';
+import CountOfPeople from '@shared/ui/CountOfPeople';
+
+import LanguagePath from './LanguagePathSimple';
+
+const LanguagePathsReport: React.FC = () => {
+  const { limit, updatePageParams } = usePageParams();
+  const { getLanguage, languagesInSelectedSource } = useDataContext();
+  const { orphans, longestPaths, cycles, multipleRoutes } =
+    getExtremeLanguagePaths(languagesInSelectedSource);
+  const orphanedLanguages = orphans
+    .map((langId) => getLanguage(langId))
+    .filter((lang) => lang != null)
+    .sort((a, b) => (b.populationEstimate ?? 0) - (a.populationEstimate ?? 0))
+    .slice(0, limit);
+
+  // A known issue for multipleRoutes is when languages have been deprecated from ISO -- they may not be matched with glottolog entries.
+  // Therefore, we should split up the multipleRoutes into 2 parts, one that includes deprecated ISO languages
+  const [validMultipleRoutes, deprecatedMultipleRoutes] = Object.entries(multipleRoutes).reduce<
+    [Record<LanguageCode, LanguageCode[][]>, Record<LanguageCode, LanguageCode[][]>]
+  >(
+    (acc, [langId, paths]) => {
+      const hasDeprecatedPathParent = paths.some(
+        (path) => getLanguage(path[0])?.ISO.retirementReason != null,
+      );
+      if (hasDeprecatedPathParent) {
+        acc[1][langId] = paths;
+      } else {
+        acc[0][langId] = paths;
+      }
+      return acc;
+    },
+    [{}, {}],
+  );
+
+  return (
+    <CollapsibleReport title="Unusual Language Paths">
+      This report looks at the parent/child relationships among languages to identify unusual
+      patterns that may indicate data issues. See also the{' '}
+      <button onClick={() => updatePageParams({ view: View.Hierarchy })}>
+        Language Family Tree
+      </button>{' '}
+      view
+      <div style={{ marginLeft: '1em', display: 'flex', flexDirection: 'column', gap: '1.5em' }}>
+        <CollapsibleReport title={`Languages with circular relationships (${cycles.length})`}>
+          This shows the detected cycles in parent-child relationships among languages. Such cycles
+          are usually the result of data errors, and can cause problems in tree visualizations and
+          analyses that assume a strict hierarchy. The cycles detected are:
+          <ul>
+            {cycles.slice(0, limit).map((cycle, i) => (
+              <li key={i}>
+                <LanguagePath path={cycle} getLanguage={getLanguage} />
+              </li>
+            ))}
+          </ul>
+          {cycles.length == 0 && <div>No cycles detected.</div>}
+        </CollapsibleReport>
+        <CollapsibleReport title={`Orphaned Languages (${orphans.length})`}>
+          These entries have no parent or child languages, dialects, or language families:
+          <ul>
+            {orphanedLanguages.map((lang) => (
+              <li key={lang?.ID}>
+                <HoverableObjectName object={lang} /> (
+                <CountOfPeople count={lang?.populationEstimate} />)
+              </li>
+            ))}
+          </ul>
+          {orphans.length > limit && (
+            <div>The list it limited to the page limit. There are {orphans.length} total.</div>
+          )}
+        </CollapsibleReport>
+        <CollapsibleReport
+          title={`Longest Language Family Paths (longest = ${longestPaths[0]?.length})`}
+        >
+          Showing the {longestPaths.length < limit ? longestPaths.length : 'top ' + limit} longest
+          paths from root languages to leaf languages, by distinct root:
+          <ol>
+            {longestPaths.slice(0, limit).map((path, i) => (
+              <li key={i}>
+                <LanguagePath path={path} getLanguage={getLanguage} /> (length: {path.length})
+              </li>
+            ))}
+          </ol>
+        </CollapsibleReport>
+        <CollapsibleReport title="Languages with multiple parent paths">
+          These languages can be reached by more than one distinct path from root languages. This
+          usually indicates data issues, as languages should ideally have a single lineage. The
+          detected multiple paths are:
+          {Object.entries(multipleRoutes).length == 0 && (
+            <div>No multiple parent paths detected.</div>
+          )}
+          <ul>
+            {Object.entries(validMultipleRoutes)
+              .slice(0, limit)
+              .map(([langId, paths], i) => (
+                <li key={i}>
+                  <strong>
+                    <HoverableObjectName object={getLanguage(langId)} />
+                  </strong>
+                  <ul>
+                    {paths.map((path, j) => (
+                      <li key={j} style={{ marginLeft: '0.5em' }}>
+                        <LanguagePath path={path} getLanguage={getLanguage} />
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              ))}
+          </ul>
+          {Object.entries(validMultipleRoutes).length == 0 && (
+            <div>No multiple parent paths detected.</div>
+          )}
+          <ul>
+            {Object.entries(deprecatedMultipleRoutes)
+              .slice(0, limit)
+              .map(([langId, paths], i) => (
+                <li key={i}>
+                  <strong>
+                    <HoverableObjectName object={getLanguage(langId)} />
+                  </strong>
+                  <ul>
+                    {paths.map((path, j) => (
+                      <li key={j} style={{ marginLeft: '0.5em' }}>
+                        <LanguagePath path={path} getLanguage={getLanguage} />
+                      </li>
+                    ))}
+                  </ul>
+                </li>
+              ))}
+          </ul>
+        </CollapsibleReport>
+      </div>
+    </CollapsibleReport>
+  );
+};
+
+type ExtremeLanguagePaths = {
+  orphans: LanguageCode[];
+  longestPaths: LanguageCode[][]; // only the top 10 based on length
+  cycles: LanguageCode[][];
+  multipleRoutes: Record<LanguageCode, LanguageCode[][]>;
+};
+
+export function getExtremeLanguagePaths(languages: LanguageData[]): ExtremeLanguagePaths {
+  const visitedLanguages = new Set<LanguageCode>();
+  const allPaths: LanguageCode[][] = [];
+  const cycles: LanguageCode[][] = [];
+  const hasMultipleRoutes = new Set<LanguageCode>();
+
+  function traverse(lang: LanguageData, path: LanguageCode[] = []) {
+    const continuedPath = [...path, lang.ID];
+
+    if (visitedLanguages.has(lang.ID)) {
+      // Sometimes there are multiple paths to the same language, particularly when merging multiple data sources
+      hasMultipleRoutes.add(lang.ID);
+    }
+
+    if (path.includes(lang.ID)) {
+      // Cycle detected
+      cycles.push(continuedPath);
+      return;
+    }
+
+    visitedLanguages.add(lang.ID);
+    if (lang.childLanguages == null || lang.childLanguages.length === 0) {
+      // Leaf node
+      allPaths.push(continuedPath);
+      return;
+    }
+
+    lang.childLanguages.forEach((child) => {
+      traverse(child, continuedPath);
+    });
+  }
+
+  // First visit all languages without parents (they are roots of paths)
+  languages.filter((lang) => !lang.parentLanguage).forEach((lang) => traverse(lang));
+
+  // Then check over the languages for any rootless cycles
+  const rootless = languages.filter((lang) => !visitedLanguages.has(lang.ID));
+  rootless.forEach((lang) => {
+    // Check if we have visited it already (could have been visited in a cycle)
+    if (!visitedLanguages.has(lang.ID)) traverse(lang);
+  });
+
+  // Identify orphans
+  const orphans: LanguageCode[] = allPaths
+    .filter((path) => path.length === 1)
+    .map((path) => path[0]);
+
+  // Get top longest paths by distinct root
+  const longestPaths = uniqueBy(
+    allPaths.filter((path) => path.length > 1).sort((a, b) => b.length - a.length),
+    (path) => path[0],
+  ).slice(0, 10);
+
+  // Find paths that contain the same language more than once (indicating multiple parent paths)
+  const multipleRoutes = Object.fromEntries(
+    Array.from(hasMultipleRoutes)
+      .map((leafID) => {
+        const pathsWithLang = allPaths
+          .filter((path) => path.includes(leafID))
+          .map((path) =>
+            // Trim the path up to the leaf language (avoiding cases where the path continues beyond the leaf)
+            path.slice(0, path.findIndex((langID) => langID === leafID) + 1),
+          );
+        return [leafID, uniqueBy(pathsWithLang, (path) => path.join('>'))];
+      })
+      .filter(([, paths]) => paths.length > 1),
+  );
+
+  return { orphans, longestPaths, cycles, multipleRoutes };
+}
+
+export default LanguagePathsReport;

--- a/src/widgets/reports/LanguagePathsReportsMultipleRoutes.tsx
+++ b/src/widgets/reports/LanguagePathsReportsMultipleRoutes.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { useDataContext } from '@features/data/context/useDataContext';
+import HoverableButton from '@features/layers/hovercard/HoverableButton';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import usePageParams from '@features/params/usePageParams';
 
@@ -11,11 +13,13 @@ import LanguagePath from './LanguagePathSimple';
 
 type Props = {
   multipleRoutes: Record<LanguageCode, LanguageCode[][]>;
-  getLanguage: (code: LanguageCode) => LanguageData | undefined;
 };
 
-const LanguagePathsReportMultipleRoutes: React.FC<Props> = ({ multipleRoutes, getLanguage }) => {
+const LanguagePathsReportMultipleRoutes: React.FC<Props> = ({ multipleRoutes }) => {
   const { limit } = usePageParams();
+  const { getLanguage } = useDataContext();
+  const [showDeprecated, setShowDeprecated] = React.useState(false);
+
   // A known issue for multipleRoutes is when languages have been deprecated from ISO -- they may not be matched with glottolog entries.
   // Therefore, we should split up the multipleRoutes into 2 parts, one that includes deprecated ISO languages
   const [validMultipleRoutes, deprecatedMultipleRoutes] = Object.entries(multipleRoutes).reduce<
@@ -36,7 +40,9 @@ const LanguagePathsReportMultipleRoutes: React.FC<Props> = ({ multipleRoutes, ge
   );
 
   return (
-    <CollapsibleReport title="Languages with multiple routes">
+    <CollapsibleReport
+      title={`Languages with multiple routes (${Object.entries(multipleRoutes).length})`}
+    >
       These languages can be reached by more than one distinct path from root languages. This
       usually indicates data issues, as languages should ideally have a single lineage.
       {Object.entries(multipleRoutes).length == 0 && <div>No multiple routes detected.</div>}
@@ -47,22 +53,32 @@ const LanguagePathsReportMultipleRoutes: React.FC<Props> = ({ multipleRoutes, ge
         </>
       )}
       {Object.entries(deprecatedMultipleRoutes).length > 0 && (
-        <>
+        <div>
           {Object.entries(validMultipleRoutes).length > 0 ? (
             <>
               Separately, the following languages have multiple routes but only when considering
-              paths that include deprecated language codes.
+              paths that include deprecated language codes.{' '}
             </>
           ) : (
             <>
               There are no duplicate routes with regular languages but there are some with
-              deprecated languages.
+              deprecated languages.{' '}
             </>
           )}
           The deprecated language codes may need to be associated with actual glottolog languoids --
           OR they may be ignored since it may have been a bad category all along.
-          <MultiplePathsList languageToPaths={deprecatedMultipleRoutes} getLanguage={getLanguage} />
-        </>
+          <div>
+            <HoverableButton onClick={() => setShowDeprecated((showDeprecated) => !showDeprecated)}>
+              {showDeprecated ? 'Hide' : 'Show'} deprecated language codes
+            </HoverableButton>
+          </div>
+          {showDeprecated && (
+            <MultiplePathsList
+              languageToPaths={deprecatedMultipleRoutes}
+              getLanguage={getLanguage}
+            />
+          )}
+        </div>
       )}
       {Object.entries(multipleRoutes).length > limit && (
         <div>

--- a/src/widgets/reports/LanguagePathsReportsMultipleRoutes.tsx
+++ b/src/widgets/reports/LanguagePathsReportsMultipleRoutes.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+
+import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
+import usePageParams from '@features/params/usePageParams';
+
+import { LanguageCode, LanguageData } from '@entities/language/LanguageTypes';
+
+import CollapsibleReport from '@shared/containers/CollapsibleReport';
+
+import LanguagePath from './LanguagePathSimple';
+
+type Props = {
+  multipleRoutes: Record<LanguageCode, LanguageCode[][]>;
+  getLanguage: (code: LanguageCode) => LanguageData | undefined;
+};
+
+const LanguagePathsReportMultipleRoutes: React.FC<Props> = ({ multipleRoutes, getLanguage }) => {
+  const { limit } = usePageParams();
+  // A known issue for multipleRoutes is when languages have been deprecated from ISO -- they may not be matched with glottolog entries.
+  // Therefore, we should split up the multipleRoutes into 2 parts, one that includes deprecated ISO languages
+  const [validMultipleRoutes, deprecatedMultipleRoutes] = Object.entries(multipleRoutes).reduce<
+    [Record<LanguageCode, LanguageCode[][]>, Record<LanguageCode, LanguageCode[][]>]
+  >(
+    (acc, [langId, paths]) => {
+      const hasDeprecatedPathParent = paths.some(
+        (path) => getLanguage(path[0])?.ISO.retirementReason != null,
+      );
+      if (hasDeprecatedPathParent) {
+        acc[1][langId] = paths;
+      } else {
+        acc[0][langId] = paths;
+      }
+      return acc;
+    },
+    [{}, {}],
+  );
+
+  return (
+    <CollapsibleReport title="Languages with multiple routes">
+      These languages can be reached by more than one distinct path from root languages. This
+      usually indicates data issues, as languages should ideally have a single lineage.
+      {Object.entries(multipleRoutes).length == 0 && <div>No multiple routes detected.</div>}
+      {Object.entries(validMultipleRoutes).length > 0 && (
+        <>
+          The detected multiple paths are:
+          <MultiplePathsList languageToPaths={validMultipleRoutes} getLanguage={getLanguage} />
+        </>
+      )}
+      {Object.entries(deprecatedMultipleRoutes).length > 0 && (
+        <>
+          {Object.entries(validMultipleRoutes).length > 0 ? (
+            <>
+              Separately, the following languages have multiple routes but only when considering
+              paths that include deprecated language codes.
+            </>
+          ) : (
+            <>
+              There are no duplicate routes with regular languages but there are some with
+              deprecated languages.
+            </>
+          )}
+          The deprecated language codes may need to be associated with actual glottolog languoids --
+          OR they may be ignored since it may have been a bad category all along.
+          <MultiplePathsList languageToPaths={deprecatedMultipleRoutes} getLanguage={getLanguage} />
+        </>
+      )}
+      {Object.entries(multipleRoutes).length > limit && (
+        <div>
+          Showing only the first {limit} results. Adjust the &quot;limit&quot; parameter to see
+          more.
+        </div>
+      )}
+    </CollapsibleReport>
+  );
+};
+
+const MultiplePathsList: React.FC<{
+  languageToPaths: Record<LanguageCode, LanguageCode[][]>;
+  getLanguage: (code: LanguageCode) => LanguageData | undefined;
+}> = ({ languageToPaths, getLanguage }) => {
+  const { limit } = usePageParams();
+  return (
+    <ul>
+      {Object.entries(languageToPaths)
+        .slice(0, limit)
+        .map(([langId, paths], i) => (
+          <li key={i}>
+            <strong>
+              <HoverableObjectName object={getLanguage(langId)} />
+            </strong>
+            <ul>
+              {paths.map((path, j) => (
+                <li key={j} style={{ marginLeft: '0.5em' }}>
+                  <LanguagePath path={path} getLanguage={getLanguage} />
+                </li>
+              ))}
+            </ul>
+          </li>
+        ))}
+    </ul>
+  );
+};
+
+export default LanguagePathsReportMultipleRoutes;

--- a/src/widgets/reports/LanguagesLargestDescendant.tsx
+++ b/src/widgets/reports/LanguagesLargestDescendant.tsx
@@ -116,7 +116,11 @@ const LanguagesLargestDescendant: React.FC = () => {
   );
 };
 
-function getLargestDescendant(language: LanguageData): LanguageData | undefined {
+function getLargestDescendant(language: LanguageData, depth = 0): LanguageData | undefined {
+  if (depth > 40)
+    console.debug('Potential infinite recursion for: ', language.ID, 'depth: ', depth);
+  if (depth > 50) return undefined;
+
   // If it has already been computed, return it.
   if (language.largestDescendant !== undefined) {
     return language.largestDescendant;
@@ -129,7 +133,7 @@ function getLargestDescendant(language: LanguageData): LanguageData | undefined 
   // sourced population (aka no language families). Dialects rarely but sometimes have directly
   // sourced populations.
   return language.childLanguages.reduce<LanguageData | undefined>((largest, child) => {
-    const childsLargest = getLargestDescendant(child);
+    const childsLargest = getLargestDescendant(child, depth + 1);
     const candidateLargest =
       (childsLargest?.populationRough || 0) > (child.populationRough || 0) ? childsLargest : child;
     if (

--- a/src/widgets/reports/LanguagesWithIdenticalNames.tsx
+++ b/src/widgets/reports/LanguagesWithIdenticalNames.tsx
@@ -41,7 +41,7 @@ const LanguagesWithIdenticalNames: React.FC = () => {
         return languagesByName;
       }, {});
   }, [languagesInSelectedSource, filterBySubstring, filterByConnections]);
-  console.log(Object.entries(languagesByName).slice(0, 5));
+
   const langsWithDupNames = Object.entries(languagesByName).reduce<Record<string, LanguageData[]>>(
     (duplicatedNames, [name, langs]) => {
       if (langs.length > 1) {

--- a/src/widgets/reports/__tests__/LanguagePathsReport.test.tsx
+++ b/src/widgets/reports/__tests__/LanguagePathsReport.test.tsx
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getDisconnectedMockedObjects,
+  getFullyInstantiatedMockedObjects,
+  getMockedDataContext,
+} from '@features/__tests__/MockObjects';
+import { updateObjectCodesNameAndPopulation } from '@features/data/compute/updateObjectCodesNameAndPopulation';
+import { LocaleSeparator, ObjectType } from '@features/params/PageParamTypes';
+
+import {
+  getBaseLanguageData,
+  LanguageData,
+  LanguageSource,
+} from '@entities/language/LanguageTypes';
+import { ObjectDictionary } from '@entities/types/DataTypes';
+
+import { getExtremeLanguagePaths } from '../LanguagePathsReport';
+
+describe('LanguagePathsReport', () => {
+  function generateObjects(): ObjectDictionary {
+    // Get regular data and add a language family so there is more data to process
+    // Each source will have a different family structure, some of which have cycles
+    // Combined: elv -> sjn -> dori0123, elv -> qya (a typical branching tree)
+    // ISO: elv -> qya && sjn -> dori0123 -> sjn (a cycle)
+    // Glottolog: sjn -> dori0123, sjn -> qya (a tree branching differently, no lang family)
+    // CLDR: elv -> sjn -> dori0123 -> elv (a bad cycle but will be missed since there is no root)
+    const inputObjects = getDisconnectedMockedObjects();
+    const elv: LanguageData = {
+      ...getBaseLanguageData('elv', 'Elvish'), // fictional language family code
+      nameEndonym: 'ɛlvɪʃ',
+      names: ['Elvish', 'Elven Languages', 'ɛlvɪʃ'],
+      populationRough: 50000,
+      // Only a parent in CLDR to create a cycle there
+      CLDR: { parentLanguageCode: 'dori0123' },
+    };
+    const qya: LanguageData = {
+      ...getBaseLanguageData('qya', 'Quenya'), // fictional Elvish language
+      nameEndonym: 'kwɛnjɑ',
+      names: ['Quenya', 'High Elvish', 'kwɛnjɑ'],
+      populationRough: 10000,
+      Combined: { parentLanguageCode: 'elv' },
+      ISO: { parentLanguageCode: 'elv' },
+      Glottolog: { parentLanguageCode: 'sjn' },
+      // No parent for CLDR, UNESCO or BCP
+    };
+    inputObjects['qya'] = qya;
+    inputObjects['elv'] = elv;
+    // Edit existing mocked languages to change language branching
+    if (inputObjects['sjn'].type === ObjectType.Language) {
+      inputObjects['sjn'].Combined.parentLanguageCode = 'elv';
+      inputObjects['sjn'].ISO.parentLanguageCode = 'dori0123'; // making a loop in ISO
+      inputObjects['sjn'].CLDR.parentLanguageCode = 'elv';
+      // no parent for Glottolog, UNESCO or BCP
+    }
+    if (inputObjects['dori0123'].type === ObjectType.Language) {
+      inputObjects['dori0123'].Combined.parentLanguageCode = 'sjn';
+      inputObjects['dori0123'].ISO.parentLanguageCode = 'sjn';
+      inputObjects['dori0123'].CLDR.parentLanguageCode = 'sjn';
+      inputObjects['dori0123'].Glottolog.parentLanguageCode = 'sjn';
+      // no parent for UNESCO or BCP
+    }
+
+    // Generate the data
+    return getFullyInstantiatedMockedObjects(inputObjects);
+  }
+
+  it('getExtremeLanguagePaths', () => {
+    const objects = generateObjects();
+    const { allLanguoids, locales, getTerritory } = getMockedDataContext(objects);
+
+    Object.values(LanguageSource).forEach((languageSource) => {
+      // This shouldn't throw an error even in the presence of cycles
+      updateObjectCodesNameAndPopulation(
+        allLanguoids,
+        locales,
+        getTerritory('001')!,
+        languageSource,
+        LocaleSeparator.Underscore,
+      );
+      const { orphans, longestPaths, cycles, multipleRoutes } =
+        getExtremeLanguagePaths(allLanguoids);
+
+      switch (languageSource) {
+        case LanguageSource.Combined:
+          // Combined: elv -> sjn -> dori0123, elv -> qya (a typical branching tree)
+          expect(orphans).toEqual([]);
+          expect(longestPaths).toEqual([['elv', 'sjn', 'dori0123']]);
+          expect(cycles).toEqual([]); // there are no cycles
+          expect(multipleRoutes).toEqual({});
+          break;
+        case LanguageSource.ISO:
+          // ISO: elv -> qya && sjn -> dori0123 -> sjn (a cycle)
+          expect(orphans).toEqual([]);
+          expect(longestPaths).toEqual([['elv', 'qya']]);
+          expect(cycles).toEqual([['sjn', 'dori0123', 'sjn']]); // cycle between sjn and dori0123
+          expect(multipleRoutes).toEqual({});
+          break;
+        case LanguageSource.Glottolog:
+          // Glottolog: sjn -> dori0123, sjn -> qya (a tree branching differently, no lang family)
+          expect(orphans).toEqual(['elv']);
+          expect(longestPaths).toEqual([['sjn', 'dori0123']]);
+          expect(cycles).toEqual([]); // there are no cycles
+          expect(multipleRoutes).toEqual({});
+          break;
+        case LanguageSource.CLDR:
+          // CLDR: elv -> sjn -> dori0123 -> elv (a bad cycle but will be missed since there is no root)
+          expect(orphans).toEqual(['qya']);
+          expect(longestPaths).toEqual([]); // the only long path is a cycle
+          expect(cycles).toEqual([['sjn', 'dori0123', 'elv', 'sjn']]);
+          expect(multipleRoutes).toEqual({});
+          break;
+        case LanguageSource.UNESCO: // No connections from these sources, all languages are orphans
+        case LanguageSource.BCP:
+          expect(orphans.join(' ')).toEqual('sjn dori0123 qya elv');
+          expect(longestPaths).toEqual([]);
+          expect(cycles).toEqual([]); // there are no cycles
+          expect(multipleRoutes).toEqual({});
+          break;
+        default:
+          throw new Error(`Unhandled LanguageSource: ${languageSource}`);
+      }
+    });
+  });
+});


### PR DESCRIPTION
This change adds some safeties when we do recursive language algorithms to stop if the depth of a node is too deep. It also adds a new Report under languages that identifies unusual graph paths (orphaned languages, long paths, cycles, and multiple routes to the same language) for debugging, especially if we import new data.

## Summary

- [x] Clear description of what and why
- [x] Scope kept focused; note follow-ups if any
- [x] Set yourself as assignee
- [x] Mention the issue: fixes #357 

## Testing

- [x] `npm run lint`
- [x] `npm run test`
  - [x] Tests added or updated for changed logic
- [x] `npm run build`
- [x] Write comments on manual testing how you tested in this PR
- [x] Include screenshots in the changes section below

## Changes

### Visual changes

- [x] Add before and after screenshots in the table below.
  - [ ] Drag and drop images in the GitHub PR comment box to upload screenshots
- [ ] Purely new views can just include the "after" screenshot.
- [ ] Since more views can be reproduced by just sharing the URL -- add links (eg. [link](https://translation-commons.github.io/lang-nav/data)) to the relevant page and/or conditions to reproduce the view.

http://localhost:5173/lang-nav/data?languageScopes=%5B%5D&view=Reports

<img width="673" height="693" alt="Screenshot 2026-01-23 at 06 56 55" src="https://github.com/user-attachments/assets/7c8274c3-a195-4bb6-bd04-b82f21b9f378" />
<img width="649" height="479" alt="Screenshot 2026-01-23 at 06 56 47" src="https://github.com/user-attachments/assets/d8912746-3cdf-4644-9cb4-4a00e3c93587" />
<img width="678" height="701" alt="Screenshot 2026-01-23 at 06 56 40" src="https://github.com/user-attachments/assets/24f0227c-7a4e-4939-b1fa-1341c170cf52" />


### Data changes

- [x] TSV edits in `public/data/`
  - Sum data with errors was updated
- [n/a] Load/connect/compute updates in `src/features/data/`

### Internal changes

- [x] Logical changes
  - The issue occurs when loading Unicode Data and manually specifying child nodes -- that has been fixed
- [n/a] Refactors, moving files around
- [x] If you notice any changes that require explanations, make sure to include the explanations in the code as well.

## Docs

- [n/a] Updated markdown readme files documenting how the code behaves or how to develop in case there are any relevant changes to make.
