### PR TITLE
Filters: filter by language modality (#381)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -503,6 +504,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -544,6 +546,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1865,8 +1868,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1948,6 +1950,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1957,6 +1960,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1966,6 +1970,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2010,6 +2015,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.48.0.tgz",
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -2365,6 +2371,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2726,6 +2733,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3226,8 +3234,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3521,6 +3528,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3580,6 +3588,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5211,6 +5220,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.2.0.tgz",
       "integrity": "sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.23",
         "@asamuzakjp/dom-selector": "^6.7.4",
@@ -5397,7 +5407,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5537,6 +5546,7 @@
       "integrity": "sha512-/5rpGC0eK8LlFqsHaBmL19/PVKxu/CCt8pO1vzp9X6SDLsRDh/Ccudkf3Ur5lyaKxJz9ndAx+LaThdv0ySqB6A==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.40.0",
@@ -6047,6 +6057,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.2.tgz",
       "integrity": "sha512-n3HV2J6QhItCXndGa3oMWvWFAgN1ibnS7R9mt6iokScBOC0Ul9/iZORmU2IWUMcyAQaMPjTlY3uT34TqocUxMA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6074,7 +6085,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6089,7 +6099,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6147,6 +6156,7 @@
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6155,6 +6165,7 @@
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6185,8 +6196,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -7098,6 +7108,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7349,6 +7360,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7466,6 +7478,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7579,6 +7592,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7591,6 +7605,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/src/features/params/PageParamTypes.tsx
+++ b/src/features/params/PageParamTypes.tsx
@@ -2,6 +2,7 @@ import { ColorBy, ColorGradient } from '@features/transforms/coloring/ColorTypes
 import { ScaleBy } from '@features/transforms/scales/ScaleTypes';
 import { SortBehavior, SortBy } from '@features/transforms/sorting/SortTypes';
 
+import { LanguageModality } from '@entities/language/LanguageModality';
 import { LanguageScope, LanguageSource } from '@entities/language/LanguageTypes';
 import {
   LanguageISOStatus,
@@ -67,6 +68,7 @@ export enum PageParamKey {
   languageFilter = 'languageFilter',
   languageSource = 'languageSource',
   languageScopes = 'languageScopes',
+  modalityFilter = 'modalityFilter',
   limit = 'limit',
   localeSeparator = 'localeSeparator',
   objectID = 'objectID',
@@ -94,6 +96,7 @@ export type PageParams = {
   isoStatus: LanguageISOStatus[];
   languageFilter: string;
   languageScopes: LanguageScope[];
+  modalityFilter: LanguageModality[];
   languageSource: LanguageSource;
   limit: number; // < 1 means show all
   localeSeparator: LocaleSeparator;
@@ -121,6 +124,7 @@ export type PageParamsOptional = {
   isoStatus?: LanguageISOStatus[];
   languageFilter?: string;
   languageScopes?: LanguageScope[];
+  modalityFilter?: LanguageModality[];
   languageSource?: LanguageSource;
   limit?: number;
   localeSeparator?: LocaleSeparator;

--- a/src/features/params/Profiles.tsx
+++ b/src/features/params/Profiles.tsx
@@ -43,6 +43,7 @@ const GLOBAL_DEFAULTS: PageParams = {
   isoStatus: [],
   languageFilter: '',
   languageScopes: [LanguageScope.Macrolanguage, LanguageScope.Language],
+  modalityFilter: [],
   languageSource: LanguageSource.Combined,
   limit: 12,
   localeSeparator: LocaleSeparator.Underscore,

--- a/src/features/params/getParamsFromURL.ts
+++ b/src/features/params/getParamsFromURL.ts
@@ -3,6 +3,7 @@ import { ColorBy, ColorGradient } from '@features/transforms/coloring/ColorTypes
 import { ScaleBy } from '@features/transforms/scales/ScaleTypes';
 import { SortBehavior, SortBy } from '@features/transforms/sorting/SortTypes';
 
+import { LanguageModality } from '@entities/language/LanguageModality';
 import { LanguageScope, LanguageSource } from '@entities/language/LanguageTypes';
 import {
   VitalityEthnologueCoarse,
@@ -55,6 +56,9 @@ export function getParamsFromURL(urlParams: URLSearchParams): PageParamsOptional
       case PageParamKey.languageScopes:
         if (value === '[]') params.languageScopes = [];
         else params.languageScopes = value.split(',').filter(Boolean) as LanguageScope[];
+        break;
+      case PageParamKey.modalityFilter:
+        params.modalityFilter = parseNumericEnumArray(value, LanguageModality);
         break;
       case PageParamKey.territoryScopes:
         if (value === '[]') params[key] = [];

--- a/src/features/table/__tests__/InteractiveObjectTable.test.tsx
+++ b/src/features/table/__tests__/InteractiveObjectTable.test.tsx
@@ -22,6 +22,7 @@ vi.mock('@features/transforms/filtering/filter', () => ({
   getFilterByVitality: vi.fn(),
   getScopeFilter: vi.fn(),
   getFilterByLanguageScope: vi.fn(),
+  getFilterByModality: vi.fn(),
   getFilterByTerritoryScope: vi.fn(),
 }));
 
@@ -93,6 +94,7 @@ describe('InteractiveObjectTable', () => {
     vi.mocked(ConnectionFilters.getFilterByConnections).mockReturnValue(() => true);
     vi.mocked(FilterModule.getFilterByVitality).mockReturnValue(() => true);
     vi.mocked(FilterModule.getFilterByLanguageScope).mockReturnValue(() => true);
+    vi.mocked(FilterModule.getFilterByModality).mockReturnValue(() => true);
     vi.mocked(FilterModule.getFilterByTerritoryScope).mockReturnValue(() => true);
     vi.mocked(FilterModule.getScopeFilter).mockReturnValue(() => true);
     vi.mocked(SortModule.getSortFunction).mockReturnValue(() => 0);

--- a/src/features/transforms/filtering/FilterBreakdown.tsx
+++ b/src/features/transforms/filtering/FilterBreakdown.tsx
@@ -9,7 +9,12 @@ import { ObjectData } from '@entities/types/DataTypes';
 
 import getFilterBySubstring from '../search/getFilterBySubstring';
 
-import { getFilterByLanguageScope, getFilterByTerritoryScope, getFilterByVitality } from './filter';
+import {
+  getFilterByLanguageScope,
+  getFilterByModality,
+  getFilterByTerritoryScope,
+  getFilterByVitality,
+} from './filter';
 import {
   getFilterByLanguage,
   getFilterByTerritory,
@@ -32,12 +37,14 @@ const FilterBreakdown: React.FC<FilterExplanationProps> = ({
   const filterByWritingSystem = getFilterByWritingSystem();
   const filterByLanguage = getFilterByLanguage();
   const filterByLanguageScope = getFilterByLanguageScope();
+  const filterByModality = getFilterByModality();
   const filterByTerritoryScope = getFilterByTerritoryScope();
   const filterByVitality = getFilterByVitality();
   const filterLabels = getFilterLabels();
 
   const [
     nInLanguageScope,
+    nInModality,
     nInTerritoryScope,
     nInTerritory,
     nWrittenIn,
@@ -46,7 +53,8 @@ const FilterBreakdown: React.FC<FilterExplanationProps> = ({
     nMatchingSubstring,
   ] = useMemo(() => {
     const filteredByLanguageScope = objects.filter(filterByLanguageScope);
-    const filteredByTerritoryScope = filteredByLanguageScope.filter(filterByTerritoryScope);
+    const filteredByModality = filteredByLanguageScope.filter(filterByModality);
+    const filteredByTerritoryScope = filteredByModality.filter(filterByTerritoryScope);
     const filteredByTerritory = filteredByTerritoryScope.filter(filterByTerritory);
     const filteredByWritingSystem = filteredByTerritory.filter(filterByWritingSystem);
     const filteredByLanguage = filteredByWritingSystem.filter(filterByLanguage);
@@ -54,6 +62,7 @@ const FilterBreakdown: React.FC<FilterExplanationProps> = ({
     const filteredBySubstring = filteredByVitality.filter(filterBySubstring);
     return [
       filteredByLanguageScope.length,
+      filteredByModality.length,
       filteredByTerritoryScope.length,
       filteredByTerritory.length,
       filteredByWritingSystem.length,
@@ -64,6 +73,7 @@ const FilterBreakdown: React.FC<FilterExplanationProps> = ({
   }, [
     objects,
     filterByLanguageScope,
+    filterByModality,
     filterByTerritoryScope,
     filterByTerritory,
     filterByWritingSystem,
@@ -74,7 +84,8 @@ const FilterBreakdown: React.FC<FilterExplanationProps> = ({
 
   const nOverall = objects.length;
   const nFilteredByLanguageScope = nOverall - nInLanguageScope;
-  const nFilteredByTerritoryScope = nInLanguageScope - nInTerritoryScope;
+  const nFilteredByModality = nInLanguageScope - nInModality;
+  const nFilteredByTerritoryScope = nInModality - nInTerritoryScope;
   const nFilteredByTerritory = nInTerritoryScope - nInTerritory;
   const nFilteredByWritingSystem = nInTerritory - nWrittenIn;
   const nFilteredByLanguage = nWrittenIn - nWithLanguage;
@@ -103,6 +114,22 @@ const FilterBreakdown: React.FC<FilterExplanationProps> = ({
                 buttonType="reset"
                 hoverContent="Clear the language scope filter"
                 onClick={() => updatePageParams({ languageScopes: [] })}
+                style={{ padding: '0.25em', marginLeft: '0.25em' }}
+              >
+                <XIcon size="1em" display="block" />
+              </HoverableButton>
+            </td>
+          </tr>
+        )}
+        {nFilteredByModality > 0 && (
+          <tr>
+            <td>Not {filterLabels.modalityFilter}:</td>
+            <td className="count">{(nFilteredByModality * -1).toLocaleString()}</td>
+            <td>
+              <HoverableButton
+                buttonType="reset"
+                hoverContent="Clear the modality filter"
+                onClick={() => updatePageParams({ modalityFilter: [] })}
                 style={{ padding: '0.25em', marginLeft: '0.25em' }}
               >
                 <XIcon size="1em" display="block" />

--- a/src/features/transforms/filtering/FilterLabels.tsx
+++ b/src/features/transforms/filtering/FilterLabels.tsx
@@ -1,13 +1,22 @@
 import usePageParams from '@features/params/usePageParams';
 
+import { getModalityLabel } from '@entities/language/LanguageModalityDisplay';
+
 export function getFilterLabels() {
   return {
     languageScope: getLanguageScopeLabel(),
+    modalityFilter: getModalityFilterLabel(),
     territoryScope: getTerritoryScopeLabel(),
     territoryFilter: getTerritoryFilterLabel(),
     writingSystemFilter: getWritingSystemFilterLabel(),
     languageFilter: getLanguageFilterLabel(),
   };
+}
+
+function getModalityFilterLabel(): string {
+  const { modalityFilter } = usePageParams();
+  if (modalityFilter.length === 0) return 'any modality';
+  return modalityFilter.map((m) => getModalityLabel(m) ?? 'modality').join(' or ');
 }
 
 function getLanguageScopeLabel(): string {

--- a/src/features/transforms/filtering/FilterPath.tsx
+++ b/src/features/transforms/filtering/FilterPath.tsx
@@ -7,6 +7,8 @@ import { getDefaultParams } from '@features/params/Profiles';
 import Selector from '@features/params/ui/Selector';
 import usePageParams from '@features/params/usePageParams';
 
+import { LanguageModality } from '@entities/language/LanguageModality';
+import { getModalityLabel } from '@entities/language/LanguageModalityDisplay';
 import { LanguageScope } from '@entities/language/LanguageTypes';
 import {
   getLanguageISOStatusLabel,
@@ -30,6 +32,7 @@ const FilterPath: React.FC = () => {
     isoStatus,
     languageFilter,
     languageScopes,
+    modalityFilter,
     searchBy,
     searchString,
     territoryFilter,
@@ -99,6 +102,24 @@ const FilterPath: React.FC = () => {
             : updatePageParams({ languageScopes: [...languageScopes, scope] })
         }
         selected={languageScopes}
+      />
+    ),
+    modalityFilter.length > 0 && (
+      <Selector
+        selectorStyle={{ marginLeft: '0' }}
+        options={Object.values(LanguageModality).filter(
+          (v): v is LanguageModality => typeof v === 'number',
+        )}
+        labelWhenEmpty="Any Modality"
+        getOptionLabel={(v) => getModalityLabel(v) ?? String(v)}
+        onChange={(modality: LanguageModality) =>
+          modalityFilter.includes(modality)
+            ? updatePageParams({
+                modalityFilter: modalityFilter.filter((m) => m !== modality),
+              })
+            : updatePageParams({ modalityFilter: [...modalityFilter, modality] })
+        }
+        selected={modalityFilter}
       />
     ),
     !areArraysIdentical(territoryScopes, defaultParams.territoryScopes) && (

--- a/src/features/transforms/filtering/LanguageModalitySelector.tsx
+++ b/src/features/transforms/filtering/LanguageModalitySelector.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import Selector from '@features/params/ui/Selector';
+import usePageParams from '@features/params/usePageParams';
+
+import { LanguageModality } from '@entities/language/LanguageModality';
+import { getModalityLabel } from '@entities/language/LanguageModalityDisplay';
+
+const MODALITY_OPTIONS_ORDERED: LanguageModality[] = [
+  LanguageModality.Written,
+  LanguageModality.MostlyWritten,
+  LanguageModality.SpokenAndWritten,
+  LanguageModality.MostlySpoken,
+  LanguageModality.Spoken,
+  LanguageModality.Sign,
+];
+
+const LanguageModalitySelector: React.FC = () => {
+  const { modalityFilter, updatePageParams } = usePageParams();
+
+  function getOptionLabel(modality: LanguageModality): string {
+    return getModalityLabel(modality) ?? String(modality);
+  }
+
+  const selectorDescription =
+    'Filter by how the language is primarily used: written, spoken, sign, or a combination.';
+
+  return (
+    <Selector
+      selectorLabel="Modality"
+      labelWhenEmpty="Any"
+      selectorDescription={selectorDescription}
+      options={MODALITY_OPTIONS_ORDERED}
+      onChange={(modality: LanguageModality) =>
+        modalityFilter.includes(modality)
+          ? updatePageParams({
+              modalityFilter: modalityFilter.filter((m) => m !== modality),
+            })
+          : updatePageParams({ modalityFilter: [...modalityFilter, modality] })
+      }
+      selected={modalityFilter}
+      getOptionLabel={getOptionLabel}
+    />
+  );
+};
+
+export default LanguageModalitySelector;

--- a/src/features/transforms/filtering/filter.tsx
+++ b/src/features/transforms/filtering/filter.tsx
@@ -18,12 +18,13 @@ export type FilterFunctionType = (a: ObjectData) => boolean;
  */
 export function getScopeFilter(): FilterFunctionType {
   const filterByLanguageScope = getFilterByLanguageScope();
+  const filterByModality = getFilterByModality();
   const filterByTerritoryScope = getFilterByTerritoryScope();
 
   const filterByScope = useCallback(
     (object: ObjectData): boolean =>
-      filterByLanguageScope(object) && filterByTerritoryScope(object),
-    [filterByLanguageScope, filterByTerritoryScope],
+      filterByLanguageScope(object) && filterByModality(object) && filterByTerritoryScope(object),
+    [filterByLanguageScope, filterByModality, filterByTerritoryScope],
   );
 
   return filterByScope;
@@ -43,6 +44,23 @@ export function getFilterByLanguageScope(): FilterFunctionType {
   );
 
   return filterByLanguageScope;
+}
+
+export function getFilterByModality(): FilterFunctionType {
+  const { modalityFilter } = usePageParams();
+
+  const filterByModality = useCallback(
+    (object: ObjectData | undefined): boolean => {
+      if (modalityFilter.length === 0) return true;
+      if (object?.type === ObjectType.Locale) return filterByModality(object.language);
+      if (object?.type !== ObjectType.Language) return true;
+      const language = object as LanguageData;
+      return language.modality != null && modalityFilter.includes(language.modality);
+    },
+    [modalityFilter],
+  );
+
+  return filterByModality;
 }
 
 export function getFilterByTerritoryScope(): FilterFunctionType {

--- a/src/features/transforms/search/useSearchSuggestions.tsx
+++ b/src/features/transforms/search/useSearchSuggestions.tsx
@@ -6,6 +6,7 @@ import { Suggestion, SUGGESTION_LIMIT } from '@features/params/ui/SelectorSugges
 import usePageParams from '@features/params/usePageParams';
 import {
   getFilterByLanguageScope,
+  getFilterByModality,
   getFilterByTerritoryScope,
 } from '@features/transforms/filtering/filter';
 
@@ -27,6 +28,7 @@ export default function useSearchSuggestions(): (query: string) => Promise<Sugge
   const { censuses, territories, languagesInSelectedSource, locales, writingSystems, variantTags } =
     useDataContext();
   const filterByLanguageScope = getFilterByLanguageScope();
+  const filterByModality = getFilterByModality();
   const filterByTerritoryScope = getFilterByTerritoryScope();
   const filterByWritingSystem = getFilterByWritingSystem();
   const filterByLanguage = getFilterByLanguage();
@@ -66,7 +68,8 @@ export default function useSearchSuggestions(): (query: string) => Promise<Sugge
       if (!filterByWritingSystem(object)) dist += 2;
       if (!filterByTerritory(object)) dist += 4;
       if (!filterByTerritoryScope(object)) dist += 8;
-      if (!filterByLanguageScope(object)) dist += 16;
+      if (!filterByModality(object)) dist += 16;
+      if (!filterByLanguageScope(object)) dist += 32;
       return dist;
     };
     const getMatchGroup = (object: ObjectData): string => {
@@ -74,6 +77,7 @@ export default function useSearchSuggestions(): (query: string) => Promise<Sugge
       if (!filterByWritingSystem(object)) return 'not ' + filterLabels.writingSystemFilter;
       if (!filterByTerritory(object)) return 'not ' + filterLabels.territoryFilter;
       if (!filterByTerritoryScope(object)) return 'not ' + filterLabels.territoryScope;
+      if (!filterByModality(object)) return 'not ' + filterLabels.modalityFilter;
       if (!filterByLanguageScope(object)) return 'not ' + filterLabels.languageScope;
       return 'matched';
     };
@@ -83,6 +87,7 @@ export default function useSearchSuggestions(): (query: string) => Promise<Sugge
     filterByWritingSystem,
     filterByTerritory,
     filterByTerritoryScope,
+    filterByModality,
     filterByLanguageScope,
     filterLabels,
   ]);

--- a/src/widgets/controls/OptionsPanel.tsx
+++ b/src/widgets/controls/OptionsPanel.tsx
@@ -10,6 +10,7 @@ import {
 import ColorBySelector from '@features/transforms/coloring/ColorBySelector';
 import ColorGradientSelector from '@features/transforms/coloring/ColorGradientSelector';
 import LanguageFilterSelector from '@features/transforms/filtering/LanguageFilterSelector';
+import LanguageModalitySelector from '@features/transforms/filtering/LanguageModalitySelector';
 import LanguageScopeSelector from '@features/transforms/filtering/LanguageScopeSelector';
 import TerritoryFilterSelector from '@features/transforms/filtering/TerritoryFilterSelector';
 import TerritoryScopeSelector from '@features/transforms/filtering/TerritoryScopeSelector';
@@ -57,6 +58,7 @@ const OptionsPanel: React.FC = () => {
           <WritingSystemFilterSelector display={SelectorDisplay.ButtonList} />
           <LanguageFilterSelector display={SelectorDisplay.ButtonList} />
           <LanguageScopeSelector />
+          <LanguageModalitySelector />
           <TerritoryScopeSelector />
           <LanguageISOStatusSelector />
           <VitalityEth2013Selector />


### PR DESCRIPTION
Fixes #381

Summary: 
Adds a modality filter so users can filter languages/locales by how they are primarily used (Written, Mostly Written, Spoken & Written, Mostly Spoken, Spoken, Sign). The filter is multi-select, stored in the URL, and follows the same patterns as the Language Scope filter. When no modalities are selected, the filter shows “Any” and does not filter by modality.


### Changes

- User experience
  - New Modality selector in the Options panel (Filter section): multi-select over the 6 modalities; when nothing is selected the control displays “Any”.
  - Modality appears in the filter path when at least one modality is selected; users can change or clear the modality filter there.
  - Filter breakdown includes a “Not [modality]” row when the modality filter removes items, with a clear button that resets modality to “Any”.
  - Search suggestions group results by whether they match the current modality filter.
- Logical changes
  - **Page params**: `modalityFilter` added as `LanguageModality[]` (default [] = Any). Included in `PageParamKey`, `PageParams`, `PageParamsOptional`, `GLOBAL_DEFAULTS`, URL parsing (`getParamsFromURL`), and URL serialization (`getNewURLSearchParams`).
  - **Filter**: `getFilterByModality()` filters Language/Locale by `language.modality`; empty `modalityFilter` means no filtering. Wired into `getScopeFilter()` and used in `FilterBreakdown` and `useSearchSuggestions`.
  - **URL**: `modalityFilter` serialized as comma-separated enum values;  [] or omitted means Any.



### Test Plan and Screenshots

How to test the changes in this PR: 
Options panel: Open Filter → check Modality shows “Any” when empty; select/deselect modalities and list/cards update.
Filter path: With at least one modality selected, confirm the path shows the modality selector; and results update.
Filter breakdown: With a modality filter that excludes items, confirm “Not [modality]” row and that its clear button resets modality to “Any”.
Search: Set a modality filter, type in the search bar, and confirm suggestion groups reflect the modality filter


| Page/View with link | Description of Changes | Screenshot Before | Screenshot After |
| ------------------- | ---------------------- | ----------------- | ---------------- |
|       [Options panel (Filter section)](https://translation-commons.github.io/lang-nav/data)              |       Modality multi-select added                 |       <img width="330" height="687" alt="image" src="https://github.com/user-attachments/assets/78f08347-1546-428d-a061-d0b5c866541f" />   |      <img width="438" height="707" alt="image" src="https://github.com/user-attachments/assets/65e12798-1306-4785-ab8d-28697d303f98" />  |
|            [Filter path (with modality set)](https://translation-commons.github.io/lang-nav/data)         |        Modality appears in path                |   <img width="772" height="128" alt="image" src="https://github.com/user-attachments/assets/4e1c9a6e-a9ee-4cc6-b334-642706da5fbb" />      |    <img width="810" height="131" alt="image" src="https://github.com/user-attachments/assets/f4f6809f-dcb0-4db7-a6ec-07295f77ff73" />     |
|            [Languages list/cards](https://translation-commons.github.io/lang-nav/data)         |        Results filtered by selected modalities                |      <img width="1466" height="782" alt="image" src="https://github.com/user-attachments/assets/a5d514f9-379a-4814-8fae-483b05fc390d" />   |        <img width="1470" height="833" alt="image" src="https://github.com/user-attachments/assets/6a2a37e5-0e14-43c9-9dc4-93fa6e026741" />            |
|            [Search](https://translation-commons.github.io/lang-nav/data)         |           suggestions are grouped based on modality  and the remaining modalities     |     <img width="654" height="413" alt="image" src="https://github.com/user-attachments/assets/1c40e8a2-eb48-41d7-a6fc-7c539063a3df" />   |       <img width="662" height="432" alt="image" src="https://github.com/user-attachments/assets/e3a86895-1806-4c55-a990-0c8953a000eb" />           |     
|            [Filter breakdown ](https://translation-commons.github.io/lang-nav/data)         |       When there are no results you can unselect any filter                |        |       <img width="1071" height="505" alt="image" src="https://github.com/user-attachments/assets/6b8fdd51-5486-4559-af61-9bf729ba442d" />        |     



## Summary

- [x] Clear description of what and why
- [x] Scope kept focused; note follow-ups if any
- [x] Set yourself as assignee
- [x] Mention the issue (Closes #381")
 

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run dev` -- tried out the website directly
  - [x] Include screenshots as noted below
  - [x] Write comments on manual testing

## Changes

### Visual changes

- [x] Add screenshots to the table template at the top of this file. You can include images inside the table
  - [x] Drag and drop images in the GitHub PR comment box to upload screenshots
- [x] Purely new views can just include the "after" screenshot.
- [x] Since more views can be reproduced by just sharing the URL -- add links (eg. [link](https://translation-commons.github.io/lang-nav/data)) to the relevant page and/or conditions to reproduce the view.


### Internal changes

- [x] Logical changes
- [x] Refactors, moving files around
- [x] If you notice any changes that require explanations, make sure to include the explanations in the code as well.

## Docs

- [x] Code is self-documenting, or if not, comments are added where needed.
