### PR TITLE
Preserve searchString and objectID when objectType changes

### DIFF
--- a/src/features/params/getNewURLSearchParams.ts
+++ b/src/features/params/getNewURLSearchParams.ts
@@ -106,6 +106,20 @@ function clearContextDependentParams(
 
   if (newParams.objectType !== undefined && newParams.objectType !== prevOrDefault.objectType) {
     if (newParams.page == null) next.delete('page');
+    const oldSearchString = prev?.get('searchString');
+    const oldObjectID = prev?.get('objectID');
+    const contextValue = oldObjectID || oldSearchString;
+    if (newParams.searchString === undefined) next.delete('searchString');
+    if (newParams.objectID === undefined) next.delete('objectID');
+    if (contextValue) {
+      if (newParams.objectType === ObjectType.Territory) {
+        next.set('languageFilter', contextValue);
+      } else if (newParams.objectType === ObjectType.Language) {
+        next.set('territoryFilter', contextValue);
+      } else if (newParams.objectType === ObjectType.WritingSystem) {
+        next.set('languageFilter', contextValue);
+      }
+    }
   }
 
   return next;


### PR DESCRIPTION
## Summary
fix issue #322 
Preserve searchString and objectID by mapping them to appropriate filters when objectType changes

- [x] Clear description of what and why
- [x] Scope kept focused; note follow-ups if any
- [x] Set yourself as assignee
- [x] Mention the issue (usually by writing "Fixes #ISSUE_NUMBER" or "Closes #ISSUE_NUMBER") 
  - [n/a] If there is no issue, create one in [the repository issues page](https://github.com/Translation-Commons/lang-nav/issues) and link it here.

## Testing

- [x] `npm run lint`
- [x] `npm run test`
  - [x] Tests added or updated for changed logic
- [x] `npm run build`
- [ ] Write comments on manual testing how you tested in this PR
- [x ] Include screenshots in the changes section below

## Changes

### Visual changes

- [ ] Add before and after screenshots in the table below.
  - [ ] Drag and drop images in the GitHub PR comment box to upload screenshots
- [ ] Purely new views can just include the "after" screenshot.
- [ ] Since more views can be reproduced by just sharing the URL -- add links (eg. [link](https://translation-commons.github.io/lang-nav/data)) to the relevant page and/or conditions to reproduce the view.

| Page/View | Changes | Before | After |
| --------- | ------- | ------ | ----- |
|           |         |        |       |
|           |         |        |       |

### Data changes

- [ ] TSV, SVG, etc. edits in `public/data/`
- [ ] Corresponding readmes updated in `public/data/`
- [ ] Load/connect/compute updates in `src/features/data/`

### Internal changes

- [x ] Logical changes
- [ ] Refactors, moving files around
- [ ] If you notice any changes that require explanations, make sure to include the explanations in the code as well.

## Docs

- [ ] Updated markdown readme files documenting how the code behaves or how to develop in case there are any relevant changes to make.

