### PR TITLE
useObjects and useFilters

### DIFF
--- a/src/entities/locale/LocaleCitationCounts.tsx
+++ b/src/entities/locale/LocaleCitationCounts.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
 
-import { useDataContext } from '@features/data/context/useDataContext';
-import { getScopeFilter } from '@features/transforms/filtering/filter';
+import { ObjectType } from '@features/params/PageParamTypes';
+import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
 
 import { CensusCollectorType } from '@entities/census/CensusTypes';
 
 import CollapsibleReport from '@shared/containers/CollapsibleReport';
 
 const LocaleCitationCounts: React.FC = () => {
-  const { locales } = useDataContext();
-  const filterByScope = getScopeFilter();
-  const filteredLocales = locales.filter(filterByScope);
+  const { filteredObjects: filteredLocales } = useFilteredObjects(ObjectType.Locale, {});
 
   // Count locales with populationCensus
   const withCensusLocales = filteredLocales.filter((loc) => loc.populationCensus != null);

--- a/src/features/data/context/useObjects.tsx
+++ b/src/features/data/context/useObjects.tsx
@@ -1,0 +1,42 @@
+import { useDataContext } from '@features/data/context/useDataContext';
+import { ObjectType } from '@features/params/PageParamTypes';
+
+import { CensusData } from '@entities/census/CensusTypes';
+import { LanguageData } from '@entities/language/LanguageTypes';
+import {
+  LocaleData,
+  TerritoryData,
+  VariantTagData,
+  WritingSystemData,
+} from '@entities/types/DataTypes';
+
+export type ObjectDataByType = {
+  [ObjectType.Language]: LanguageData;
+  [ObjectType.Locale]: LocaleData;
+  [ObjectType.Territory]: TerritoryData;
+  [ObjectType.WritingSystem]: WritingSystemData;
+  [ObjectType.VariantTag]: VariantTagData;
+  [ObjectType.Census]: CensusData;
+};
+
+function useObjects<K extends keyof ObjectDataByType>(type: K): ObjectDataByType[K][] {
+  const { languagesInSelectedSource, locales, territories, writingSystems, variantTags, censuses } =
+    useDataContext();
+
+  switch (type) {
+    case ObjectType.Census:
+      return Object.values(censuses) as ObjectDataByType[typeof type][];
+    case ObjectType.Language:
+      return languagesInSelectedSource as ObjectDataByType[typeof type][];
+    case ObjectType.Locale:
+      return locales as ObjectDataByType[typeof type][];
+    case ObjectType.Territory:
+      return territories as ObjectDataByType[typeof type][];
+    case ObjectType.WritingSystem:
+      return writingSystems as ObjectDataByType[typeof type][];
+    case ObjectType.VariantTag:
+      return variantTags as ObjectDataByType[typeof type][];
+  }
+}
+
+export default useObjects;

--- a/src/features/transforms/filtering/__tests__/useFilteredObjects.test.tsx
+++ b/src/features/transforms/filtering/__tests__/useFilteredObjects.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach, Mock } from 'vitest';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
-import { PageParamsOptional } from '@features/params/PageParamTypes';
+import { ObjectType, PageParamsOptional } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 import { SortBehavior, SortBy } from '@features/transforms/sorting/SortTypes';
 
@@ -25,13 +25,13 @@ vi.mock('@features/data/context/useDataContext', () => ({
 // Helper to get hook result
 function getHookResult(
   params: {
-    useScope?: boolean;
-    useSubstring?: boolean;
-    useTerritory?: boolean;
-    useVitality?: boolean;
+    scope?: boolean;
+    substring?: boolean;
+    connections?: boolean;
+    vitality?: boolean;
   } = {},
 ) {
-  const res = renderHook(() => useFilteredObjects(params));
+  const res = renderHook(() => useFilteredObjects(ObjectType.Language, params));
   return res.result.current;
 }
 
@@ -95,7 +95,7 @@ describe('useFilteredObjects', () => {
   });
 
   it("if we don't want to filter by scope, it will allow the language family (ine) even though the page param wouldn't normally allow it", () => {
-    const { filteredObjects } = getHookResult({ useScope: false });
+    const { filteredObjects } = getHookResult({ scope: false });
     expect(filteredObjects.map((obj) => obj.ID)).toEqual([
       'ine', // usually filtered out as family
       'gem',

--- a/src/features/transforms/filtering/useFilteredObjects.tsx
+++ b/src/features/transforms/filtering/useFilteredObjects.tsx
@@ -1,88 +1,24 @@
-import { useMemo } from 'react';
+import useObjects, { ObjectDataByType } from '@features/data/context/useObjects';
 
-import { useDataContext } from '@features/data/context/useDataContext';
-import { ObjectType } from '@features/params/PageParamTypes';
-import usePageParams from '@features/params/usePageParams';
-import { getSortFunction } from '@features/transforms/sorting/sort';
+import useFilters, { FilterOptions } from './useFilters';
 
-import { ObjectData } from '@entities/types/DataTypes';
+function useFilteredObjects<K extends keyof ObjectDataByType>(
+  type: K,
+  { scope = true, substring = true, connections = true, vitality = true }: FilterOptions,
+): {
+  filteredObjects: ObjectDataByType[K][];
+  allObjectsInType: ObjectDataByType[K][];
+} {
+  const objects = useObjects(type);
 
-import getFilterBySubstring from '../search/getFilterBySubstring';
-
-import { getFilterByVitality, getScopeFilter } from './filter';
-import { getFilterByConnections } from './filterByConnections';
-
-type UseFilteredObjectsParams = {
-  useScope?: boolean;
-  useSubstring?: boolean;
-  useConnections?: boolean;
-  useVitality?: boolean;
-  inputObjects?: ObjectData[];
-};
-
-const useFilteredObjects = ({
-  useScope = true,
-  useSubstring = true,
-  useConnections = true,
-  useVitality = true,
-  inputObjects,
-}: UseFilteredObjectsParams): { filteredObjects: ObjectData[]; allObjectsInType: ObjectData[] } => {
-  // Implementation of filtering logic goes here
-  const { objectType } = usePageParams();
-  const { languagesInSelectedSource, locales, territories, writingSystems, variantTags, censuses } =
-    useDataContext();
-  const filterByScope = useScope ? getScopeFilter() : () => true;
-  const filterBySubstring = useSubstring ? getFilterBySubstring() : () => true;
-  const filterByConnections = useConnections ? getFilterByConnections() : () => true;
-  const filterByVitality = useVitality ? getFilterByVitality() : () => true;
-  const sortFunction = getSortFunction();
-
-  const objects = useMemo(() => {
-    if (inputObjects) return inputObjects;
-    switch (objectType) {
-      case ObjectType.Census:
-        return Object.values(censuses);
-      case ObjectType.Language:
-        return languagesInSelectedSource;
-      case ObjectType.Locale:
-        return locales;
-      case ObjectType.Territory:
-        return territories;
-      case ObjectType.WritingSystem:
-        return writingSystems;
-      case ObjectType.VariantTag:
-        return variantTags;
-    }
-  }, [
-    objectType,
-    censuses,
-    languagesInSelectedSource,
-    locales,
-    territories,
-    writingSystems,
-    variantTags,
-  ]);
-
-  const filteredObjects = useMemo(() => {
-    return objects
-      .filter(
-        (obj) =>
-          filterByScope(obj) &&
-          filterBySubstring(obj) &&
-          filterByConnections(obj) &&
-          filterByVitality(obj),
-      )
-      .sort(sortFunction);
-  }, [
-    objects,
-    filterByScope,
-    filterBySubstring,
-    filterByConnections,
-    filterByVitality,
-    sortFunction,
-  ]);
+  const filteredObjects = useFilters(objects, {
+    scope,
+    substring,
+    connections,
+    vitality,
+  });
 
   return { filteredObjects, allObjectsInType: objects };
-};
+}
 
 export default useFilteredObjects;

--- a/src/features/transforms/filtering/useFilters.tsx
+++ b/src/features/transforms/filtering/useFilters.tsx
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+
+import { getSortFunction } from '@features/transforms/sorting/sort';
+
+import { ObjectData } from '@entities/types/DataTypes';
+
+import getFilterBySubstring from '../search/getFilterBySubstring';
+
+import { getFilterByVitality, getScopeFilter } from './filter';
+import { getFilterByConnections } from './filterByConnections';
+
+// You may not always want to use all filters, for example, if we want to show
+// language families in the hierarchy view
+export type FilterOptions = {
+  scope?: boolean;
+  substring?: boolean;
+  connections?: boolean;
+  vitality?: boolean;
+};
+
+const useFilters = <T extends ObjectData>(objects: T[], options: FilterOptions): T[] => {
+  const { scope = true, substring = true, connections = true, vitality = true } = options;
+  const filterByScope = scope ? getScopeFilter() : () => true;
+  const filterBySubstring = substring ? getFilterBySubstring() : () => true;
+  const filterByConnections = connections ? getFilterByConnections() : () => true;
+  const filterByVitality = vitality ? getFilterByVitality() : () => true;
+  const sortFunction = getSortFunction();
+
+  return useMemo(() => {
+    return objects
+      .filter(
+        (obj) =>
+          filterByScope(obj) &&
+          filterBySubstring(obj) &&
+          filterByConnections(obj) &&
+          filterByVitality(obj),
+      )
+      .sort(sortFunction);
+  }, [
+    objects,
+    filterByScope,
+    filterBySubstring,
+    filterByConnections,
+    filterByVitality,
+    sortFunction,
+  ]);
+};
+
+export default useFilters;

--- a/src/features/transforms/search/useSearchSuggestions.tsx
+++ b/src/features/transforms/search/useSearchSuggestions.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { useDataContext } from '@features/data/context/useDataContext';
-import { ObjectType } from '@features/params/PageParamTypes';
+import useObjects from '@features/data/context/useObjects';
 import { Suggestion, SUGGESTION_LIMIT } from '@features/params/ui/SelectorSuggestions';
 import usePageParams from '@features/params/usePageParams';
 import {
@@ -24,8 +23,6 @@ import HighlightedObjectField from './HighlightedObjectField';
 
 export default function useSearchSuggestions(): (query: string) => Promise<Suggestion[]> {
   const { searchBy, objectType } = usePageParams();
-  const { censuses, territories, languagesInSelectedSource, locales, writingSystems, variantTags } =
-    useDataContext();
   const filterByLanguageScope = getFilterByLanguageScope();
   const filterByTerritoryScope = getFilterByTerritoryScope();
   const filterByWritingSystem = getFilterByWritingSystem();
@@ -33,31 +30,7 @@ export default function useSearchSuggestions(): (query: string) => Promise<Sugge
   const filterByTerritory = getFilterByTerritory();
   const filterLabels = getFilterLabels();
 
-  const objects = useMemo(() => {
-    switch (objectType) {
-      case ObjectType.Language:
-        return languagesInSelectedSource;
-      case ObjectType.Locale:
-        return locales;
-      case ObjectType.Territory:
-        return territories;
-      case ObjectType.WritingSystem:
-        return writingSystems;
-      case ObjectType.Census:
-        return Object.values(censuses);
-      case ObjectType.VariantTag:
-        return variantTags;
-    }
-  }, [
-    censuses,
-    languagesInSelectedSource,
-    locales,
-    territories,
-    variantTags,
-    writingSystems,
-    objectType,
-    searchBy,
-  ]);
+  const objects = useObjects(objectType);
 
   const [getMatchDistance, getMatchGroup] = useMemo(() => {
     const getMatchDistance = (object: ObjectData): number => {

--- a/src/pages/dataviews/ViewMap.tsx
+++ b/src/pages/dataviews/ViewMap.tsx
@@ -24,7 +24,7 @@ import './styles.css';
 
 function ViewMap() {
   const { colorBy, objectType } = usePageParams();
-  const { filteredObjects } = useFilteredObjects({});
+  const { filteredObjects } = useFilteredObjects(objectType, {});
   const { getCurrentObjects } = usePagination<ObjectData>();
 
   const isDrawingTerritories = objectType !== ObjectType.Language;

--- a/src/widgets/cardlists/CardList.tsx
+++ b/src/widgets/cardlists/CardList.tsx
@@ -4,6 +4,7 @@ import { DetailsContainer } from '@pages/dataviews/ViewDetails';
 
 import usePagination from '@features/pagination/usePagination';
 import VisibleItemsMeter from '@features/pagination/VisibleItemsMeter';
+import usePageParams from '@features/params/usePageParams';
 import useColors from '@features/transforms/coloring/useColors';
 import FilterBreakdown from '@features/transforms/filtering/FilterBreakdown';
 import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
@@ -20,7 +21,8 @@ import ObjectDetails from '../details/ObjectDetails';
 import ResponsiveGrid from './ResponsiveGrid';
 
 const CardList: React.FC = () => {
-  const { filteredObjects, allObjectsInType } = useFilteredObjects({});
+  const { objectType } = usePageParams();
+  const { filteredObjects, allObjectsInType } = useFilteredObjects(objectType, {});
   const { getCurrentObjects } = usePagination<ObjectData>();
   const currentObjects = useMemo(
     () => getCurrentObjects(filteredObjects),

--- a/src/widgets/reports/DubiousLanguages.tsx
+++ b/src/widgets/reports/DubiousLanguages.tsx
@@ -5,8 +5,8 @@ import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName'
 import LimitInput from '@features/pagination/LimitInput';
 import PaginationControls from '@features/pagination/PaginationControls';
 import usePagination from '@features/pagination/usePagination';
-import { getFilterByConnections } from '@features/transforms/filtering/filterByConnections';
-import getFilterBySubstring from '@features/transforms/search/getFilterBySubstring';
+import { ObjectType } from '@features/params/PageParamTypes';
+import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
 import { getSortFunction } from '@features/transforms/sorting/sort';
 
 import { LanguageData } from '@entities/language/LanguageTypes';
@@ -16,19 +16,13 @@ import ViewCard from '@shared/containers/ViewCard';
 import Deemphasized from '@shared/ui/Deemphasized';
 
 const DubiousLanguages: React.FC = () => {
-  const { getLanguage, getTerritory, getWritingSystem, languagesInSelectedSource } =
-    useDataContext();
-  const filterBySubstring = getFilterBySubstring();
-  const filterByConnections = getFilterByConnections();
+  const { getLanguage, getTerritory, getWritingSystem } = useDataContext();
+  const { filteredObjects: languages } = useFilteredObjects(ObjectType.Language, {});
   const sortFunction = getSortFunction();
   const { getCurrentObjects } = usePagination<LanguageData>();
   const languagesFiltered = useMemo(
-    () =>
-      languagesInSelectedSource
-        .filter(filterBySubstring)
-        .filter(filterByConnections)
-        .filter((lang) => lang.codeDisplay.match('xx.-|^[0-9]')),
-    [languagesInSelectedSource, filterBySubstring, filterByConnections],
+    () => languages.filter((lang) => lang.codeDisplay.match('xx.-|^[0-9]')),
+    [languages],
   );
 
   return (

--- a/src/widgets/reports/LanguagesLargestDescendant.tsx
+++ b/src/widgets/reports/LanguagesLargestDescendant.tsx
@@ -1,12 +1,13 @@
 import React, { useMemo } from 'react';
 
-import { useDataContext } from '@features/data/context/useDataContext';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
+import { ObjectType } from '@features/params/PageParamTypes';
 import Selector from '@features/params/ui/Selector';
 import { CodeColumn, NameColumn } from '@features/table/CommonColumns';
 import InteractiveObjectTable from '@features/table/InteractiveObjectTable';
 import TableID from '@features/table/TableID';
 import TableValueType from '@features/table/TableValueType';
+import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
 import { SortBy } from '@features/transforms/sorting/SortTypes';
 
 import { LanguageData } from '@entities/language/LanguageTypes';
@@ -15,18 +16,18 @@ import { getObjectPopulationPercentInBiggestDescendantLanguage } from '@entities
 import CollapsibleReport from '@shared/containers/CollapsibleReport';
 
 const LanguagesLargestDescendant: React.FC = () => {
-  const { languagesInSelectedSource } = useDataContext();
+  const { filteredObjects: languages } = useFilteredObjects(ObjectType.Language, {});
 
   // TODO move this algorithm earlier in the data processing pipeline so it doesn't need to be
   // recomputed every time the component renders.
 
   // Clear the largest descendants first since it may change a lot if the schema changes.
-  languagesInSelectedSource.forEach((lang) => {
+  languages.forEach((lang) => {
     lang.largestDescendant = undefined;
   });
 
   // Compute the largest descendants for each language
-  languagesInSelectedSource.forEach((lang) => {
+  languages.forEach((lang) => {
     lang.largestDescendant = getLargestDescendant(lang);
   });
 
@@ -35,7 +36,7 @@ const LanguagesLargestDescendant: React.FC = () => {
 
   const filteredLanguages = useMemo(
     () =>
-      languagesInSelectedSource.filter((lang) => {
+      languages.filter((lang) => {
         if (
           lang.largestDescendant == null ||
           lang.populationEstimate == null ||
@@ -48,7 +49,7 @@ const LanguagesLargestDescendant: React.FC = () => {
           100;
         return percent >= minimumPercentThreshold && percent <= maximumPercentThreshold;
       }),
-    [languagesInSelectedSource, minimumPercentThreshold, maximumPercentThreshold],
+    [languages, minimumPercentThreshold, maximumPercentThreshold],
   );
 
   return (

--- a/src/widgets/reports/LanguagesWithIdenticalNames.tsx
+++ b/src/widgets/reports/LanguagesWithIdenticalNames.tsx
@@ -2,12 +2,11 @@ import React, { useMemo } from 'react';
 
 import ResponsiveGrid from '@widgets/cardlists/ResponsiveGrid';
 
-import { useDataContext } from '@features/data/context/useDataContext';
 import LimitInput from '@features/pagination/LimitInput';
 import PaginationControls from '@features/pagination/PaginationControls';
 import usePagination from '@features/pagination/usePagination';
-import { getFilterByConnections } from '@features/transforms/filtering/filterByConnections';
-import getFilterBySubstring from '@features/transforms/search/getFilterBySubstring';
+import { ObjectType } from '@features/params/PageParamTypes';
+import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
 import { getSortFunction } from '@features/transforms/sorting/sort';
 import TreeListRoot from '@features/treelist/TreeListRoot';
 
@@ -22,26 +21,21 @@ import Deemphasized from '@shared/ui/Deemphasized';
 import { getLanguageTreeNodes } from '../treelists/LanguageHierarchy';
 
 const LanguagesWithIdenticalNames: React.FC = () => {
-  const { languagesInSelectedSource } = useDataContext();
-  const filterBySubstring = getFilterBySubstring();
-  const filterByConnections = getFilterByConnections();
+  const { filteredObjects: languages } = useFilteredObjects(ObjectType.Language, {});
   const sortFunction = getSortFunction();
   const { getCurrentObjects } = usePagination<[string, LanguageData[]]>();
   const languagesByName = useMemo(() => {
-    return languagesInSelectedSource
-      .filter(filterBySubstring)
-      .filter(filterByConnections)
-      .reduce<Record<string, LanguageData[]>>((languagesByName, lang) => {
-        const name = lang.nameDisplay;
-        if (languagesByName[name] == null) {
-          languagesByName[name] = [lang];
-        } else {
-          languagesByName[name].push(lang);
-        }
-        return languagesByName;
-      }, {});
-  }, [languagesInSelectedSource, filterBySubstring, filterByConnections]);
-  console.log(Object.entries(languagesByName).slice(0, 5));
+    return languages.reduce<Record<string, LanguageData[]>>((languagesByName, lang) => {
+      const name = lang.nameDisplay;
+      if (languagesByName[name] == null) {
+        languagesByName[name] = [lang];
+      } else {
+        languagesByName[name].push(lang);
+      }
+      return languagesByName;
+    }, {});
+  }, [languages]);
+
   const langsWithDupNames = Object.entries(languagesByName).reduce<Record<string, LanguageData[]>>(
     (duplicatedNames, [name, langs]) => {
       if (langs.length > 1) {

--- a/src/widgets/reports/LocaleCitationCounts.tsx
+++ b/src/widgets/reports/LocaleCitationCounts.tsx
@@ -10,7 +10,7 @@ import { TerritoryScope } from '@entities/types/DataTypes';
 import CollapsibleReport from '@shared/containers/CollapsibleReport';
 
 const LocaleCitationCounts: React.FC = () => {
-  const { filteredObjects: filteredLocales } = useFilteredObjects({});
+  const { filteredObjects: filteredLocales } = useFilteredObjects(ObjectType.Locale, {});
 
   // Count locales with populationCensus
   const locales = filteredLocales.filter((obj) => obj.type === ObjectType.Locale);

--- a/src/widgets/treelists/LanguageHierarchy.tsx
+++ b/src/widgets/treelists/LanguageHierarchy.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import LanguageSourceSelector from '@widgets/controls/selectors/LanguageSourceSelector';
 
@@ -7,11 +7,12 @@ import { ObjectType } from '@features/params/PageParamTypes';
 import { SelectorDisplay } from '@features/params/ui/SelectorDisplayContext';
 import usePageParams from '@features/params/usePageParams';
 import { getScopeFilter } from '@features/transforms/filtering/filter';
+import { getFilterByConnections } from '@features/transforms/filtering/filterByConnections';
 import { getSortFunction } from '@features/transforms/sorting/sort';
 import { TreeNodeData } from '@features/treelist/TreeListNode';
 import TreeListPageBody from '@features/treelist/TreeListPageBody';
 
-import { LanguageData, LanguageSource, LanguageScope } from '@entities/language/LanguageTypes';
+import { LanguageData, LanguageScope, LanguageSource } from '@entities/language/LanguageTypes';
 import { ObjectData } from '@entities/types/DataTypes';
 
 export const LanguageHierarchy: React.FC = () => {
@@ -19,14 +20,19 @@ export const LanguageHierarchy: React.FC = () => {
   const { languagesInSelectedSource } = useDataContext();
   const sortFunction = getSortFunction();
   const filterByScope = getScopeFilter();
+  const filterByConnections = getFilterByConnections();
+  const filterInnerNodes = useCallback((a: ObjectData) => {
+    // Always show inner nodes (families) even if they don't pass the connections filter
+    return filterByScope(a) || filterByConnections(a);
+  }, []);
 
   const rootNodes = getLanguageTreeNodes(
     languagesInSelectedSource.filter(
-      (lang) => lang.parentLanguage == null || !filterByScope(lang.parentLanguage),
+      (lang) => lang.parentLanguage == null || !filterInnerNodes(lang.parentLanguage),
     ),
     languageSource,
     sortFunction,
-    filterByScope,
+    filterInnerNodes,
     0,
   );
 


### PR DESCRIPTION
This improves the code for `useFilteredObjects` to make it more compact and to split out `useObjects` and `useFilters` so it is easier to use.

## Summary

- [x] Clear description of what and why
- [x] Scope kept focused; note follow-ups if any
- [x] Set yourself as assignee
- [x] Mention the issue no issue -- yes I'm guilty

## Testing

- [x] `npm run lint`
- [x] `npm run test`
  - [updated] Tests added or updated for changed logic
- [x] `npm run build`
- [x] Write comments on manual testing how you tested in this PR
- [x] Include screenshots in the changes section below

## Changes

nothing visible, just under the hood updates.
