### PR TITLE
refactor: standardize colon rendering in DetailsField component (#360)

### DIFF
--- a/src/entities/language/vitality/LanguageDetailsVitalityAndViability.tsx
+++ b/src/entities/language/vitality/LanguageDetailsVitalityAndViability.tsx
@@ -20,32 +20,32 @@ const LanguageDetailsVitalityAndViability: React.FC<{ lang: LanguageData }> = ({
 
   return (
     <DetailsSection title="Vitality & Viability">
-      <DetailsField title="Vitality Metascore:">
+      <DetailsField title="Vitality Metascore">
         <LanguageVitalityMeter lang={lang} src={VitalitySource.Metascore} />
       </DetailsField>
 
-      <DetailsField title="ISO Status:">
+      <DetailsField title="ISO Status">
         <LanguageVitalityMeter lang={lang} src={VitalitySource.ISO} />{' '}
         {vitality.iso != null &&
           (lang.ISO.status != null ? <Pill>ISO</Pill> : <Pill>Derived</Pill>)}
       </DetailsField>
 
-      <DetailsField title="Ethnologue (2013):">
+      <DetailsField title="Ethnologue (2013)">
         <LanguageVitalityMeter lang={lang} src={VitalitySource.Eth2013} />{' '}
         {vitality.ethFine != null &&
           (vitality.ethnologue2013 != null ? <Pill>Ethnologue 2013</Pill> : <Pill>Derived</Pill>)}
       </DetailsField>
 
-      <DetailsField title="Ethnologue (2025):">
+      <DetailsField title="Ethnologue (2025)">
         <LanguageVitalityMeter lang={lang} src={VitalitySource.Eth2025} />{' '}
         {vitality.ethCoarse != null &&
           (vitality.ethnologue2025 != null ? <Pill>Ethnologue 2025</Pill> : <Pill>Derived</Pill>)}
       </DetailsField>
-      <DetailsField title="Should use in World Atlas:">
+      <DetailsField title="Should use in World Atlas">
         {viabilityConfidence} ... {viabilityExplanation}
       </DetailsField>
       <DetailsField
-        title="Digital Support (Ethnologue):"
+        title="Digital Support (Ethnologue)"
         endContent={
           <LinkButton href="https://www.ethnologue.com/insights/digital-language-divide/">
             Ethnologue
@@ -54,18 +54,18 @@ const LanguageDetailsVitalityAndViability: React.FC<{ lang: LanguageData }> = ({
       >
         {digitalSupport}
       </DetailsField>
-      <DetailsField title="CLDR Coverage:">
+      <DetailsField title="CLDR Coverage">
         <div style={{ display: 'inline-flex', flexDirection: 'row', gap: '0.5em' }}>
           <CLDRWarningNotes object={lang} />
           <ObjectCLDRCoverageLevel object={lang} />
           <ObjectCLDRLocaleCount object={lang} verbose={true} />
         </div>
       </DetailsField>
-      <DetailsField title="ICU Support:">
+      <DetailsField title="ICU Support">
         <ICUSupportStatus object={lang} />
       </DetailsField>
       <DetailsField
-        title="Wikipedia:"
+        title="Wikipedia"
         endContent={
           lang.wikipedia && <LinkButton href={lang.wikipedia.url}>{lang.wikipedia.url}</LinkButton>
         }

--- a/src/shared/containers/DetailsField.tsx
+++ b/src/shared/containers/DetailsField.tsx
@@ -20,9 +20,7 @@ const DetailsField: React.FC<Props> = ({ children, title, description, endConten
               <InfoIcon size="1em" display="block" aria-label="More information" />
             </Hoverable>
           )}
-          {/* Most usages are manually adding a colon after the title, before that is phased out we are
-          adding it back in when we add a description */}
-          {description && <>:</>}
+          <span style={{ fontWeight: 'normal' }}>:</span>
         </div>
         {children}
       </div>

--- a/src/widgets/details/CensusDetails.tsx
+++ b/src/widgets/details/CensusDetails.tsx
@@ -31,20 +31,20 @@ function CensusPrimarySection({ census }: { census: CensusData }) {
   const { territory, isoRegionCode, domain, proficiency, acquisitionOrder, modality } = census;
   return (
     <DetailsSection title="Primary Information">
-      <DetailsField title="Territory:">
+      <DetailsField title="Territory">
         {territory != null ? (
           <HoverableObjectName object={territory} />
         ) : (
           <span>{isoRegionCode}</span>
         )}
       </DetailsField>
-      <DetailsField title="Year:">{census.yearCollected}</DetailsField>
-      {modality != null && <DetailsField title="Modality:">{modality}</DetailsField>}
-      {proficiency != null && <DetailsField title="Proficiency:">{proficiency}</DetailsField>}
+      <DetailsField title="Year">{census.yearCollected}</DetailsField>
+      {modality != null && <DetailsField title="Modality">{modality}</DetailsField>}
+      {proficiency != null && <DetailsField title="Proficiency">{proficiency}</DetailsField>}
       {acquisitionOrder != null && (
-        <DetailsField title="Acquisition Order:">{acquisitionOrder}</DetailsField>
+        <DetailsField title="Acquisition Order">{acquisitionOrder}</DetailsField>
       )}
-      {domain != null && <DetailsField title="Where language used:">{domain}</DetailsField>}
+      {domain != null && <DetailsField title="Where language used">{domain}</DetailsField>}
     </DetailsSection>
   );
 }
@@ -65,38 +65,36 @@ function CensusPopulationCharacteristics({ census }: { census: CensusData }) {
 
   return (
     <DetailsSection title="Population Characteristics">
-      <DetailsField title="Eligible Population:">
-        {populationEligible.toLocaleString()}
-      </DetailsField>
+      <DetailsField title="Eligible Population">{populationEligible.toLocaleString()}</DetailsField>
       {populationWithPositiveResponses && (
-        <DetailsField title="Responding Population:">
+        <DetailsField title="Responding Population">
           {populationWithPositiveResponses.toLocaleString()}
         </DetailsField>
       )}
       {populationSurveyed && (
-        <DetailsField title="Surveyed Population:">
+        <DetailsField title="Surveyed Population">
           {populationSurveyed.toLocaleString()}
         </DetailsField>
       )}
       {sampleRate ? (
-        <DetailsField title="Sample rate:">
+        <DetailsField title="Sample rate">
           {typeof sampleRate === 'number' ? (sampleRate * 100).toLocaleString() + '%' : sampleRate}
         </DetailsField>
       ) : populationSurveyed ? (
-        <DetailsField title="Sample rate:">
+        <DetailsField title="Sample rate">
           {((populationSurveyed / populationEligible) * 100).toLocaleString()}%
         </DetailsField>
       ) : null}
       {languagesIncluded && (
-        <DetailsField title="Languages Included:">{languagesIncluded}</DetailsField>
+        <DetailsField title="Languages Included">{languagesIncluded}</DetailsField>
       )}
-      {geographicScope && <DetailsField title="Geographic Scope:">{geographicScope}</DetailsField>}
-      {age && <DetailsField title="Age:">{age}</DetailsField>}
+      {geographicScope && <DetailsField title="Geographic Scope">{geographicScope}</DetailsField>}
+      {age && <DetailsField title="Age">{age}</DetailsField>}
       {responsesPerIndividual && (
-        <DetailsField title="Responses per Individual:">{responsesPerIndividual}</DetailsField>
+        <DetailsField title="Responses per Individual">{responsesPerIndividual}</DetailsField>
       )}
-      {quantity && <DetailsField title="Quantity Provided:">{toTitleCase(quantity)}</DetailsField>}
-      {notes && <DetailsField title="Notes:">{notes}</DetailsField>}
+      {quantity && <DetailsField title="Quantity Provided">{toTitleCase(quantity)}</DetailsField>}
+      {notes && <DetailsField title="Notes">{notes}</DetailsField>}
     </DetailsSection>
   );
 }
@@ -117,28 +115,28 @@ function CensusSourceSection({ census }: { census: CensusData }) {
 
   return (
     <DetailsSection title="Source">
-      <DetailsField title="Collected by:">
+      <DetailsField title="Collected by">
         {collectorName == null ? collectorType : `${collectorName} (${collectorType})`}
         {collectorNameShort && ` aka ${collectorNameShort}`}
       </DetailsField>
-      {documentName && <DetailsField title="Document Name:">{documentName}</DetailsField>}
-      {tableName && <DetailsField title="Table Name:">{tableName}</DetailsField>}
-      {columnName && <DetailsField title="Column Name:">{columnName}</DetailsField>}
-      {citation && <DetailsField title="Citation:">{citation}</DetailsField>}
+      {documentName && <DetailsField title="Document Name">{documentName}</DetailsField>}
+      {tableName && <DetailsField title="Table Name">{tableName}</DetailsField>}
+      {columnName && <DetailsField title="Column Name">{columnName}</DetailsField>}
+      {citation && <DetailsField title="Citation">{citation}</DetailsField>}
       {url && (
-        <DetailsField title="URL:">
+        <DetailsField title="URL">
           <a href={url} target="_blank" rel="noopener noreferrer">
             {url}
           </a>
         </DetailsField>
       )}
       {datePublished && (
-        <DetailsField title="Date Published:">
+        <DetailsField title="Date Published">
           {new Date(datePublished).toLocaleDateString()}
         </DetailsField>
       )}
       {dateAccessed && (
-        <DetailsField title="Date Accessed:">
+        <DetailsField title="Date Accessed">
           {new Date(dateAccessed).toLocaleDateString()}
         </DetailsField>
       )}

--- a/src/widgets/details/LanguageDetails.tsx
+++ b/src/widgets/details/LanguageDetails.tsx
@@ -58,32 +58,32 @@ const LanguageAttributes: React.FC<{ lang: LanguageData }> = ({ lang }) => {
   return (
     <DetailsSection title="Attributes">
       {populationEstimate && (
-        <DetailsField title="Population Estimate:">
+        <DetailsField title="Population Estimate">
           <LanguagePopulationEstimate lang={lang} />
           <LanguagePopulationBreakdownButton lang={lang} />
         </DetailsField>
       )}
       {populationEstimateSource && (
-        <DetailsField title="Population Estimate Source:">{populationEstimateSource}</DetailsField>
+        <DetailsField title="Population Estimate Source">{populationEstimateSource}</DetailsField>
       )}
       {populationOfDescendants && (
-        <DetailsField title="Population of Descendants:">
+        <DetailsField title="Population of Descendants">
           <LanguagePopulationOfDescendants lang={lang} />
         </DetailsField>
       )}
       {populationFromLocales && (
-        <DetailsField title="Population from Locales:">
+        <DetailsField title="Population from Locales">
           <LanguagePopulationFromLocales lang={lang} />
         </DetailsField>
       )}
-      {modality && <DetailsField title="Modality:">{modality}</DetailsField>}
+      {modality && <DetailsField title="Modality">{modality}</DetailsField>}
       {primaryWritingSystem && (
-        <DetailsField title="Primary Writing System:">
+        <DetailsField title="Primary Writing System">
           <HoverableObjectName object={primaryWritingSystem} />
         </DetailsField>
       )}
       {Object.values(writingSystems).length > 0 && (
-        <DetailsField title="Writing Systems:">
+        <DetailsField title="Writing Systems">
           <CommaSeparated>
             {Object.values(writingSystems)
               .sort(getSortFunction())
@@ -93,7 +93,7 @@ const LanguageAttributes: React.FC<{ lang: LanguageData }> = ({ lang }) => {
           </CommaSeparated>
         </DetailsField>
       )}
-      <DetailsField title="Plural Categories:">
+      <DetailsField title="Plural Categories">
         <div
           style={{ display: 'inline-flex', flexWrap: 'wrap', alignItems: 'start', gap: '0.5em' }}
         >
@@ -114,17 +114,17 @@ const LanguageConnections: React.FC<{ lang: LanguageData }> = ({ lang }) => {
   return (
     <DetailsSection title="Connections">
       {ISO.parentLanguage && (
-        <DetailsField title="ISO group:">
+        <DetailsField title="ISO group">
           <HoverableObjectName object={ISO.parentLanguage} />
         </DetailsField>
       )}
       {Glottolog.parentLanguage && (
-        <DetailsField title="Glottolog group:">
+        <DetailsField title="Glottolog group">
           <HoverableObjectName object={Glottolog.parentLanguage} />
         </DetailsField>
       )}
       {variantTags && variantTags.length > 0 && (
-        <DetailsField title="Variant Tags:">
+        <DetailsField title="Variant Tags">
           <CommaSeparated>
             {variantTags.map((tag) => (
               <HoverableObjectName key={tag.ID} object={tag} />
@@ -133,7 +133,7 @@ const LanguageConnections: React.FC<{ lang: LanguageData }> = ({ lang }) => {
         </DetailsField>
       )}
       <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-        <DetailsField title="Descendant Languages:">
+        <DetailsField title="Descendant Languages">
           {childLanguages.length > 0 ? (
             <TreeListRoot rootNodes={getLanguageTreeNodes([lang], languageSource, sortFunction)} />
           ) : (
@@ -142,7 +142,7 @@ const LanguageConnections: React.FC<{ lang: LanguageData }> = ({ lang }) => {
             </div>
           )}
         </DetailsField>
-        <DetailsField title="Locales:">
+        <DetailsField title="Locales">
           {lang.locales.length > 0 ? (
             <TreeListRoot rootNodes={getLocaleTreeNodes([lang], sortFunction, filterByScope)} />
           ) : (

--- a/src/widgets/details/LocaleDetails.tsx
+++ b/src/widgets/details/LocaleDetails.tsx
@@ -50,7 +50,7 @@ const LocaleDefinitionSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
 
   return (
     <DetailsSection title="Definition">
-      <DetailsField title="Language:">
+      <DetailsField title="Language">
         {language ? (
           <HoverableObjectName object={language} />
         ) : (
@@ -60,7 +60,7 @@ const LocaleDefinitionSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
         )}
       </DetailsField>
       {(territory || territoryCode) && (
-        <DetailsField title="Territory:">
+        <DetailsField title="Territory">
           {territory ? (
             <HoverableObjectName object={territory} />
           ) : (
@@ -71,7 +71,7 @@ const LocaleDefinitionSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
         </DetailsField>
       )}
       {scriptCode && (
-        <DetailsField title="Writing System:">
+        <DetailsField title="Writing System">
           {writingSystem ? (
             <HoverableObjectName object={writingSystem} />
           ) : (
@@ -82,7 +82,7 @@ const LocaleDefinitionSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
         </DetailsField>
       )}
       {!scriptCode && language?.primaryWritingSystem && (
-        <DetailsField title="Writing System:">
+        <DetailsField title="Writing System">
           <HoverableObjectName object={language?.primaryWritingSystem} />{' '}
           <Hoverable
             hoverContent={
@@ -99,7 +99,7 @@ const LocaleDefinitionSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
         </DetailsField>
       )}
       {variantTagCodes && variantTagCodes.length > 0 && (
-        <DetailsField title={`Variant Tag${variantTagCodes.length > 1 ? 's' : ''}:`}>
+        <DetailsField title={`Variant Tag${variantTagCodes.length > 1 ? 's' : ''}`}>
           {variantTags ? (
             <CommaSeparated>
               {variantTags.map((tag) => (
@@ -134,7 +134,7 @@ const LocalePopulationSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
       {populationSpeaking == null && <Deemphasized>No population data available.</Deemphasized>}
 
       {populationAdjusted && (
-        <DetailsField title={`Population Adjusted to ${TerritoryDataYear}:`}>
+        <DetailsField title={`Population Adjusted to ${TerritoryDataYear}`}>
           <LocalePopulationAdjusted locale={locale} />
           <HoverableButton
             style={{ marginLeft: '0.5em', padding: '0.25em', fontWeight: 'normal' }}
@@ -151,7 +151,7 @@ const LocalePopulationSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
       )}
 
       {populationSpeaking != null && (
-        <DetailsField title="Speakers (from best cited source(s)):">
+        <DetailsField title="Speakers (from best cited source(s))">
           <CountOfPeople count={populationSpeaking} />
           {' ['}
           <LocaleCensusCitation locale={locale} />
@@ -162,7 +162,7 @@ const LocalePopulationSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
         <DetailsField
           title={
             <span style={{ marginLeft: '2em' }}>
-              % in {territory?.scope.toLowerCase() ?? 'territory'}:
+              % in {territory?.scope.toLowerCase() ?? 'territory'}
             </span>
           }
         >
@@ -170,7 +170,7 @@ const LocalePopulationSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
         </DetailsField>
       )}
       {populationWriting != null && territory && (
-        <DetailsField title="Writers:">
+        <DetailsField title="Writers">
           ~<CountOfPeople count={populationWriting} />
           {' [previous estimate * literacy'}
           {territory.literacyPercent != null && ` (${territory.literacyPercent.toFixed(1)}%)`}
@@ -181,7 +181,7 @@ const LocalePopulationSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
         <DetailsField
           title={
             <span style={{ marginLeft: '2em' }}>
-              % in {territory?.scope.toLowerCase() ?? 'territory'}:
+              % in {territory?.scope.toLowerCase() ?? 'territory'}
             </span>
           }
         >
@@ -190,7 +190,7 @@ const LocalePopulationSection: React.FC<{ locale: LocaleData }> = ({ locale }) =
       )}
 
       {censusRecords && censusRecords.length > 0 && (
-        <DetailsField title="Other Censuses:">
+        <DetailsField title="Other Censuses">
           <table style={{ marginLeft: '2em', borderSpacing: '1em 0' }}>
             <thead>
               <tr>
@@ -235,18 +235,18 @@ const LocaleOtherSection: React.FC<{ locale: LocaleData }> = ({ locale }) => {
   return (
     <DetailsSection title="Other">
       {officialStatus && (
-        <DetailsField title="Government Status:">{getOfficialLabel(officialStatus)}</DetailsField>
+        <DetailsField title="Government Status">{getOfficialLabel(officialStatus)}</DetailsField>
       )}
       {wikipedia && (
-        <DetailsField title="Wikipedia:">
+        <DetailsField title="Wikipedia">
           <ObjectWikipediaInfo object={locale} />
         </DetailsField>
       )}
-      <DetailsField title="Locale Source:">
+      <DetailsField title="Locale Source">
         <LocaleSourceLabel localeSource={localeSource} />
       </DetailsField>
       {relatedLocales?.moreGeneral && relatedLocales.moreGeneral.length > 0 && (
-        <DetailsField title="More General Locales:">
+        <DetailsField title="More General Locales">
           <CommaSeparated>
             {relatedLocales.moreGeneral.map((locale) => (
               <HoverableObjectName key={locale.ID} object={locale} labelSource="code" />
@@ -255,7 +255,7 @@ const LocaleOtherSection: React.FC<{ locale: LocaleData }> = ({ locale }) => {
         </DetailsField>
       )}
       {relatedLocales?.moreSpecific && relatedLocales.moreSpecific.length > 0 && (
-        <DetailsField title="More Specific Locales:">
+        <DetailsField title="More Specific Locales">
           <CommaSeparated>
             {relatedLocales.moreSpecific.map((locale) => (
               <HoverableObjectName key={locale.ID} object={locale} labelSource="code" />
@@ -264,12 +264,12 @@ const LocaleOtherSection: React.FC<{ locale: LocaleData }> = ({ locale }) => {
         </DetailsField>
       )}
       {relatedLocales?.parentLanguage && (
-        <DetailsField title="Parent Language Locale:">
+        <DetailsField title="Parent Language Locale">
           <HoverableObjectName object={relatedLocales.parentLanguage} labelSource="code" />
         </DetailsField>
       )}
       {relatedLocales?.childLanguages && relatedLocales.childLanguages.length > 0 && (
-        <DetailsField title="Child Language Locales:">
+        <DetailsField title="Child Language Locales">
           <CommaSeparated>
             {relatedLocales.childLanguages.map((locale) => (
               <HoverableObjectName key={locale.ID} object={locale} labelSource="code" />
@@ -278,12 +278,12 @@ const LocaleOtherSection: React.FC<{ locale: LocaleData }> = ({ locale }) => {
         </DetailsField>
       )}
       {relatedLocales?.parentTerritory && (
-        <DetailsField title="Encapsulating Territory Locale:">
+        <DetailsField title="Encapsulating Territory Locale">
           <HoverableObjectName object={relatedLocales.parentTerritory} labelSource="code" />
         </DetailsField>
       )}
       {relatedLocales?.childTerritories && relatedLocales.childTerritories.length > 0 && (
-        <DetailsField title="Contained Territory Locales:">
+        <DetailsField title="Contained Territory Locales">
           <CommaSeparated>
             {relatedLocales.childTerritories.map((locale) => (
               <HoverableObjectName key={locale.ID} object={locale} labelSource="code" />

--- a/src/widgets/details/TerritoryDetails.tsx
+++ b/src/widgets/details/TerritoryDetails.tsx
@@ -37,12 +37,12 @@ const TerritoryDetails: React.FC<Props> = ({ territory }) => {
 
       <DetailsSection title="Connections">
         {parentUNRegion != null && (
-          <DetailsField title="In UN region:">
+          <DetailsField title="In UN region">
             <HoverableObjectName object={parentUNRegion} />
           </DetailsField>
         )}
         {containsTerritories && containsTerritories.length > 0 && (
-          <DetailsField title="Contains:">
+          <DetailsField title="Contains">
             <CommaSeparated>
               {containsTerritories.sort(sortFunction).map((territory) => (
                 <HoverableObjectName key={territory.ID} object={territory} />
@@ -52,12 +52,12 @@ const TerritoryDetails: React.FC<Props> = ({ territory }) => {
         )}
 
         {sovereign != null && (
-          <DetailsField title="Administered by:">
+          <DetailsField title="Administered by">
             <HoverableObjectName object={sovereign} />
           </DetailsField>
         )}
         {dependentTerritories && dependentTerritories.length > 0 && (
-          <DetailsField title="Administers:">
+          <DetailsField title="Administers">
             <CommaSeparated>
               {dependentTerritories.sort(sortFunction).map((territory) => (
                 <HoverableObjectName key={territory.ID} object={territory} />
@@ -67,7 +67,7 @@ const TerritoryDetails: React.FC<Props> = ({ territory }) => {
         )}
 
         {censuses && censuses.length > 0 && (
-          <DetailsField title="Census Tables:">
+          <DetailsField title="Census Tables">
             <CommaSeparated>
               {censuses.sort(sortFunction).map((census) => (
                 <HoverableObjectName key={census.ID} object={census} />

--- a/src/widgets/details/VariantTagDetails.tsx
+++ b/src/widgets/details/VariantTagDetails.tsx
@@ -18,20 +18,20 @@ const VariantTagDetails: React.FC<Props> = ({ variantTag }) => {
   return (
     <div className="Details">
       <DetailsSection title="Attributes">
-        <DetailsField title="IANA Code:">{ID}</DetailsField>
-        <DetailsField title="Name:">{nameDisplay}</DetailsField>
-        {description && <DetailsField title="Description:">{description}</DetailsField>}
-        {dateAdded && <DetailsField title="Added:">{dateAdded.toLocaleDateString()}</DetailsField>}
+        <DetailsField title="IANA Code">{ID}</DetailsField>
+        <DetailsField title="Name">{nameDisplay}</DetailsField>
+        {description && <DetailsField title="Description">{description}</DetailsField>}
+        {dateAdded && <DetailsField title="Added">{dateAdded.toLocaleDateString()}</DetailsField>}
       </DetailsSection>
 
       <DetailsSection title="Connections">
         {prefixes.length > 0 && (
-          <DetailsField title="Declared Prefixes:">
+          <DetailsField title="Declared Prefixes">
             <CommaSeparated>{prefixes}</CommaSeparated>
           </DetailsField>
         )}
         {languages.length > 0 && (
-          <DetailsField title="Languages:">
+          <DetailsField title="Languages">
             <CommaSeparated>
               {Object.values(languages).map((lang) => (
                 <HoverableObjectName key={lang.ID} object={lang} />
@@ -40,7 +40,7 @@ const VariantTagDetails: React.FC<Props> = ({ variantTag }) => {
           </DetailsField>
         )}
         {locales.length > 0 && (
-          <DetailsField title="Locales:">
+          <DetailsField title="Locales">
             <CommaSeparated>
               {Object.values(locales).map((locale) => (
                 <HoverableObjectName key={locale.ID} object={locale} />

--- a/src/widgets/details/WritingSystemDetails.tsx
+++ b/src/widgets/details/WritingSystemDetails.tsx
@@ -36,14 +36,14 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
   return (
     <div className="Details">
       <DetailsSection title="Attributes">
-        <DetailsField title="Scope:">{scope}</DetailsField>
+        <DetailsField title="Scope">{scope}</DetailsField>
         {rightToLeft != null && (
           <DetailsField title="Direction">
             {rightToLeft ? 'Right to Left' : 'Left to Right'}
           </DetailsField>
         )}
         {sample && <DetailsField title="Sample">{sample}</DetailsField>}
-        <DetailsField title="Unicode Support:">
+        <DetailsField title="Unicode Support">
           {unicodeVersion != null ? (
             `since version ${unicodeVersion}`
           ) : (
@@ -55,8 +55,7 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
             title={
               <>
                 Population (Upper Bound
-                <PopulationWarning />
-                ):
+                <PopulationWarning />)
               </>
             }
           >
@@ -67,7 +66,7 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
 
       <DetailsSection title="Connections">
         {primaryLanguageCode != null && (
-          <DetailsField title="Primary language:">
+          <DetailsField title="Primary language">
             {primaryLanguage != null ? (
               <HoverableObjectName object={primaryLanguage} />
             ) : (
@@ -76,7 +75,7 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
           </DetailsField>
         )}
         {languages && Object.values(languages).length > 0 && (
-          <DetailsField title="Languages:">
+          <DetailsField title="Languages">
             <CommaSeparated>
               {Object.values(languages)
                 .sort(getSortFunction())
@@ -88,13 +87,13 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
         )}
 
         {territoryOfOrigin && (
-          <DetailsField title="Territory of Origin:">
+          <DetailsField title="Territory of Origin">
             <HoverableObjectName object={territoryOfOrigin} />
           </DetailsField>
         )}
 
         {localesWhereExplicit && localesWhereExplicit.length > 0 && (
-          <DetailsField title="Locales (where writing system is explicit):">
+          <DetailsField title="Locales (where writing system is explicit)">
             <CommaSeparated>
               {localesWhereExplicit.sort(getSortFunction()).map((locale) => (
                 <HoverableObjectName key={locale.ID} object={locale} />
@@ -104,12 +103,12 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
         )}
 
         {parentWritingSystem && (
-          <DetailsField title="Originated from:">
+          <DetailsField title="Originated from">
             <HoverableObjectName object={parentWritingSystem} />
           </DetailsField>
         )}
         {childWritingSystems && childWritingSystems.length > 0 && (
-          <DetailsField title="Inspired:">
+          <DetailsField title="Inspired">
             <CommaSeparated>
               {childWritingSystems.sort(getSortFunction()).map((writingSystem) => (
                 <HoverableObjectName key={writingSystem.ID} object={writingSystem} />
@@ -118,7 +117,7 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
           </DetailsField>
         )}
         {containsWritingSystems && containsWritingSystems.length > 0 && (
-          <DetailsField title="Contains:">
+          <DetailsField title="Contains">
             <CommaSeparated>
               {containsWritingSystems.sort(getSortFunction()).map((writingSystem) => (
                 <HoverableObjectName key={writingSystem.ID} object={writingSystem} />

--- a/src/widgets/details/sections/LanguageCodes.tsx
+++ b/src/widgets/details/sections/LanguageCodes.tsx
@@ -19,7 +19,7 @@ const LanguageCodes: React.FC<{ lang: LanguageData }> = ({ lang }) => {
 
   return (
     <DetailsSection title="Language Codes">
-      <DetailsField title="Scope:">
+      <DetailsField title="Scope">
         <LanguageScopeDisplay lang={lang} />
       </DetailsField>
       <DetailsField
@@ -90,7 +90,7 @@ const LanguageCodes: React.FC<{ lang: LanguageData }> = ({ lang }) => {
         {CLDR.code ? <>{CLDR.code}</> : <Deemphasized>Not in CLDR</Deemphasized>}
       </DetailsField>
       {ISO.code && (
-        <DetailsField title="Other external links:">
+        <DetailsField title="Other external links">
           <LinkButton href={`https://www.ethnologue.com/language/${ISO.code}`}>
             Ethnologue
           </LinkButton>

--- a/src/widgets/details/sections/LanguageLocation.tsx
+++ b/src/widgets/details/sections/LanguageLocation.tsx
@@ -26,7 +26,7 @@ const LanguageLocation: React.FC<{ lang: LanguageData }> = ({ lang }) => {
 
   return (
     <DetailsSection title="Location">
-      <DetailsField title="Coordinates:">
+      <DetailsField title="Coordinates">
         {lang.latitude && lang.longitude ? (
           <>
             {lang.latitude.toFixed(4)}°, {lang.longitude.toFixed(4)}° <Pill>Glottolog</Pill>

--- a/src/widgets/details/sections/LanguageNames.tsx
+++ b/src/widgets/details/sections/LanguageNames.tsx
@@ -15,34 +15,34 @@ const LanguageNames: React.FC<{ lang: LanguageData }> = ({ lang }) => {
 
   return (
     <DetailsSection title="Names">
-      <DetailsField title="Canonical Name:">
+      <DetailsField title="Canonical Name">
         <LanguageCanonicalName lang={lang} />
       </DetailsField>
       {nameEndonym && nameDisplay !== nameEndonym && (
-        <DetailsField title="Endonym:">
+        <DetailsField title="Endonym">
           <ObjectFieldHighlightedByPageSearch object={lang} field={SearchableField.NameEndonym} />
         </DetailsField>
       )}
       {nameFrench && nameFrench !== nameDisplay.toLowerCase() && (
-        <DetailsField title="French Name:">{nameFrench}</DetailsField>
+        <DetailsField title="French Name">{nameFrench}</DetailsField>
       )}
       {Glottolog.name && nameDisplay !== Glottolog.name && (
-        <DetailsField title="Glottolog Name:">
+        <DetailsField title="Glottolog Name">
           <ObjectFieldHighlightedByPageSearch object={lang} field={SearchableField.NameGlottolog} />
         </DetailsField>
       )}
       {ISO.name && nameDisplay !== ISO.name && (
-        <DetailsField title="ISO Name:">
+        <DetailsField title="ISO Name">
           <ObjectFieldHighlightedByPageSearch object={lang} field={SearchableField.NameISO} />
         </DetailsField>
       )}
       {CLDR.name && nameDisplay !== CLDR.name && (
-        <DetailsField title="CLDR Name:">
+        <DetailsField title="CLDR Name">
           <ObjectFieldHighlightedByPageSearch object={lang} field={SearchableField.NameCLDR} />
         </DetailsField>
       )}
       {getLanguageOtherNames(lang).length > 0 && (
-        <DetailsField title="Other names:">
+        <DetailsField title="Other names">
           <LanguageOtherNames lang={lang} />
         </DetailsField>
       )}

--- a/src/widgets/details/sections/TerritoryAttributes.tsx
+++ b/src/widgets/details/sections/TerritoryAttributes.tsx
@@ -17,23 +17,23 @@ const TerritoryAttributes: React.FC<{ territory: TerritoryData }> = ({ territory
   return (
     <DetailsSection title="Attributes">
       {!Number.isNaN(population) && (
-        <DetailsField title="Population:">
+        <DetailsField title="Population">
           <CountOfPeople count={population} />
         </DetailsField>
       )}
       {literacyPercent && !Number.isNaN(literacyPercent) && (
-        <DetailsField title="Literacy:">{literacyPercent.toFixed(1)}%</DetailsField>
+        <DetailsField title="Literacy">{literacyPercent.toFixed(1)}%</DetailsField>
       )}
       {gdp && !Number.isNaN(gdp) && (
-        <DetailsField title="Gross Domestic Product:">{getCurrencyCompactLong(gdp)}</DetailsField>
+        <DetailsField title="Gross Domestic Product">{getCurrencyCompactLong(gdp)}</DetailsField>
       )}
       {landArea && (
-        <DetailsField title="Land Area:">
+        <DetailsField title="Land Area">
           {numberToSigFigs(landArea, 3)?.toLocaleString()} km²
         </DetailsField>
       )}
       {landArea && population && (
-        <DetailsField title="Density:">
+        <DetailsField title="Density">
           {numberToFixedUnlessSmall(population / landArea, 3)} people/km²
         </DetailsField>
       )}

--- a/src/widgets/details/sections/TerritoryIdentification.tsx
+++ b/src/widgets/details/sections/TerritoryIdentification.tsx
@@ -21,23 +21,23 @@ const TerritoryIdentification: React.FC<{ territory: TerritoryData }> = ({ terri
       <DetailsField
         title={
           ID.match(/^[A-Z]{2}$/)
-            ? 'ISO-3166 Alpha-2 Code:'
+            ? 'ISO-3166 Alpha-2 Code'
             : ID.match(/^[0-9]{3}$/)
-              ? 'UN M.49 Numeric Code:'
-              : 'Territory ID:'
+              ? 'UN M.49 Numeric Code'
+              : 'Territory ID'
         }
       >
         {ID}
       </DetailsField>
-      {codeAlpha3 && <DetailsField title="ISO-3166 Alpha-3 Code:">{codeAlpha3}</DetailsField>}
-      {codeNumeric && <DetailsField title="ISO-3166 Numeric Code:">{codeNumeric}</DetailsField>}
-      <DetailsField title="Display Name:">{nameDisplay}</DetailsField>
-      {nameEndonym && <DetailsField title="Endonym:">{nameEndonym}</DetailsField>}
+      {codeAlpha3 && <DetailsField title="ISO-3166 Alpha-3 Code">{codeAlpha3}</DetailsField>}
+      {codeNumeric && <DetailsField title="ISO-3166 Numeric Code">{codeNumeric}</DetailsField>}
+      <DetailsField title="Display Name">{nameDisplay}</DetailsField>
+      {nameEndonym && <DetailsField title="Endonym">{nameEndonym}</DetailsField>}
       {nameOtherEndonyms && nameOtherEndonyms.length > 0 && (
-        <DetailsField title="Other Endonyms:">{nameOtherEndonyms.join(', ')}</DetailsField>
+        <DetailsField title="Other Endonyms">{nameOtherEndonyms.join(', ')}</DetailsField>
       )}
       {nameOtherExonyms && nameOtherExonyms.length > 0 && (
-        <DetailsField title="Other Names:">{nameOtherExonyms.join(', ')}</DetailsField>
+        <DetailsField title="Other Names">{nameOtherExonyms.join(', ')}</DetailsField>
       )}
     </DetailsSection>
   );

--- a/src/widgets/details/sections/TerritoryLocation.tsx
+++ b/src/widgets/details/sections/TerritoryLocation.tsx
@@ -13,7 +13,7 @@ import LinkButton from '@shared/ui/LinkButton';
 const TerritoryLocation: React.FC<{ territory: TerritoryData }> = ({ territory }) => {
   return (
     <DetailsSection title="Location">
-      <DetailsField title="Center:">
+      <DetailsField title="Center">
         {territory.latitude && territory.longitude ? (
           <>
             {territory.latitude.toFixed(4)}°, {territory.longitude.toFixed(4)}°
@@ -23,7 +23,7 @@ const TerritoryLocation: React.FC<{ territory: TerritoryData }> = ({ territory }
         )}
       </DetailsField>
 
-      <DetailsField title="Map:">Showing {getMapLabel(territory)}</DetailsField>
+      <DetailsField title="Map">Showing {getMapLabel(territory)}</DetailsField>
       <MapContainer>
         <ObjectMap
           objects={[


### PR DESCRIPTION
## Summary
- Updated `DetailsField` component to automatically append a non-bold colon after the title
- Removed manually-added colons from all `DetailsField` title props across 13 files.

fixes #360 

## Testing

- [x] `npm run lint`
- [x] `npm run test`
  - [x] Tests added or updated for changed logic
- [x] `npm run build`
- [x] Write comments on manual testing how you tested in this PR
  - **Manual testing performed:**
    - Verified Language details page
    - Verified Territory details page
    - Verified Locale details page
    - Verified Writing System details page
    - Verified Census details page
    - Verified Variant Tag details page
    - Confirmed all colons appear correctly with non-bold styling after bold titles

## Screenshots
<img width="1470" height="829" alt="image" src="https://github.com/user-attachments/assets/fda05994-0b63-4a9f-90cf-decad5d75d78" />

