### PR TITLE
Language Families: Add Depth Field

### DIFF
--- a/src/entities/language/LanguageTypes.ts
+++ b/src/entities/language/LanguageTypes.ts
@@ -119,6 +119,7 @@ export interface LanguageData extends ObjectBase {
 
   latitude?: number;
   longitude?: number;
+  depth?: number; // Computed depth in the language family tree, with 0 being a root language
 
   // References to other objects, filled in after loading the TSV
   locales: LocaleData[];

--- a/src/entities/language/vitality/LanguageVitalityComputation.ts
+++ b/src/entities/language/vitality/LanguageVitalityComputation.ts
@@ -1,7 +1,5 @@
 import { LanguageData } from '@entities/language/LanguageTypes';
 
-import { maxBy } from '@shared/lib/setUtils';
-
 import { VitalitySource } from './VitalityTypes';
 
 /**
@@ -40,53 +38,4 @@ export function getVitalityScore(source: VitalitySource, lang: LanguageData): nu
     case VitalitySource.Metascore:
       return lang.vitality?.meta;
   }
-}
-
-/**
- * Compute derived vitality data for all languages, filling in gaps when it doesn't come
- * directly from a source. For example, Ethnologue doesn't provide vitality for language families
- * or macrolanguages.
- *
- * Re-run this when changing language parent/child relationships since language families may have
- * different compositions.
- */
-export function precomputeLanguageVitality(languages: LanguageData[]): void {
-  // For all language roots, recompute vitality scores
-  languages
-    .filter((lang) => lang.parentLanguage == null)
-    .forEach((lang) => computeLanguageFamilyVitality(lang));
-}
-
-function computeLanguageFamilyVitality(lang: LanguageData, depth = 0): void {
-  if (depth > 40) console.debug('Potential infinite recursion for: ', lang.ID, 'depth: ', depth);
-  if (depth > 50) return;
-
-  // Recursively compute vitality for all descendants first
-  const descendants = lang.childLanguages || [];
-  descendants.forEach((child) => computeLanguageFamilyVitality(child, depth + 1));
-
-  // Now compute vitality for this language
-  const vitality = lang.vitality || {};
-  const Ethnologue = lang.Ethnologue;
-
-  // If it's declared by a source use that, otherwise use its children's max vitality
-  if (lang.ISO.status != null) {
-    vitality.iso = lang.ISO.status;
-  } else {
-    vitality.iso = maxBy(descendants, (child) => child.vitality?.iso);
-  }
-  if (Ethnologue.vitality2012 != null) {
-    vitality.ethFine = Ethnologue.vitality2012;
-  } else {
-    vitality.ethFine = maxBy(descendants, (child) => child.vitality?.ethFine);
-  }
-  if (Ethnologue.vitality2025 != null) {
-    vitality.ethCoarse = Ethnologue.vitality2025;
-  } else {
-    vitality.ethCoarse = maxBy(descendants, (child) => child.vitality?.ethCoarse);
-  }
-
-  // Compute the meta score and store the results in the language object
-  vitality.meta = getVitalityMetascore(lang);
-  lang.vitality = vitality;
 }

--- a/src/entities/language/vitality/__tests__/LanguageVitalityComputation.test.ts
+++ b/src/entities/language/vitality/__tests__/LanguageVitalityComputation.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
+import computeRecursiveLanguageData from '@features/data/compute/computeRecursiveLanguageData';
+
 import {
   getBaseLanguageData,
   LanguageData,
   LanguageVitality,
 } from '@entities/language/LanguageTypes';
 
-import { getVitalityMetascore, precomputeLanguageVitality } from '../LanguageVitalityComputation';
+import { getVitalityMetascore } from '../LanguageVitalityComputation';
 import {
   parseLanguageISOStatus,
   parseVitalityEthnologue2012,
@@ -133,7 +135,7 @@ describe('computeVitalityMetascore', () => {
     expect(metascoreBefore).toBeUndefined();
 
     // Simulate precomputation
-    precomputeLanguageVitality([lang]);
+    computeRecursiveLanguageData([lang]);
     const metascoreAfter = getVitalityMetascore(lang);
     expect(metascoreAfter).toBe(5.5); // (5 + 6) / 2
     expect(lang.vitality?.meta).toBe(5.5);

--- a/src/entities/lib/__tests__/getObjectMiscFields.test.ts
+++ b/src/entities/lib/__tests__/getObjectMiscFields.test.ts
@@ -11,6 +11,7 @@ import {
   getCountOfCensuses,
   getCountOfLanguages,
   getCountOfWritingSystems,
+  getDepth,
   getObjectDate,
   getObjectLiteracy,
   getObjectMostImportantLanguageName,
@@ -199,6 +200,37 @@ describe('getCountOfCensuses', () => {
       sjn_Teng_BE: 0,
       sjn_BE: 1, // in be0590
       sjn_ER: 0, // not in any censuses
+      tolkorth: undefined,
+    });
+  });
+});
+
+describe('getDepth', () => {
+  it('returns depth for objects', () => {
+    const results = Object.fromEntries(
+      Object.values(mockedObjects).map((obj) => [obj.ID, getDepth(obj)]),
+    );
+    expect(results).toEqual({
+      '001': 0, // top-level territory
+      '123': 1, // child of 001
+      AM: 1, // child of 001
+      BE: 2, // child of 123
+      ER: 2, // child of 123
+      HA: 2, // child of 123
+      Teng: 0, // top-level writing system
+      be0590: undefined,
+      dori0123: 1, // child of sjn
+      dori0123_001: 1, // locale with territory
+      dori0123_123: 1,
+      dori0123_ER: 1,
+      sjn: 0, // top-level language
+      sjn_001: 1, // locale with territory
+      sjn_123: 1,
+      sjn_Teng_001: 2, // locale with territory and explicit writing system
+      sjn_Teng_123: 2,
+      sjn_Teng_BE: 2,
+      sjn_ER: 1, // locale with territory
+      sjn_BE: 1,
       tolkorth: undefined,
     });
   });

--- a/src/entities/ui/ObjectDepthDisplay.tsx
+++ b/src/entities/ui/ObjectDepthDisplay.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import ObjectPath from '@widgets/pathnav/ObjectPath';
+
+import Hoverable from '@features/layers/hovercard/Hoverable';
+import { ObjectType } from '@features/params/PageParamTypes';
+
+import { getDepth } from '@entities/lib/getObjectMiscFields';
+import { ObjectData } from '@entities/types/DataTypes';
+
+import Deemphasized from '@shared/ui/Deemphasized';
+
+const ObjectDepthDisplay: React.FC<{
+  object: ObjectData;
+}> = ({ object }) => {
+  if (object.type === ObjectType.Census || object.type === ObjectType.VariantTag)
+    return <Deemphasized>n/a</Deemphasized>;
+
+  const depth = getDepth(object);
+  if (depth == null) return <Deemphasized>Unknown</Deemphasized>;
+
+  return (
+    <Hoverable hoverContent={<ObjectPath object={object} showChildren={false} />}>
+      {depth || 'Root'}
+    </Hoverable>
+  );
+};
+
+export default ObjectDepthDisplay;

--- a/src/features/data/compute/computeRecursiveLanguageData.ts
+++ b/src/features/data/compute/computeRecursiveLanguageData.ts
@@ -1,0 +1,58 @@
+import { LanguageData } from '@entities/language/LanguageTypes';
+import { getVitalityMetascore } from '@entities/language/vitality/LanguageVitalityComputation';
+
+import { maxBy } from '@shared/lib/setUtils';
+
+/**
+ * Compute derived vitality data for all languages, filling in gaps when it doesn't come
+ * directly from a source. For example, Ethnologue doesn't provide vitality for language families
+ * or macrolanguages.
+ *
+ * Re-run this when changing language parent/child relationships since language families may have
+ * different compositions.
+ */
+function computeRecursiveLanguageData(languages: LanguageData[]): void {
+  // For all language roots, recompute vitality scores
+  languages
+    .filter((lang) => lang.parentLanguage == null)
+    .forEach((lang) => computeRecursiveDataOnLanguage(lang));
+}
+
+function computeRecursiveDataOnLanguage(lang: LanguageData, depth = 0): void {
+  if (depth > 40) console.debug('Potential infinite recursion for: ', lang.ID, 'depth: ', depth);
+  if (depth > 50) return;
+
+  // Store the depth
+  lang.depth = depth;
+
+  // Recursively compute vitality for all descendants first
+  const descendants = lang.childLanguages || [];
+  descendants.forEach((child) => computeRecursiveDataOnLanguage(child, depth + 1));
+
+  // Now compute vitality for this language
+  const vitality = lang.vitality || {};
+  const Ethnologue = lang.Ethnologue;
+
+  // If it's declared by a source use that, otherwise use its children's max vitality
+  if (lang.ISO.status != null) {
+    vitality.iso = lang.ISO.status;
+  } else {
+    vitality.iso = maxBy(descendants, (child) => child.vitality?.iso);
+  }
+  if (Ethnologue.vitality2012 != null) {
+    vitality.ethFine = Ethnologue.vitality2012;
+  } else {
+    vitality.ethFine = maxBy(descendants, (child) => child.vitality?.ethFine);
+  }
+  if (Ethnologue.vitality2025 != null) {
+    vitality.ethCoarse = Ethnologue.vitality2025;
+  } else {
+    vitality.ethCoarse = maxBy(descendants, (child) => child.vitality?.ethCoarse);
+  }
+
+  // Compute the meta score and store the results in the language object
+  vitality.meta = getVitalityMetascore(lang);
+  lang.vitality = vitality;
+}
+
+export default computeRecursiveLanguageData;

--- a/src/features/data/compute/updateObjectCodesNameAndPopulation.ts
+++ b/src/features/data/compute/updateObjectCodesNameAndPopulation.ts
@@ -1,11 +1,11 @@
 import { LocaleSeparator } from '@features/params/PageParamTypes';
 
 import { LanguageData, LanguageSource } from '@entities/language/LanguageTypes';
-import { precomputeLanguageVitality } from '@entities/language/vitality/LanguageVitalityComputation';
 import { getLocaleCode } from '@entities/locale/LocaleParsing';
 import { getLocaleName } from '@entities/locale/LocaleStrings';
 import { LocaleData, TerritoryData } from '@entities/types/DataTypes';
 
+import computeRecursiveLanguageData from './computeRecursiveLanguageData';
 import { updatePopulations } from './updatePopulations';
 
 /**
@@ -35,7 +35,7 @@ export function updateObjectCodesNameAndPopulation(
   updateParentsAndDescendants(languages, languageSource);
   updatePopulations(languages, locales, world);
   updateObjectNamesAndCodes(languages, locales, languageSource, localeSeparator);
-  precomputeLanguageVitality(languages);
+  computeRecursiveLanguageData(languages);
 }
 
 // Update parent/child relationships

--- a/src/features/transforms/coloring/getGradientForColorby.ts
+++ b/src/features/transforms/coloring/getGradientForColorby.ts
@@ -41,6 +41,7 @@ function getGradientForColorBy(colorBy: Field): ColorGradient {
     case Field.CountOfCountries:
     case Field.CountOfChildTerritories:
     case Field.CountOfCensuses:
+    case Field.Depth:
       return ColorGradient.SequentialBlue;
 
     default:

--- a/src/features/transforms/fields/Field.ts
+++ b/src/features/transforms/fields/Field.ts
@@ -12,6 +12,7 @@ enum Field {
   Longitude = 'Longitude',
   Date = 'Date',
   Area = 'Area',
+  Depth = 'Depth',
 
   // Vitality metrics
   VitalityMetascore = 'Vitality: Metascore',

--- a/src/features/transforms/fields/FieldApplicability.ts
+++ b/src/features/transforms/fields/FieldApplicability.ts
@@ -13,6 +13,7 @@ function getSpecificFieldsForObjectType(objectType: ObjectType): Field[] {
     case ObjectType.Locale:
       return [
         Field.Endonym,
+        Field.Depth,
         Field.PopulationDirectlySourced,
         Field.Literacy,
         Field.Modality,
@@ -30,6 +31,7 @@ function getSpecificFieldsForObjectType(objectType: ObjectType): Field[] {
     case ObjectType.Territory:
       return [
         Field.Endonym,
+        Field.Depth,
         Field.Literacy,
         Field.CountOfLanguages,
         Field.CountOfWritingSystems,
@@ -49,6 +51,7 @@ function getSpecificFieldsForObjectType(objectType: ObjectType): Field[] {
     case ObjectType.Language:
       return [
         Field.Endonym,
+        Field.Depth,
         Field.Literacy,
         Field.CountOfLanguages,
         Field.CountOfWritingSystems,
@@ -78,6 +81,7 @@ function getSpecificFieldsForObjectType(objectType: ObjectType): Field[] {
     case ObjectType.WritingSystem:
       return [
         Field.Endonym,
+        Field.Depth,
         // Field.Literacy, Data not available yet
         Field.Language,
         Field.CountOfLanguages,
@@ -126,6 +130,7 @@ export function getColorBysApplicableToObjectType(objectType: ObjectType): Field
     Field.Population,
     Field.PopulationDirectlySourced,
     Field.Area,
+    Field.Depth,
     Field.CountOfLanguages,
     Field.CountOfWritingSystems,
     Field.CountOfCountries,
@@ -158,6 +163,7 @@ export function getScaleBysApplicableToObjectType(objectType: ObjectType): Field
     Field.Population,
     Field.PopulationDirectlySourced,
     Field.Area,
+    Field.Depth,
     Field.CountOfLanguages,
     Field.CountOfCountries,
     Field.CountOfChildTerritories,

--- a/src/features/transforms/fields/ObjectFieldDisplay.tsx
+++ b/src/features/transforms/fields/ObjectFieldDisplay.tsx
@@ -7,11 +7,11 @@ import { LanguageModalityIcon } from '@entities/language/LanguageModalityDisplay
 import LanguageVitalityMeter from '@entities/language/vitality/VitalityMeter';
 import { VitalitySource } from '@entities/language/vitality/VitalityTypes';
 import { ObjectData } from '@entities/types/DataTypes';
+import ObjectDepthDisplay from '@entities/ui/ObjectDepthDisplay';
 
 import enforceExhaustiveSwitch from '@shared/lib/enforceExhaustiveness';
 import CountOfPeople from '@shared/ui/CountOfPeople';
 import DecimalNumber from '@shared/ui/DecimalNumber';
-import Deemphasized from '@shared/ui/Deemphasized';
 
 import Field from './Field';
 import getField from './getField';
@@ -76,10 +76,7 @@ const ObjectFieldDisplay: React.FC<Props> = ({ object, field }) => {
       return fieldValue ? new Date(fieldValue).toLocaleDateString() : '';
 
     case Field.Depth:
-      if (typeof fieldValue !== 'number' || fieldValue < 0)
-        return <Deemphasized>Unknown</Deemphasized>;
-      if (fieldValue === 0) return 'Root';
-      return fieldValue.toLocaleString();
+      return <ObjectDepthDisplay object={object} />;
 
     default:
       enforceExhaustiveSwitch(field);

--- a/src/features/transforms/fields/ObjectFieldDisplay.tsx
+++ b/src/features/transforms/fields/ObjectFieldDisplay.tsx
@@ -11,6 +11,7 @@ import { ObjectData } from '@entities/types/DataTypes';
 import enforceExhaustiveSwitch from '@shared/lib/enforceExhaustiveness';
 import CountOfPeople from '@shared/ui/CountOfPeople';
 import DecimalNumber from '@shared/ui/DecimalNumber';
+import Deemphasized from '@shared/ui/Deemphasized';
 
 import Field from './Field';
 import getField from './getField';
@@ -73,6 +74,12 @@ const ObjectFieldDisplay: React.FC<Props> = ({ object, field }) => {
           ? new Date(fieldValue).toLocaleDateString(undefined, { year: 'numeric' })
           : '';
       return fieldValue ? new Date(fieldValue).toLocaleDateString() : '';
+
+    case Field.Depth:
+      if (typeof fieldValue !== 'number' || fieldValue < 0)
+        return <Deemphasized>Unknown</Deemphasized>;
+      if (fieldValue === 0) return 'Root';
+      return fieldValue.toLocaleString();
 
     default:
       enforceExhaustiveSwitch(field);

--- a/src/features/transforms/fields/getField.ts
+++ b/src/features/transforms/fields/getField.ts
@@ -4,6 +4,7 @@ import {
   getCountOfCensuses,
   getCountOfLanguages,
   getCountOfWritingSystems,
+  getDepth,
   getObjectDateAsNumber,
   getObjectLiteracy,
   getObjectMostImportantLanguageName,
@@ -38,7 +39,6 @@ function getField(object: ObjectData, field: Field): string | number | undefined
       return object.nameDisplay;
     case Field.Endonym:
       return object.nameEndonym;
-
     // Counts of Related Objects
     case Field.CountOfLanguages:
       return getCountOfLanguages(object);
@@ -51,6 +51,8 @@ function getField(object: ObjectData, field: Field): string | number | undefined
     case Field.CountOfCensuses:
       return getCountOfCensuses(object);
 
+    case Field.Depth:
+      return getDepth(object);
     case Field.Literacy:
       return getObjectLiteracy(object);
     case Field.Date:

--- a/src/features/transforms/fields/rangeUtils.ts
+++ b/src/features/transforms/fields/rangeUtils.ts
@@ -3,6 +3,7 @@ import { VitalityEthnologueCoarse } from '@entities/language/vitality/VitalityTy
 import { ObjectData } from '@entities/types/DataTypes';
 
 import enforceExhaustiveSwitch from '@shared/lib/enforceExhaustiveness';
+import { maxBy } from '@shared/lib/setUtils';
 import { convertAlphaToNumber } from '@shared/lib/stringUtils';
 
 import Field from './Field';
@@ -35,6 +36,7 @@ export function getMinimumValue(field?: Field): number {
     case Field.CountOfChildTerritories:
     case Field.CountOfCensuses:
     case Field.Area:
+    case Field.Depth:
       return 0;
     case Field.None:
       return 0;
@@ -84,9 +86,8 @@ export function getMaximumValue(objects: ObjectData[], field?: Field): number {
     case Field.PopulationOfDescendants:
     case Field.PopulationPercentInBiggestDescendantLanguage:
     case Field.Area:
-      return Math.max(
-        objects.reduce((acc, obj) => Math.max(acc, (getField(obj, field) as number) || 0), 0),
-      );
+    case Field.Depth:
+      return maxBy(objects, (obj) => (getField(obj, field) as number) || 0) || 0;
     case Field.Name:
     case Field.Endonym:
     case Field.Code:

--- a/src/features/transforms/sorting/__tests__/sortMocks.test.tsx
+++ b/src/features/transforms/sorting/__tests__/sortMocks.test.tsx
@@ -11,6 +11,35 @@ import { SortBehavior } from '../SortTypes';
 const mockedObjects = getFullyInstantiatedMockedObjects();
 
 describe('getSortByParameterized', () => {
+  it('sortBy: None', () => {
+    const objects = Object.values(mockedObjects) as ObjectData[];
+    const sort = getSortFunctionParameterized(Field.None, SortBehavior.Normal);
+    expect(objects.sort(sort).map((obj) => obj.ID)).toEqual([
+      // Original input order
+      '123',
+      'sjn',
+      'dori0123',
+      'BE',
+      'ER',
+      'HA',
+      'AM',
+      '001',
+      'be0590',
+      'sjn_BE',
+      'sjn_ER',
+      'dori0123_ER',
+      'Teng',
+      'sjn_Teng_BE',
+      'tolkorth',
+      'sjn_123',
+      'sjn_Teng_123',
+      'dori0123_123',
+      'sjn_001',
+      'sjn_Teng_001',
+      'dori0123_001',
+    ]);
+  });
+
   it('sortBy: Code', () => {
     const objects = Object.values(mockedObjects) as ObjectData[];
     const sort = getSortFunctionParameterized(Field.Code, SortBehavior.Normal);
@@ -627,6 +656,41 @@ describe('getSortByParameterized', () => {
       // All below undefined, stable to input order
       'be0590',
       'Teng',
+      'tolkorth',
+    ]);
+  });
+
+  it('sortBy: Depth', () => {
+    const objects = Object.values(mockedObjects) as ObjectData[];
+    const sort = getSortFunctionParameterized(Field.Depth, SortBehavior.Normal);
+    expect(objects.sort(sort).map((obj) => obj.ID)).toEqual([
+      // Depth 0 (root nodes)
+      'sjn',
+      '001',
+      'Teng',
+
+      // Depth 1
+      '123',
+      'dori0123',
+      'AM',
+      'sjn_BE',
+      'sjn_ER',
+      'dori0123_ER',
+      'sjn_123',
+      'dori0123_123',
+      'sjn_001',
+      'dori0123_001',
+      'BE',
+      'ER',
+      'HA',
+
+      // Depth 2
+      'sjn_Teng_BE',
+      'sjn_Teng_123',
+      'sjn_Teng_001',
+
+      // Undefined depth, stable to input order
+      'be0590',
       'tolkorth',
     ]);
   });

--- a/src/features/transforms/sorting/__tests__/sortVitality.test.tsx
+++ b/src/features/transforms/sorting/__tests__/sortVitality.test.tsx
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
+import computeRecursiveLanguageData from '@features/data/compute/computeRecursiveLanguageData';
 import { ObjectType } from '@features/params/PageParamTypes';
 import Field from '@features/transforms/fields/Field';
 
 import { getBaseLanguageData, LanguageCode, LanguageData } from '@entities/language/LanguageTypes';
-import { precomputeLanguageVitality } from '@entities/language/vitality/LanguageVitalityComputation';
 import {
   LanguageISOStatus,
   VitalityEthnologueCoarse,
@@ -44,7 +44,7 @@ describe('Vitality Sorting', () => {
         createLanguageWithVitality('fr', 'French', { eth2012: VitalityEthnologueFine.Threatened }), // 4
         createLanguageWithVitality('es', 'Spanish', { eth2012: VitalityEthnologueFine.Shifting }), // 3
       ];
-      precomputeLanguageVitality(langs);
+      computeRecursiveLanguageData(langs);
 
       const sortFn = getSortFunctionParameterized(Field.VitalityMetascore, SortBehavior.Normal);
       const sorted = [...langs].sort(sortFn);
@@ -59,7 +59,7 @@ describe('Vitality Sorting', () => {
         createLanguageWithVitality('en', 'English', {}), // no data = -1
         createLanguageWithVitality('fr', 'French', { eth2012: VitalityEthnologueFine.Threatened }), // 4
       ];
-      precomputeLanguageVitality(langs);
+      computeRecursiveLanguageData(langs);
 
       const sortFn = getSortFunctionParameterized(Field.VitalityMetascore, SortBehavior.Normal);
       const sorted = [...langs].sort(sortFn);
@@ -77,7 +77,7 @@ describe('Vitality Sorting', () => {
       langs[0].populationEstimate = 100;
       langs[1].populationEstimate = 300;
       langs[2].populationEstimate = 200;
-      precomputeLanguageVitality(langs);
+      computeRecursiveLanguageData(langs);
 
       const sortFn = getSortFunctionParameterized(
         Field.VitalityMetascore,
@@ -106,7 +106,7 @@ describe('Vitality Sorting', () => {
         population: 0,
         populationFromUN: 0,
       };
-      precomputeLanguageVitality([lang]);
+      computeRecursiveLanguageData([lang]);
 
       const sortFn = getSortFunctionParameterized(Field.VitalityMetascore, SortBehavior.Normal);
       const sorted = [territory, lang].sort(sortFn);

--- a/src/features/transforms/sorting/sort.tsx
+++ b/src/features/transforms/sorting/sort.tsx
@@ -77,6 +77,7 @@ export function getNormalSortDirection(sortBy: Field): SortDirection {
     case Field.Longitude:
     case Field.Latitude:
     case Field.Modality:
+    case Field.Depth:
       return SortDirection.Ascending; // A to Z
     case Field.Date:
     case Field.Population:

--- a/src/widgets/details/DetailsPanel.tsx
+++ b/src/widgets/details/DetailsPanel.tsx
@@ -34,7 +34,7 @@ const DetailsPanel: React.FC = () => {
     >
       <DetailsBody>
         <PathContainer style={{ marginTop: '0.5em' }}>
-          <ObjectPath />
+          <ObjectPath object={object} />
         </PathContainer>
         <Suspense fallback={<Loading />}>{object && <ObjectDetails object={object} />}</Suspense>
         {!object && (

--- a/src/widgets/pathnav/ObjectPath.tsx
+++ b/src/widgets/pathnav/ObjectPath.tsx
@@ -6,15 +6,16 @@ import { ObjectType } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 
 import { LanguageSource } from '@entities/language/LanguageTypes';
-import getObjectFromID from '@entities/lib/getObjectFromID';
 import { ObjectData } from '@entities/types/DataTypes';
 
 import ObjectPathChildren from './ObjectPathChildren';
 import ObjectPathParents from './ObjectPathParents';
 
-const ObjectPath: React.FC = () => {
-  const { objectID, languageSource } = usePageParams();
-  const object = getObjectFromID(objectID);
+const ObjectPath: React.FC<{ object: ObjectData | undefined; showChildren?: boolean }> = ({
+  object,
+  showChildren = true,
+}) => {
+  const { languageSource } = usePageParams();
   if (!object) return null;
   if (object.type === ObjectType.Language) {
     // Not all language sources have parent/child data
@@ -36,7 +37,7 @@ const ObjectPath: React.FC = () => {
     <>
       <ObjectPathParents object={object} />
       <ObjectName object={object} />
-      <ObjectPathChildren object={object} />
+      {showChildren && <ObjectPathChildren object={object} />}
     </>
   );
 };

--- a/src/widgets/tables/LanguageTable.tsx
+++ b/src/widgets/tables/LanguageTable.tsx
@@ -13,7 +13,6 @@ import TableColumn from '@features/table/TableColumn';
 import TableID from '@features/table/TableID';
 import TableValueType from '@features/table/TableValueType';
 import Field from '@features/transforms/fields/Field';
-import ObjectFieldDisplay from '@features/transforms/fields/ObjectFieldDisplay';
 
 import {
   getLanguageRootLanguageFamily,
@@ -27,6 +26,7 @@ import LanguagePluralCategories from '@entities/language/plurals/LanguagePluralC
 import LanguagePluralRuleExamplesGrid from '@entities/language/plurals/LanguagePluralGrid';
 import { getObjectLiteracy } from '@entities/lib/getObjectMiscFields';
 import { getCountriesInObject } from '@entities/lib/getObjectRelatedTerritories';
+import ObjectDepthDisplay from '@entities/ui/ObjectDepthDisplay';
 
 import CommaSeparated from '@shared/ui/CommaSeparated';
 import Deemphasized from '@shared/ui/Deemphasized';
@@ -100,16 +100,6 @@ const LanguageTable: React.FC = () => {
         columnGroup: 'Relations',
       },
       {
-        key: 'Depth',
-        description: 'How deep in a language family tree this language is.',
-        render: (lang) => <ObjectFieldDisplay object={lang} field={Field.Depth} />,
-        exportValue: (lang) => lang.depth ?? '', // Export as blank instead of "—"
-        isInitiallyVisible: false,
-        valueType: TableValueType.Count,
-        field: Field.Depth,
-        columnGroup: 'Relations',
-      },
-      {
         key: 'Dialects',
         render: (lang) => (
           <HoverableEnumeration
@@ -121,6 +111,16 @@ const LanguageTable: React.FC = () => {
         valueType: TableValueType.Count,
         isInitiallyVisible: false,
         field: Field.CountOfLanguages,
+        columnGroup: 'Relations',
+      },
+      {
+        key: 'Depth',
+        description: 'How deep in a language family tree this language is.',
+        render: (lang) => <ObjectDepthDisplay object={lang} />,
+        exportValue: (lang) => lang.depth ?? '', // Export as blank instead of "—"
+        isInitiallyVisible: false,
+        valueType: TableValueType.Count,
+        field: Field.Depth,
         columnGroup: 'Relations',
       },
       {

--- a/src/widgets/tables/LanguageTable.tsx
+++ b/src/widgets/tables/LanguageTable.tsx
@@ -13,6 +13,7 @@ import TableColumn from '@features/table/TableColumn';
 import TableID from '@features/table/TableID';
 import TableValueType from '@features/table/TableValueType';
 import Field from '@features/transforms/fields/Field';
+import ObjectFieldDisplay from '@features/transforms/fields/ObjectFieldDisplay';
 
 import {
   getLanguageRootLanguageFamily,
@@ -96,6 +97,16 @@ const LanguageTable: React.FC = () => {
         key: 'Language Family',
         render: (lang) => <HoverableObjectName object={getLanguageRootLanguageFamily(lang)} />,
         isInitiallyVisible: false,
+        columnGroup: 'Relations',
+      },
+      {
+        key: 'Depth',
+        description: 'How deep in a language family tree this language is.',
+        render: (lang) => <ObjectFieldDisplay object={lang} field={Field.Depth} />,
+        exportValue: (lang) => lang.depth ?? '', // Export as blank instead of "—"
+        isInitiallyVisible: false,
+        valueType: TableValueType.Count,
+        field: Field.Depth,
         columnGroup: 'Relations',
       },
       {


### PR DESCRIPTION
Fixes #350 

Summary: When managing language families it is useful to measure object depth. We already compute it when we prevent recursion from becoming too much -- might as well make it a value we can sort by, color by, etc.

### Changes

- User experience
  - New Field: Depth, an option for sorting, coloring, and scaling
  - ObjectDepthDisplay added, currently viewable in the table view & tree list view
- Refactors
  - Since I added to it, I moved the recursive vitality computation to its own file from src/entities/language/vitality/LanguageVitalityComputation.ts to src/features/data/compute/computeRecursiveLanguageData.ts

### Test Plan and Screenshots

See it in the language table http://localhost:5173/lang-nav/data?view=Table&columns=1-70jyhu69
<img width="931" height="490" alt="Screenshot 2026-02-10 at 20 01 43" src="https://github.com/user-attachments/assets/7fe0e501-98c6-46d3-acee-07f682e64c5b" />

And see it in the map, note that languages in Sub-Saharan Africa have a lot more depth from being categorized in linguistic hierarchies. http://localhost:5173/lang-nav/data?view=Map&limit=-1&colorBy=Depth
<img width="889" height="557" alt="Screenshot 2026-02-10 at 19 52 53" src="https://github.com/user-attachments/assets/f9ad9628-6eb0-4e82-83a7-90bdfae8600f" />
