### PR TITLE
Fix LocaleCard CardField formatting

### DIFF
--- a/src/entities/locale/LocaleCard.tsx
+++ b/src/entities/locale/LocaleCard.tsx
@@ -1,7 +1,4 @@
-import CardField from '@shared/containers/CardField';
-import Deemphasized from '@shared/ui/Deemphasized';
 import { ActivityIcon, UsersIcon } from 'lucide-react';
-
 import React from 'react';
 
 import usePageParams from '@features/params/usePageParams';
@@ -10,7 +7,9 @@ import { LocaleData } from '@entities/types/DataTypes';
 import ObjectSubtitle from '@entities/ui/ObjectSubtitle';
 import ObjectTitle from '@entities/ui/ObjectTitle';
 
+import CardField from '@shared/containers/CardField';
 import DecimalNumber from '@shared/ui/DecimalNumber';
+import Deemphasized from '@shared/ui/Deemphasized';
 
 import LocaleCensusCitation from './LocaleCensusCitation';
 import LocalePopulationAdjusted from './LocalePopulationAdjusted';


### PR DESCRIPTION
Fixes #404
<img width="1066" height="698" alt="截屏2026-02-10 下午4 51 17" src="https://github.com/user-attachments/assets/57008982-a61d-449b-822a-cb3c239a30f0" />


Updates LocaleCard to use icon-based CardField layout,
matching the pattern introduced in #398.