### PR TITLE
Add icons to TerritoryCard fields

### DIFF
--- a/src/entities/territory/TerritoryCard.tsx
+++ b/src/entities/territory/TerritoryCard.tsx
@@ -68,7 +68,7 @@ const TerritoryCard: React.FC<Props> = ({ territory }) => {
         {sovereign ? (
           <HoverableObjectName object={sovereign} />
         ) : (
-          <Deemphasized>Unknown</Deemphasized>
+          <Deemphasized>Independent</Deemphasized>
         )}
       </CardField>
     </div>


### PR DESCRIPTION
Fixes #405 
<img width="781" height="592" alt="截屏2026-02-11 下午12 10 51" src="https://github.com/user-attachments/assets/b82e0328-d073-44c4-bc0a-e4d04672671e" />

Updates TerritoryCard to use icon-based CardField layout,
matching the pattern introduced in https://github.com/Translation-Commons/lang-nav/pull/398.