### PR TITLE
Add icons to LocaleCard fields

### DIFF
--- a/src/entities/locale/LocaleCard.tsx
+++ b/src/entities/locale/LocaleCard.tsx
@@ -35,7 +35,7 @@ const LocaleCard: React.FC<Props> = ({ locale }) => {
         <CardField
           title="Population"
           icon={UsersIcon}
-          description="How many people live in this locale (with citation)."
+          description="How many people in this territory that use this language. Adjusted to 2025 population and including citation."
         >
           <LocalePopulationAdjusted locale={locale} />
           {' ['}


### PR DESCRIPTION
Fixes #404 

<img width="781" height="592" alt="404" src="https://github.com/user-attachments/assets/38c4b210-f077-4886-a649-14a120ed8961" />

Updates LocaleCard to use icon-based CardField layout, matching the pattern introduced in https://github.com/Translation-Commons/lang-nav/pull/398.