### PR TITLE
Break up Data Type files

### DIFF
--- a/public/data/locales.tsv
+++ b/public/data/locales.tsv
@@ -10618,3 +10618,12 @@ wol_Gara_SN	Wolof (Senegal, Garay)
 zag_Berf_TD	Zaghawa (Chad, Beria Erfe)				
 swh_KE	Coastal Swahili (Kenya)			16134247	
 kuj_KE	Kuria (Kenya)			349478	
+aij_IQ	Neo-Aramaic (Iraq)				
+aij_IR	Neo-Aramaic (Iran)				
+bjf_IQ	Barzani Jewish Neo-Aramaic (Iraq)				
+huy_IQ	Hulaulá (Iraq)				
+yhd_IQ	Judeo-Iraqi Arabic (Iraq)				
+ido_NL	Ido (Netherlands)				
+ido_FR	Ido (France)				
+ina_US	Interlingua (United States)				
+tok_CA	Toki Pona (Canada)				

--- a/src/entities/census/CensusCountForLocale.tsx
+++ b/src/entities/census/CensusCountForLocale.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Hoverable from '@features/layers/hovercard/Hoverable';
 
-import { LocaleData } from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
 
 import Deemphasized from '@shared/ui/Deemphasized';
 

--- a/src/entities/census/CensusCountForTerritory.tsx
+++ b/src/entities/census/CensusCountForTerritory.tsx
@@ -4,7 +4,7 @@ import Hoverable from '@features/layers/hovercard/Hoverable';
 import { ObjectType, View } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 
-import { TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import Deemphasized from '@shared/ui/Deemphasized';
 

--- a/src/entities/census/CensusRecordsForLocale.tsx
+++ b/src/entities/census/CensusRecordsForLocale.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 
-import { LocaleData } from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
 
 import CountOfPeople from '@shared/ui/CountOfPeople';
 

--- a/src/entities/census/CensusTypes.tsx
+++ b/src/entities/census/CensusTypes.tsx
@@ -1,7 +1,9 @@
 import { ObjectType } from '@features/params/PageParamTypes';
 
+import { TerritoryCode, TerritoryData } from '@entities/territory/TerritoryTypes';
+
 import { LanguageCode } from '../language/LanguageTypes';
-import { ObjectBase, TerritoryCode, TerritoryData } from '../types/DataTypes';
+import { ObjectBase } from '../types/DataTypes';
 
 // Unique identifier for the census or other source of population data
 export type CensusID = string; // eg. 'ca2021.2', 'us2013.1'

--- a/src/entities/census/CensusesInTerritory.tsx
+++ b/src/entities/census/CensusesInTerritory.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 
-import { TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import { getCensusCollectorTypeRank } from './CensusTypes';
 

--- a/src/entities/language/LanguageCard.tsx
+++ b/src/entities/language/LanguageCard.tsx
@@ -13,7 +13,7 @@ import usePageParams from '@features/params/usePageParams';
 import { getSortFunction } from '@features/transforms/sorting/sort';
 
 import { LanguageData } from '@entities/language/LanguageTypes';
-import { TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
 import ObjectSubtitle from '@entities/ui/ObjectSubtitle';
 import ObjectTitle from '@entities/ui/ObjectTitle';
 

--- a/src/entities/language/LanguageTypes.ts
+++ b/src/entities/language/LanguageTypes.ts
@@ -8,16 +8,12 @@ import React from 'react';
 import { RetirementReason } from '@features/data/load/extra_entities/ISORetirements';
 import { ObjectType } from '@features/params/PageParamTypes';
 
+import { LocaleData, PopulationSourceCategory } from '@entities/locale/LocaleTypes';
+import { VariantTagData } from '@entities/varianttag/VariantTagTypes';
+import { ScriptCode, WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
+
 import { CLDRCoverageData } from '../types/CLDRTypes';
-import {
-  LocaleData,
-  ObjectBase,
-  PopulationSourceCategory,
-  ScriptCode,
-  VariantTagData,
-  WikipediaData,
-  WritingSystemData,
-} from '../types/DataTypes';
+import { ObjectBase, WikipediaData } from '../types/DataTypes';
 
 import { LanguageModality } from './LanguageModality';
 import {

--- a/src/entities/language/population/LanguagePopulationBreakdownButton.tsx
+++ b/src/entities/language/population/LanguagePopulationBreakdownButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import HoverableButton from '@features/layers/hovercard/HoverableButton';
 
-import { PopulationSourceCategory } from '@entities/types/DataTypes';
+import { PopulationSourceCategory } from '@entities/locale/LocaleTypes';
 
 import { LanguageData } from '../LanguageTypes';
 

--- a/src/entities/language/population/LanguagePopulationEstimate.tsx
+++ b/src/entities/language/population/LanguagePopulationEstimate.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Hoverable from '@features/layers/hovercard/Hoverable';
 
-import { PopulationSourceCategory } from '@entities/types/DataTypes';
+import { PopulationSourceCategory } from '@entities/locale/LocaleTypes';
 
 import CountOfPeople from '@shared/ui/CountOfPeople';
 import Deemphasized from '@shared/ui/Deemphasized';

--- a/src/entities/language/population/LanguagePopulationFromLocales.tsx
+++ b/src/entities/language/population/LanguagePopulationFromLocales.tsx
@@ -7,7 +7,7 @@ import { ObjectType, View } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 import { sortByPopulation } from '@features/transforms/sorting/sort';
 
-import { TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
 
 import CellPopulation from '@shared/containers/CellPopulation';
 import { groupBy, sumBy } from '@shared/lib/setUtils';

--- a/src/entities/lib/getObjectMiscFields.ts
+++ b/src/entities/lib/getObjectMiscFields.ts
@@ -4,7 +4,9 @@ import { ObjectType } from '@features/params/PageParamTypes';
 import { sortByPopulation } from '@features/transforms/sorting/sort';
 
 import { LanguageData } from '@entities/language/LanguageTypes';
-import { ObjectData, TerritoryScope, WritingSystemData } from '@entities/types/DataTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
+import { ObjectData } from '@entities/types/DataTypes';
+import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 import enforceExhaustiveSwitch from '@shared/lib/enforceExhaustiveness';
 import { sumBy, uniqueBy } from '@shared/lib/setUtils';

--- a/src/entities/lib/getObjectRelatedTerritories.ts
+++ b/src/entities/lib/getObjectRelatedTerritories.ts
@@ -15,14 +15,14 @@ import { ObjectType } from '@features/params/PageParamTypes';
 import { sortByPopulation } from '@features/transforms/sorting/sort';
 
 import { LanguageData } from '@entities/language/LanguageTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
 import {
   isTerritoryGroup,
-  LocaleData,
-  ObjectData,
   TerritoryData,
   TerritoryScope,
-  WritingSystemData,
-} from '@entities/types/DataTypes';
+} from '@entities/territory/TerritoryTypes';
+import { ObjectData } from '@entities/types/DataTypes';
+import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 import { uniqueBy } from '@shared/lib/setUtils';
 

--- a/src/entities/locale/LocaleCard.tsx
+++ b/src/entities/locale/LocaleCard.tsx
@@ -1,7 +1,7 @@
 import { BracketsIcon, LandmarkIcon, PercentIcon, UsersIcon } from 'lucide-react';
 import React from 'react';
 
-import { LocaleData } from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
 import ObjectSubtitle from '@entities/ui/ObjectSubtitle';
 import ObjectTitle from '@entities/ui/ObjectTitle';
 

--- a/src/entities/locale/LocaleCensusCitation.tsx
+++ b/src/entities/locale/LocaleCensusCitation.tsx
@@ -4,7 +4,7 @@ import Hoverable from '@features/layers/hovercard/Hoverable';
 import HoverableObject from '@features/layers/hovercard/HoverableObject';
 
 import { CensusCollectorType, CensusData } from '@entities/census/CensusTypes';
-import { LocaleData, PopulationSourceCategory } from '@entities/types/DataTypes';
+import { LocaleData, PopulationSourceCategory } from '@entities/locale/LocaleTypes';
 
 import Deemphasized from '@shared/ui/Deemphasized';
 

--- a/src/entities/locale/LocaleNameWithFilters.tsx
+++ b/src/entities/locale/LocaleNameWithFilters.tsx
@@ -4,7 +4,7 @@ import HoverableObject from '@features/layers/hovercard/HoverableObject';
 import { SearchableField } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 
-import { LocaleData } from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
 
 import Highlightable from '@shared/ui/Highlightable';
 

--- a/src/entities/locale/LocaleParsing.ts
+++ b/src/entities/locale/LocaleParsing.ts
@@ -1,11 +1,13 @@
 import { LocaleSeparator } from '@features/params/PageParamTypes';
 
-import { ISO3166Code, LocaleData } from '@entities/types/DataTypes';
+import { TerritoryCode } from '@entities/territory/TerritoryTypes';
+
+import { LocaleData } from './LocaleTypes';
 
 export function getLocaleCode(
   locale: LocaleData,
   localeSeparator: LocaleSeparator,
-  territoryOverride?: ISO3166Code,
+  territoryOverride?: TerritoryCode,
 ): string {
   return [
     locale.language?.codeDisplay ?? locale.languageCode,
@@ -27,7 +29,7 @@ export type LocaleTags = {
 export function getLocaleCodeFromTags(
   localeTags: LocaleTags,
   localeSeparator: LocaleSeparator = LocaleSeparator.Underscore,
-  territoryOverride?: ISO3166Code,
+  territoryOverride?: TerritoryCode,
 ): string {
   return [
     localeTags.languageCode,

--- a/src/entities/locale/LocalePopulationAdjusted.tsx
+++ b/src/entities/locale/LocalePopulationAdjusted.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Hoverable from '@features/layers/hovercard/Hoverable';
 
-import { LocaleData } from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
 
 import CountOfPeople from '@shared/ui/CountOfPeople';
 

--- a/src/entities/locale/LocalePopulationBreakdown.tsx
+++ b/src/entities/locale/LocalePopulationBreakdown.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { LocaleData, PopulationSourceCategory } from '@entities/types/DataTypes';
+import { LocaleData, PopulationSourceCategory } from '@entities/locale/LocaleTypes';
 
 import LocalePopulationBreakdownAdjusted from './LocalePopulationBreakdownAdjusted';
 import LocalePopulationBreakdownAggregated from './LocalePopulationBreakdownAggregated';

--- a/src/entities/locale/LocalePopulationBreakdownAdjusted.tsx
+++ b/src/entities/locale/LocalePopulationBreakdownAdjusted.tsx
@@ -4,7 +4,7 @@ import TerritoryDataYear from '@features/data/context/TerritoryDataYear';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 
 import { CensusCollectorType } from '@entities/census/CensusTypes';
-import { LocaleData, PopulationSourceCategory } from '@entities/types/DataTypes';
+import { LocaleData, PopulationSourceCategory } from '@entities/locale/LocaleTypes';
 
 import CellLabel from '@shared/containers/CellLabel';
 import CellPercent from '@shared/containers/CellPercent';

--- a/src/entities/locale/LocalePopulationBreakdownAggregated.tsx
+++ b/src/entities/locale/LocalePopulationBreakdownAggregated.tsx
@@ -5,7 +5,7 @@ import HoverableButton from '@features/layers/hovercard/HoverableButton';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import { sortByPopulation } from '@features/transforms/sorting/sort';
 
-import { LocaleData, PopulationSourceCategory } from '@entities/types/DataTypes';
+import { LocaleData, PopulationSourceCategory } from '@entities/locale/LocaleTypes';
 
 import LabelTableCell from '@shared/containers/CellLabel';
 import CellPercent from '@shared/containers/CellPercent';

--- a/src/entities/locale/LocaleStrings.tsx
+++ b/src/entities/locale/LocaleStrings.tsx
@@ -1,4 +1,4 @@
-import { LocaleData, OfficialStatus } from '@entities/types/DataTypes';
+import { LocaleData, OfficialStatus } from '@entities/locale/LocaleTypes';
 
 export function getLocaleName(locale: LocaleData, includeTerritory: boolean = true): string {
   const languageName = locale.language?.nameDisplay ?? locale.languageCode;

--- a/src/entities/locale/LocaleTypes.ts
+++ b/src/entities/locale/LocaleTypes.ts
@@ -1,0 +1,107 @@
+import { ObjectType } from '@features/params/PageParamTypes';
+
+import { CensusData } from '@entities/census/CensusTypes';
+import { LanguageCode, LanguageData } from '@entities/language/LanguageTypes';
+import { TerritoryCode, TerritoryData } from '@entities/territory/TerritoryTypes';
+import { ObjectBase, WikipediaData } from '@entities/types/DataTypes';
+import { VariantIANATag, VariantTagData } from '@entities/varianttag/VariantTagTypes';
+import { ScriptCode, WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
+
+/**
+ * Standard locale code for the app following the BCP-47 convention with some departures:
+ *   Underscores separate
+ *   Languages prefer 3-letter ISO codes, otherwise Glottocodes
+ *   Writing systems always use ISO 15924 codes as usual
+ *   Territories ISO 3166-1 alpha-2 codes or UN M49 codes
+ *   Variant tags are added at the end, separated by underscores, and can be any IANA-registered tag
+ *
+ * TODO: Make the type stricter than string
+ */
+export type StandardLocaleCode = string;
+
+export enum PopulationSourceCategory {
+  // From inputted data
+  Official = 'Official', // Has a cited source
+  UnverifiedOfficial = 'Unverified Official', // Source lost in merge but allegedly official
+  Study = 'Study',
+  Ethnologue = 'Ethnologue',
+  EDL = 'EDL', // Endangered Languages Project
+  CLDR = 'CLDR', // Unicode's Common Locale Data Repository
+  Other = 'Other',
+  NoSource = '',
+
+  // Algorithmically derived
+  AggregatedFromTerritories = 'Aggregated from Territories',
+  AggregatedFromLanguages = 'Aggregated from Languages',
+  Algorithmic = 'Algorithmic', // not further specified
+}
+
+export enum LocaleSource {
+  StableDatabase = 'StableDatabase', // the standard source, kept in locales.tsv
+  IANA = 'IANA', // created when importing IANA variant tags
+  Census = 'census', // created when importing census data
+  CreateRegionalLocales = 'createRegionalLocales', // created when generating aggregated regional locales
+  CreateFamilyLocales = 'createFamilyLocales', // created when generating locales for language families
+}
+
+export enum OfficialStatus {
+  Official = 'official',
+  DeFactoOfficial = 'de_facto_official',
+  Recognized = 'recognized',
+  OfficialRegionally = 'official_regional',
+  RecognizedRegionally = 'recognized_regional',
+}
+
+export type LocaleInCensus = {
+  census: CensusData;
+  populationEstimate: number;
+  populationPercent: number;
+};
+
+export interface LocaleData extends ObjectBase {
+  type: ObjectType.Locale;
+
+  ID: StandardLocaleCode;
+  codeDisplay: StandardLocaleCode; // Changes based on the language schema
+  localeSource: LocaleSource;
+
+  nameDisplay: string;
+  nameEndonym?: string;
+  languageCode: LanguageCode;
+  territoryCode?: TerritoryCode;
+  scriptCode?: ScriptCode;
+  variantTagCodes?: VariantIANATag[];
+
+  populationSource?: PopulationSourceCategory;
+  populationSpeaking?: number;
+  officialStatus?: OfficialStatus;
+  wikipedia?: WikipediaData;
+
+  // References to other objects, filled in after loading the TSV
+  language?: LanguageData;
+  territory?: TerritoryData;
+  writingSystem?: WritingSystemData;
+  variantTags?: VariantTagData[];
+
+  // References to other locales
+  relatedLocales?: {
+    moreGeneral?: LocaleData[]; // Locales that are less specific forms of this locale (eg. zh_Hant_SG -> zh_Hant or zh_SG)
+    parentTerritory?: LocaleData; // The locale for the parent territory containing this locale's territory
+    parentLanguage?: LocaleData; // The locale for the parent language family containing this locale's language
+    moreSpecific?: LocaleData[]; // Locales that are more specific forms of this locale (eg. zh_SG -> zh_Hant_SG, zh_Hans_SG)
+    childTerritories?: LocaleData[]; // Locales that represent subdivisions of this locale's territory
+    childLanguages?: LocaleData[]; // Locales that represent child/descendant languages of this locale's language
+
+    sumOfPopulationFromChildTerritories?: number;
+    sumOfPopulationFromChildLanguages?: number;
+  };
+
+  // Data computed from other references, particularly territories.tsv and censuses
+  populationAdjusted?: number; // Speaking population adjusted to latest territory population
+  populationSpeakingPercent?: number;
+  literacyPercent?: number;
+  populationWriting?: number;
+  populationWritingPercent?: number;
+  populationCensus?: CensusData; // The census record that provides the population estimate
+  censusRecords?: LocaleInCensus[]; // Maps census ID to population estimate
+}

--- a/src/entities/locale/LocalesInTerritoryCard.tsx
+++ b/src/entities/locale/LocalesInTerritoryCard.tsx
@@ -4,7 +4,7 @@ import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName'
 import { getFilterByLanguageScope } from '@features/transforms/filtering/filter';
 import { sortByPopulation } from '@features/transforms/sorting/sort';
 
-import { TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 type Props = {
   territory: TerritoryData;

--- a/src/entities/locale/test/LocaleStrings.test.tsx
+++ b/src/entities/locale/test/LocaleStrings.test.tsx
@@ -3,15 +3,11 @@ import { describe, expect, it } from 'vitest';
 import { ObjectType } from '@features/params/PageParamTypes';
 
 import { getBaseLanguageData } from '@entities/language/LanguageTypes';
-import {
-  LocaleData,
-  LocaleSource,
-  PopulationSourceCategory,
-  TerritoryScope,
-  WritingSystemScope,
-} from '@entities/types/DataTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
+import { WritingSystemScope } from '@entities/writingsystem/WritingSystemTypes';
 
 import { getLocaleName } from '../LocaleStrings';
+import { LocaleData, LocaleSource, PopulationSourceCategory } from '../LocaleTypes';
 
 describe('getLocaleName', () => {
   it('Language with tags but no linked objects', () => {

--- a/src/entities/territory/TerritoryCard.tsx
+++ b/src/entities/territory/TerritoryCard.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import { getScopeFilter } from '@features/transforms/filtering/filter';
 
-import { TerritoryData, TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryData, TerritoryScope } from '@entities/territory/TerritoryTypes';
 import ObjectTitle from '@entities/ui/ObjectTitle';
 
 import CardField from '@shared/containers/CardField';

--- a/src/entities/territory/TerritoryTypes.ts
+++ b/src/entities/territory/TerritoryTypes.ts
@@ -1,0 +1,69 @@
+/**
+ * Enums and types related to territories, which are the main geographic unit in the app.
+ */
+
+import { ObjectType } from '@features/params/PageParamTypes';
+
+import { CensusData } from '@entities/census/CensusTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
+import { ObjectBase } from '@entities/types/DataTypes';
+
+// ISO 3166 territory code OR UN M49 code
+export type TerritoryCode = ISO3166Code | UNM49Code;
+export type ISO3166Code = string; // ISO 3166-1 alpha-2 code, eg. US, CA, etc.
+export type UNM49Code = string; // UN M49 code, eg. 001, 150, 419, etc.
+
+export enum TerritoryScope {
+  World = 6, // larger value = broader scope
+  Continent = 5,
+  Region = 4, // eg, Latin America, Middle East, etc.
+  Subcontinent = 3,
+  Country = 2,
+  Dependency = 1,
+  // 0 is intentionally not included to avoid problems using truthy comparisons
+}
+
+export const isTerritoryGroup = (scope?: TerritoryScope): boolean => {
+  return (
+    scope != null &&
+    [
+      TerritoryScope.World,
+      TerritoryScope.Continent,
+      TerritoryScope.Region,
+      TerritoryScope.Subcontinent,
+    ].includes(scope)
+  );
+};
+
+export interface TerritoryData extends ObjectBase {
+  type: ObjectType.Territory;
+  ID: TerritoryCode;
+  codeDisplay: TerritoryCode;
+  codeAlpha3?: string; // ISO 3166-1 alpha-3 code, eg. USA, CAN, etc.
+  codeNumeric?: string; // ISO 3166-1 numeric code, eg. 840, 124, etc.
+
+  nameDisplay: string;
+  scope: TerritoryScope;
+  population: number; // May be reduced when re-computing with dependent territories
+  populationFromUN: number; // Imported by the TSV
+
+  // Supplemental data
+  nameEndonym?: string;
+  nameOtherEndonyms?: string[];
+  nameOtherExonyms?: string[];
+  containedUNRegionCode?: UNM49Code;
+  sovereignCode?: ISO3166Code;
+  literacyPercent?: number;
+  gdp?: number;
+  latitude?: number;
+  longitude?: number;
+  landArea?: number; // in square kilometers
+
+  // References to other objects, filled in after loading the TSV
+  parentUNRegion?: TerritoryData;
+  containsTerritories?: TerritoryData[];
+  sovereign?: TerritoryData;
+  dependentTerritories?: TerritoryData[];
+  locales?: LocaleData[];
+  censuses?: CensusData[];
+}

--- a/src/entities/types/CLDRTypes.tsx
+++ b/src/entities/types/CLDRTypes.tsx
@@ -1,6 +1,7 @@
-import { LanguageCode } from '../language/LanguageTypes';
+import { TerritoryCode } from '@entities/territory/TerritoryTypes';
+import { ScriptCode } from '@entities/writingsystem/WritingSystemTypes';
 
-import { ScriptCode, TerritoryCode } from './DataTypes';
+import { LanguageCode } from '../language/LanguageTypes';
 
 export enum CLDRCoverageLevel {
   Core = 'core', // Language identification

--- a/src/entities/types/DataTypes.tsx
+++ b/src/entities/types/DataTypes.tsx
@@ -4,8 +4,13 @@
 
 import { ObjectType } from '@features/params/PageParamTypes';
 
+import { LocaleData, StandardLocaleCode } from '@entities/locale/LocaleTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
+import { VariantTagData } from '@entities/varianttag/VariantTagTypes';
+import { ScriptCode, WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
+
 import { CensusData } from '../census/CensusTypes';
-import { LanguageCode, LanguageData } from '../language/LanguageTypes';
+import { LanguageData } from '../language/LanguageTypes';
 
 export interface ObjectBase {
   readonly type: ObjectType;
@@ -25,218 +30,6 @@ export type ObjectData =
   | VariantTagData;
 export type ObjectDictionary = Record<string, ObjectData>;
 
-// ISO 3166 territory code OR UN M49 code
-export type TerritoryCode = ISO3166Code | UNM49Code;
-export type ISO3166Code = string; // ISO 3166-1 alpha-2 code, eg. US, CA, etc.
-export type UNM49Code = string; // UN M49 code, eg. 001, 150, 419, etc.
-
-export enum TerritoryScope {
-  World = 6, // larger value = broader scope
-  Continent = 5,
-  Region = 4, // eg, Latin America, Middle East, etc.
-  Subcontinent = 3,
-  Country = 2,
-  Dependency = 1,
-  // 0 is intentionally not included to avoid problems using truthy comparisons
-}
-
-export const isTerritoryGroup = (scope?: TerritoryScope): boolean => {
-  return (
-    scope != null &&
-    [
-      TerritoryScope.World,
-      TerritoryScope.Continent,
-      TerritoryScope.Region,
-      TerritoryScope.Subcontinent,
-    ].includes(scope)
-  );
-};
-
-export interface TerritoryData extends ObjectBase {
-  type: ObjectType.Territory;
-  ID: TerritoryCode;
-  codeDisplay: TerritoryCode;
-  codeAlpha3?: string; // ISO 3166-1 alpha-3 code, eg. USA, CAN, etc.
-  codeNumeric?: string; // ISO 3166-1 numeric code, eg. 840, 124, etc.
-
-  nameDisplay: string;
-  scope: TerritoryScope;
-  population: number; // May be reduced when re-computing with dependent territories
-  populationFromUN: number; // Imported by the TSV
-
-  // Supplemental data
-  nameEndonym?: string;
-  nameOtherEndonyms?: string[];
-  nameOtherExonyms?: string[];
-  containedUNRegionCode?: UNM49Code;
-  sovereignCode?: ISO3166Code;
-  literacyPercent?: number;
-  gdp?: number;
-  latitude?: number;
-  longitude?: number;
-  landArea?: number; // in square kilometers
-
-  // References to other objects, filled in after loading the TSV
-  parentUNRegion?: TerritoryData;
-  containsTerritories?: TerritoryData[];
-  sovereign?: TerritoryData;
-  dependentTerritories?: TerritoryData[];
-  locales?: LocaleData[];
-  censuses?: CensusData[];
-}
-
-export type ScriptCode = string; // ISO 15924 script code, eg. Latn, Cyrl, etc.
-
-export enum WritingSystemScope {
-  Group = 'Group',
-  IndividualScript = 'Individual script',
-  Variation = 'Variation',
-  SpecialCode = 'Special Code',
-}
-
-export interface WritingSystemData extends ObjectBase {
-  type: ObjectType.WritingSystem;
-
-  ID: ScriptCode;
-  codeDisplay: ScriptCode; // This should be stable
-  scope: WritingSystemScope;
-
-  nameDisplay: string;
-  nameDisplayOriginal?: string;
-  nameFull?: string;
-  nameEndonym?: string;
-  names: string[];
-
-  unicodeVersion?: number;
-  sample?: string;
-  rightToLeft?: boolean;
-  primaryLanguageCode?: LanguageCode;
-  territoryOfOriginCode?: TerritoryCode;
-  parentWritingSystemCode?: ScriptCode;
-  containsWritingSystemsCodes?: ScriptCode[];
-
-  // Derived when combining data
-  populationUpperBound?: number;
-  populationOfDescendants?: number;
-
-  // References to other objects, filled in after loading the TSV
-  primaryLanguage?: LanguageData;
-  territoryOfOrigin?: TerritoryData;
-  languages?: Record<LanguageCode, LanguageData>;
-  localesWhereExplicit?: LocaleData[];
-  parentWritingSystem?: WritingSystemData;
-  childWritingSystems?: WritingSystemData[];
-  containsWritingSystems?: WritingSystemData[];
-}
-
-// BCP-47 Locale	Locale Display Name	Native Locale Name	Language Code	Territory ISO	Explicit Script	Variant IANA Tag	Pop Source	Best Guess	Official Language
-export type BCP47LocaleCode = string; // BCP-47 formatted locale, eg. en_US, fr_CA, etc.
-
-export enum PopulationSourceCategory {
-  // From inputted data
-  Official = 'Official', // Has a cited source
-  UnverifiedOfficial = 'Unverified Official', // Source lost in merge but allegedly official
-  Study = 'Study',
-  Ethnologue = 'Ethnologue',
-  EDL = 'EDL', // Endangered Languages Project
-  CLDR = 'CLDR', // Unicode's Common Locale Data Repository
-  Other = 'Other',
-  NoSource = '',
-
-  // Algorithmically derived
-  AggregatedFromTerritories = 'Aggregated from Territories',
-  AggregatedFromLanguages = 'Aggregated from Languages',
-  Algorithmic = 'Algorithmic', // not further specified
-}
-
-export enum OfficialStatus {
-  Official = 'official',
-  DeFactoOfficial = 'de_facto_official',
-  Recognized = 'recognized',
-  OfficialRegionally = 'official_regional',
-  RecognizedRegionally = 'recognized_regional',
-}
-
-export type LocaleInCensus = {
-  census: CensusData;
-  populationEstimate: number;
-  populationPercent: number;
-};
-
-export enum LocaleSource {
-  StableDatabase = 'StableDatabase', // the standard source, kept in locales.tsv
-  IANA = 'IANA', // created when importing IANA variant tags
-  Census = 'census', // created when importing census data
-  CreateRegionalLocales = 'createRegionalLocales', // created when generating aggregated regional locales
-  CreateFamilyLocales = 'createFamilyLocales', // created when generating locales for language families
-}
-
-export interface LocaleData extends ObjectBase {
-  type: ObjectType.Locale;
-
-  ID: BCP47LocaleCode;
-  codeDisplay: BCP47LocaleCode; // Changes based on the language schema
-  localeSource: LocaleSource;
-
-  nameDisplay: string;
-  nameEndonym?: string;
-  languageCode: LanguageCode;
-  territoryCode?: TerritoryCode;
-  scriptCode?: ScriptCode;
-  variantTagCodes?: VariantIANATag[];
-
-  populationSource?: PopulationSourceCategory;
-  populationSpeaking?: number;
-  officialStatus?: OfficialStatus;
-  wikipedia?: WikipediaData;
-
-  // References to other objects, filled in after loading the TSV
-  language?: LanguageData;
-  territory?: TerritoryData;
-  writingSystem?: WritingSystemData;
-  variantTags?: VariantTagData[];
-
-  // References to other locales
-  relatedLocales?: {
-    moreGeneral?: LocaleData[]; // Locales that are less specific forms of this locale (eg. zh_Hant_SG -> zh_Hant or zh_SG)
-    parentTerritory?: LocaleData; // The locale for the parent territory containing this locale's territory
-    parentLanguage?: LocaleData; // The locale for the parent language family containing this locale's language
-    moreSpecific?: LocaleData[]; // Locales that are more specific forms of this locale (eg. zh_SG -> zh_Hant_SG, zh_Hans_SG)
-    childTerritories?: LocaleData[]; // Locales that represent subdivisions of this locale's territory
-    childLanguages?: LocaleData[]; // Locales that represent child/descendant languages of this locale's language
-
-    sumOfPopulationFromChildTerritories?: number;
-    sumOfPopulationFromChildLanguages?: number;
-  };
-
-  // Data computed from other references, particularly territories.tsv and censuses
-  populationAdjusted?: number; // Speaking population adjusted to latest territory population
-  populationSpeakingPercent?: number;
-  literacyPercent?: number;
-  populationWriting?: number;
-  populationWritingPercent?: number;
-  populationCensus?: CensusData; // The census record that provides the population estimate
-  censusRecords?: LocaleInCensus[]; // Maps census ID to population estimate
-}
-
-export type VariantIANATag = string; // IANA tag, eg. valencia in cat-ES-valencia
-export interface VariantTagData extends ObjectBase {
-  type: ObjectType.VariantTag;
-  ID: VariantIANATag;
-  codeDisplay: VariantIANATag;
-  nameDisplay: string;
-  description?: string;
-
-  dateAdded?: Date;
-  prefixes: string[]; // Usually language codes but sometimes composites like zh-Latn or oc-lengadoc
-  languageCodes: LanguageCode[]; // zh, oc, etc.
-  localeCodes: BCP47LocaleCode[]; // would look like zh-Latn-pinyin or oc-lengadoc-grclass
-
-  // References to other objects
-  languages: LanguageData[];
-  locales: LocaleData[];
-}
-
 export enum WikipediaStatus {
   Active = 'Active',
   Closed = 'Closed',
@@ -250,7 +43,7 @@ export type WikipediaData = {
   languageName: string;
   scriptCodes: ScriptCode[];
   wikipediaSubdomain: string; // eg. en, fr, simple, zh-classical, map-bms
-  localeCode: BCP47LocaleCode; // eg. eng, fra, mis, lzh, bany1247
+  localeCode: StandardLocaleCode; // eg. eng, fra, mis, lzh, bany1247
   articles: number;
   activeUsers: number;
   url: string;

--- a/src/entities/ui/PopulationSourceCategoryDisplay.tsx
+++ b/src/entities/ui/PopulationSourceCategoryDisplay.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { PopulationSourceCategory } from '@entities/types/DataTypes';
+import { PopulationSourceCategory } from '@entities/locale/LocaleTypes';
 
 import Deemphasized from '@shared/ui/Deemphasized';
 

--- a/src/entities/varianttag/VariantTagCard.tsx
+++ b/src/entities/varianttag/VariantTagCard.tsx
@@ -4,11 +4,12 @@ import React from 'react';
 
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 
-import { VariantTagData } from '@entities/types/DataTypes';
 import ObjectSubtitle from '@entities/ui/ObjectSubtitle';
 import ObjectTitle from '@entities/ui/ObjectTitle';
 
 import CommaSeparated from '@shared/ui/CommaSeparated';
+
+import { VariantTagData } from './VariantTagTypes';
 
 interface Props {
   data: VariantTagData;

--- a/src/entities/varianttag/VariantTagTypes.ts
+++ b/src/entities/varianttag/VariantTagTypes.ts
@@ -1,0 +1,26 @@
+import { ObjectType } from '@features/params/PageParamTypes';
+
+import { LanguageCode, LanguageData } from '@entities/language/LanguageTypes';
+import { LocaleData, StandardLocaleCode } from '@entities/locale/LocaleTypes';
+import { ObjectBase } from '@entities/types/DataTypes';
+
+export type VariantIANATag = string; // IANA tag, eg. valencia in cat-ES-valencia
+
+export type VariantTagDictionary = Record<VariantIANATag, VariantTagData>;
+
+export interface VariantTagData extends ObjectBase {
+  type: ObjectType.VariantTag;
+  ID: VariantIANATag;
+  codeDisplay: VariantIANATag;
+  nameDisplay: string;
+  description?: string;
+
+  dateAdded?: Date;
+  prefixes: string[]; // Usually language codes but sometimes composites like zh-Latn or oc-lengadoc
+  languageCodes: LanguageCode[]; // zh, oc, etc.
+  localeCodes: StandardLocaleCode[]; // would look like zh-Latn-pinyin or oc-lengadoc-grclass
+
+  // References to other objects
+  languages: LanguageData[];
+  locales: LocaleData[];
+}

--- a/src/entities/writingsystem/WritingSystemCard.tsx
+++ b/src/entities/writingsystem/WritingSystemCard.tsx
@@ -12,8 +12,8 @@ import Hoverable from '@features/layers/hovercard/Hoverable';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import usePageParams from '@features/params/usePageParams';
 
-import { WritingSystemData, WritingSystemScope } from '@entities/types/DataTypes';
 import ObjectTitle from '@entities/ui/ObjectTitle';
+import { WritingSystemData, WritingSystemScope } from '@entities/writingsystem/WritingSystemTypes';
 
 import CardField from '@shared/containers/CardField';
 import CommaSeparated from '@shared/ui/CommaSeparated';

--- a/src/entities/writingsystem/WritingSystemTypes.ts
+++ b/src/entities/writingsystem/WritingSystemTypes.ts
@@ -1,0 +1,54 @@
+/**
+ * Enums and types related to writing systems
+ */
+
+import { ObjectType } from '@features/params/PageParamTypes';
+
+import { LanguageCode, LanguageData } from '@entities/language/LanguageTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
+import { TerritoryCode, TerritoryData } from '@entities/territory/TerritoryTypes';
+import { ObjectBase } from '@entities/types/DataTypes';
+
+export type ScriptCode = string; // ISO 15924 script code, eg. Latn, Cyrl, etc.
+
+export enum WritingSystemScope {
+  Group = 'Group',
+  IndividualScript = 'Individual script',
+  Variation = 'Variation',
+  SpecialCode = 'Special Code',
+}
+
+export interface WritingSystemData extends ObjectBase {
+  type: ObjectType.WritingSystem;
+
+  ID: ScriptCode;
+  codeDisplay: ScriptCode; // This should be stable
+  scope: WritingSystemScope;
+
+  nameDisplay: string;
+  nameDisplayOriginal?: string;
+  nameFull?: string;
+  nameEndonym?: string;
+  names: string[];
+
+  unicodeVersion?: number;
+  sample?: string;
+  rightToLeft?: boolean;
+  primaryLanguageCode?: LanguageCode;
+  territoryOfOriginCode?: TerritoryCode;
+  parentWritingSystemCode?: ScriptCode;
+  containsWritingSystemsCodes?: ScriptCode[];
+
+  // Derived when combining data
+  populationUpperBound?: number;
+  populationOfDescendants?: number;
+
+  // References to other objects, filled in after loading the TSV
+  primaryLanguage?: LanguageData;
+  territoryOfOrigin?: TerritoryData;
+  languages?: Record<LanguageCode, LanguageData>;
+  localesWhereExplicit?: LocaleData[];
+  parentWritingSystem?: WritingSystemData;
+  childWritingSystems?: WritingSystemData[];
+  containsWritingSystems?: WritingSystemData[];
+}

--- a/src/entities/writingsystem/WritingSystemsInTerritoryCard.tsx
+++ b/src/entities/writingsystem/WritingSystemsInTerritoryCard.tsx
@@ -4,7 +4,7 @@ import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName'
 import { getFilterByConnections } from '@features/transforms/filtering/filterByConnections';
 
 import { getWritingSystemsInObject } from '@entities/lib/getObjectMiscFields';
-import { TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 type Props = {
   territory: TerritoryData;

--- a/src/features/__tests__/MockObjects.tsx
+++ b/src/features/__tests__/MockObjects.tsx
@@ -16,16 +16,11 @@ import {
   LanguageData,
   LanguageSource,
 } from '@entities/language/LanguageTypes';
-import {
-  LocaleData,
-  LocaleSource,
-  ObjectDictionary,
-  TerritoryData,
-  TerritoryScope,
-  VariantTagData,
-  WritingSystemData,
-  WritingSystemScope,
-} from '@entities/types/DataTypes';
+import { LocaleData, LocaleSource } from '@entities/locale/LocaleTypes';
+import { TerritoryData, TerritoryScope } from '@entities/territory/TerritoryTypes';
+import { ObjectDictionary } from '@entities/types/DataTypes';
+import { VariantTagData } from '@entities/varianttag/VariantTagTypes';
+import { WritingSystemData, WritingSystemScope } from '@entities/writingsystem/WritingSystemTypes';
 
 import { toDictionary } from '@shared/lib/setUtils';
 

--- a/src/features/data/compute/__tests__/computeLocalesPopulationFromCensuses.test.ts
+++ b/src/features/data/compute/__tests__/computeLocalesPopulationFromCensuses.test.ts
@@ -9,7 +9,8 @@ import { CoreData } from '@features/data/load/CoreData';
 import { ObjectType } from '@features/params/PageParamTypes';
 
 import { CensusCollectorType, CensusData } from '@entities/census/CensusTypes';
-import { LocaleData, LocaleSource, ObjectDictionary } from '@entities/types/DataTypes';
+import { LocaleData, LocaleSource } from '@entities/locale/LocaleTypes';
+import { ObjectDictionary } from '@entities/types/DataTypes';
 
 import { computeRegionalLocalesPopulation } from '../computeAggregatedLocalesPopulation';
 import { computeLocalesPopulationFromCensuses } from '../computeLocalesPopulationFromCensuses';

--- a/src/features/data/compute/__tests__/updateObjectCodesNameAndPopulation.test.ts
+++ b/src/features/data/compute/__tests__/updateObjectCodesNameAndPopulation.test.ts
@@ -8,7 +8,7 @@ import {
 import { LocaleSeparator, ObjectType } from '@features/params/PageParamTypes';
 
 import { LanguageSource } from '@entities/language/LanguageTypes';
-import { LocaleData, LocaleSource } from '@entities/types/DataTypes';
+import { LocaleData, LocaleSource } from '@entities/locale/LocaleTypes';
 
 import { updateObjectCodesNameAndPopulation } from '../updateObjectCodesNameAndPopulation';
 

--- a/src/features/data/compute/computeAggregatedLocalesPopulation.ts
+++ b/src/features/data/compute/computeAggregatedLocalesPopulation.ts
@@ -1,11 +1,7 @@
 import { sortByPopulation } from '@features/transforms/sorting/sort';
 
-import {
-  isTerritoryGroup,
-  LocaleData,
-  LocaleSource,
-  TerritoryData,
-} from '@entities/types/DataTypes';
+import { LocaleData, LocaleSource } from '@entities/locale/LocaleTypes';
+import { isTerritoryGroup, TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import { sumBy, uniqueBy } from '@shared/lib/setUtils';
 

--- a/src/features/data/compute/computeDescendantPopulation.ts
+++ b/src/features/data/compute/computeDescendantPopulation.ts
@@ -1,5 +1,5 @@
 import { LanguageData, LanguagesBySource } from '@entities/language/LanguageTypes';
-import { ScriptCode, WritingSystemData } from '@entities/types/DataTypes';
+import { ScriptCode, WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 export function computeDescendantPopulation(
   languagesBySource: LanguagesBySource,

--- a/src/features/data/compute/computeLocalesPopulationFromCensuses.ts
+++ b/src/features/data/compute/computeLocalesPopulationFromCensuses.ts
@@ -1,5 +1,5 @@
 import { getCensusCollectorTypeRank } from '@entities/census/CensusTypes';
-import { LocaleData, LocaleInCensus } from '@entities/types/DataTypes';
+import { LocaleData, LocaleInCensus } from '@entities/locale/LocaleTypes';
 
 type CensusCmp = (a: LocaleInCensus, b: LocaleInCensus) => number;
 

--- a/src/features/data/compute/computeLocalesWritingPopulation.ts
+++ b/src/features/data/compute/computeLocalesWritingPopulation.ts
@@ -1,4 +1,5 @@
-import { isTerritoryGroup, LocaleData } from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
+import { isTerritoryGroup } from '@entities/territory/TerritoryTypes';
 
 import { sumBy, uniqueBy } from '@shared/lib/setUtils';
 

--- a/src/features/data/compute/computeTerritoryStats.ts
+++ b/src/features/data/compute/computeTerritoryStats.ts
@@ -1,4 +1,4 @@
-import { isTerritoryGroup, TerritoryData } from '@entities/types/DataTypes';
+import { isTerritoryGroup, TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import { sumBy } from '@shared/lib/setUtils';
 

--- a/src/features/data/compute/connectObjects.ts
+++ b/src/features/data/compute/connectObjects.ts
@@ -1,10 +1,8 @@
 import { LanguagesBySource } from '@entities/language/LanguageTypes';
-import {
-  LocaleData,
-  TerritoryData,
-  VariantTagData,
-  WritingSystemData,
-} from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
+import { VariantTagData } from '@entities/varianttag/VariantTagTypes';
+import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 import { connectLanguagesToParent } from '../connect/connectLanguagesToParent';
 import connectLocales from '../connect/connectLocales';

--- a/src/features/data/compute/searchLocalesForMissingLinks.ts
+++ b/src/features/data/compute/searchLocalesForMissingLinks.ts
@@ -1,9 +1,11 @@
 import { getLocaleCodeFromTags, LocaleTags } from '@entities/locale/LocaleParsing';
-import { BCP47LocaleCode, LocaleData } from '@entities/types/DataTypes';
+import { LocaleData, StandardLocaleCode } from '@entities/locale/LocaleTypes';
 
 import { unique } from '@shared/lib/setUtils';
 
-export function searchLocalesForMissingLinks(locales: Record<BCP47LocaleCode, LocaleData>): void {
+export function searchLocalesForMissingLinks(
+  locales: Record<StandardLocaleCode, LocaleData>,
+): void {
   Object.values(locales).forEach((locale) => {
     if (!locale.relatedLocales) locale.relatedLocales = {};
     const relatedLocales = locale.relatedLocales ?? {};

--- a/src/features/data/compute/updateObjectCodesNameAndPopulation.ts
+++ b/src/features/data/compute/updateObjectCodesNameAndPopulation.ts
@@ -3,7 +3,8 @@ import { LocaleSeparator } from '@features/params/PageParamTypes';
 import { LanguageData, LanguageSource } from '@entities/language/LanguageTypes';
 import { getLocaleCode } from '@entities/locale/LocaleParsing';
 import { getLocaleName } from '@entities/locale/LocaleStrings';
-import { LocaleData, TerritoryData } from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import computeRecursiveLanguageData from './computeRecursiveLanguageData';
 import { updatePopulations } from './updatePopulations';

--- a/src/features/data/compute/updatePopulations.ts
+++ b/src/features/data/compute/updatePopulations.ts
@@ -1,5 +1,6 @@
 import { LanguageData } from '@entities/language/LanguageTypes';
-import { LocaleData, PopulationSourceCategory, TerritoryData } from '@entities/types/DataTypes';
+import { LocaleData, PopulationSourceCategory } from '@entities/locale/LocaleTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import { sumBy } from '@shared/lib/setUtils';
 

--- a/src/features/data/connect/connectCensuses.ts
+++ b/src/features/data/connect/connectCensuses.ts
@@ -3,7 +3,8 @@ import { ObjectType } from '@features/params/PageParamTypes';
 import { CensusData } from '@entities/census/CensusTypes';
 import { LanguageData } from '@entities/language/LanguageTypes';
 import { setLanguageNames } from '@entities/language/setLanguageNames';
-import { LocaleData, TerritoryData } from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import { CensusImport } from '../load/extra_entities/loadCensusData';
 

--- a/src/features/data/connect/connectLocales.ts
+++ b/src/features/data/connect/connectLocales.ts
@@ -1,13 +1,8 @@
 import { LanguageDictionary } from '@entities/language/LanguageTypes';
 import { getLocaleName } from '@entities/locale/LocaleStrings';
-import {
-  BCP47LocaleCode,
-  LocaleData,
-  ScriptCode,
-  TerritoryCode,
-  TerritoryData,
-  WritingSystemData,
-} from '@entities/types/DataTypes';
+import { LocaleData, StandardLocaleCode } from '@entities/locale/LocaleTypes';
+import { TerritoryCode, TerritoryData } from '@entities/territory/TerritoryTypes';
+import { ScriptCode, WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 /**
  * Connects locales to their languages and territories
@@ -21,7 +16,7 @@ export default function connectLocales(
   languages: LanguageDictionary,
   territories: Record<TerritoryCode, TerritoryData>,
   writingSystems: Record<ScriptCode, WritingSystemData>,
-  locales: Record<BCP47LocaleCode, LocaleData>,
+  locales: Record<StandardLocaleCode, LocaleData>,
 ): void {
   Object.values(locales).forEach((locale) => {
     const territory = locale.territoryCode ? territories[locale.territoryCode] : undefined;

--- a/src/features/data/connect/connectTerritoriesToParent.ts
+++ b/src/features/data/connect/connectTerritoriesToParent.ts
@@ -1,4 +1,4 @@
-import { TerritoryCode, TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryCode, TerritoryData } from '@entities/territory/TerritoryTypes';
 
 export function connectTerritoriesToParent(
   territoriesByCode: Record<TerritoryCode, TerritoryData>,

--- a/src/features/data/connect/connectWritingSystems.ts
+++ b/src/features/data/connect/connectWritingSystems.ts
@@ -1,10 +1,6 @@
 import { LanguageDictionary } from '@entities/language/LanguageTypes';
-import {
-  ScriptCode,
-  TerritoryCode,
-  TerritoryData,
-  WritingSystemData,
-} from '@entities/types/DataTypes';
+import { TerritoryCode, TerritoryData } from '@entities/territory/TerritoryTypes';
+import { ScriptCode, WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 export function connectWritingSystems(
   languages: LanguageDictionary,

--- a/src/features/data/connect/createFamilyLocales.ts
+++ b/src/features/data/connect/createFamilyLocales.ts
@@ -1,7 +1,7 @@
 import { ObjectType } from '@features/params/PageParamTypes';
 
 import { LanguageData, LanguageDictionary, LanguageSource } from '@entities/language/LanguageTypes';
-import { LocaleData, LocaleSource, PopulationSourceCategory } from '@entities/types/DataTypes';
+import { LocaleData, LocaleSource, PopulationSourceCategory } from '@entities/locale/LocaleTypes';
 
 // SOURCE is a constant to pick what source to use when creating family locales.
 // Ideally we'd do this for all sources or the Combined source -- but because it can create so

--- a/src/features/data/connect/createRegionalLocales.ts
+++ b/src/features/data/connect/createRegionalLocales.ts
@@ -2,14 +2,12 @@ import { LocaleSeparator, ObjectType } from '@features/params/PageParamTypes';
 
 import { getLocaleCode } from '@entities/locale/LocaleParsing';
 import {
-  BCP47LocaleCode,
-  isTerritoryGroup,
   LocaleData,
   LocaleSource,
   PopulationSourceCategory,
-  TerritoryCode,
-  TerritoryData,
-} from '@entities/types/DataTypes';
+  StandardLocaleCode,
+} from '@entities/locale/LocaleTypes';
+import { isTerritoryGroup, TerritoryCode, TerritoryData } from '@entities/territory/TerritoryTypes';
 
 /**
  * Locale input data is contained to countries and dependencies -- this adds up data from
@@ -17,7 +15,7 @@ import {
  */
 export function createRegionalLocales(
   territories: Record<TerritoryCode, TerritoryData>,
-  locales: Record<BCP47LocaleCode, LocaleData>,
+  locales: Record<StandardLocaleCode, LocaleData>,
 ): void {
   // Start with the world and recursively create locales for all territory groups
   createRegionalLocalesForTerritory(territories['001'], locales);
@@ -25,7 +23,7 @@ export function createRegionalLocales(
 
 function createRegionalLocalesForTerritory(
   territory: TerritoryData,
-  allLocales: Record<BCP47LocaleCode, LocaleData>,
+  allLocales: Record<StandardLocaleCode, LocaleData>,
 ): void {
   if (!territory) return;
 
@@ -37,7 +35,7 @@ function createRegionalLocalesForTerritory(
     return; // Only going this for regions/continents
   }
 
-  const territoryLocales = containsTerritories?.reduce<Record<BCP47LocaleCode, LocaleData>>(
+  const territoryLocales = containsTerritories?.reduce<Record<StandardLocaleCode, LocaleData>>(
     (locs, childTerritory) => {
       childTerritory.locales?.forEach((loc) => {
         const newLocaleCode = getLocaleCode(loc, LocaleSeparator.Underscore, territory.ID);

--- a/src/features/data/context/DataProvider.tsx
+++ b/src/features/data/context/DataProvider.tsx
@@ -4,13 +4,11 @@ import { ObjectType } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 
 import { LanguageData } from '@entities/language/LanguageTypes';
-import {
-  LocaleData,
-  ObjectData,
-  TerritoryData,
-  VariantTagData,
-  WritingSystemData,
-} from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
+import { ObjectData } from '@entities/types/DataTypes';
+import { VariantTagData } from '@entities/varianttag/VariantTagTypes';
+import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 import { updateObjectCodesNameAndPopulation } from '../compute/updateObjectCodesNameAndPopulation';
 import { useCoreData } from '../load/CoreData';

--- a/src/features/data/context/useDataContext.tsx
+++ b/src/features/data/context/useDataContext.tsx
@@ -1,13 +1,11 @@
 import { createContext, useContext } from 'react';
 
 import { LanguageData } from '@entities/language/LanguageTypes';
-import {
-  LocaleData,
-  ObjectData,
-  TerritoryData,
-  VariantTagData,
-  WritingSystemData,
-} from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
+import { ObjectData } from '@entities/types/DataTypes';
+import { VariantTagData } from '@entities/varianttag/VariantTagTypes';
+import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 import { CoreDataArrays } from '../load/CoreData';
 

--- a/src/features/data/load/CoreData.tsx
+++ b/src/features/data/load/CoreData.tsx
@@ -8,13 +8,11 @@ import { ObjectType } from '@features/params/PageParamTypes';
 
 import { CensusData, CensusID } from '@entities/census/CensusTypes';
 import { LanguageData, LanguagesBySource } from '@entities/language/LanguageTypes';
-import {
-  LocaleData,
-  ObjectData,
-  TerritoryData,
-  VariantTagData,
-  WritingSystemData,
-} from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
+import { ObjectData } from '@entities/types/DataTypes';
+import { VariantTagData } from '@entities/varianttag/VariantTagTypes';
+import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 import { connectObjectsAndCreateDerivedData } from '../compute/connectObjects';
 import { groupLanguagesBySource } from '../connect/connectLanguages';

--- a/src/features/data/load/entities/loadLocales.ts
+++ b/src/features/data/load/entities/loadLocales.ts
@@ -6,7 +6,7 @@ import {
   LocaleSource,
   OfficialStatus,
   PopulationSourceCategory,
-} from '@entities/types/DataTypes';
+} from '@entities/locale/LocaleTypes';
 
 import { loadObjectsFromFile } from './loadObjectsFromFile';
 

--- a/src/features/data/load/entities/loadTerritories.ts
+++ b/src/features/data/load/entities/loadTerritories.ts
@@ -1,6 +1,6 @@
 import { ObjectType } from '@features/params/PageParamTypes';
 
-import { TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import { parseTerritoryScope } from '@strings/TerritoryScopeStrings';
 

--- a/src/features/data/load/entities/loadWritingSystems.ts
+++ b/src/features/data/load/entities/loadWritingSystems.ts
@@ -1,6 +1,6 @@
 import { ObjectType } from '@features/params/PageParamTypes';
 
-import { WritingSystemData, WritingSystemScope } from '@entities/types/DataTypes';
+import { WritingSystemData, WritingSystemScope } from '@entities/writingsystem/WritingSystemTypes';
 
 import { loadObjectsFromFile } from './loadObjectsFromFile';
 

--- a/src/features/data/load/extra_entities/IANAData.tsx
+++ b/src/features/data/load/extra_entities/IANAData.tsx
@@ -2,18 +2,10 @@ import { LocaleSeparator, ObjectType } from '@features/params/PageParamTypes';
 
 import { LanguageDictionary } from '@entities/language/LanguageTypes';
 import { getLocaleCodeFromTags, LocaleTags, parseLocaleCode } from '@entities/locale/LocaleParsing';
-import {
-  BCP47LocaleCode,
-  LocaleData,
-  LocaleSource,
-  VariantTagData,
-} from '@entities/types/DataTypes';
+import { LocaleData, LocaleSource, StandardLocaleCode } from '@entities/locale/LocaleTypes';
+import { VariantTagData, VariantTagDictionary } from '@entities/varianttag/VariantTagTypes';
 
 import { toDictionary, unique } from '@shared/lib/setUtils';
-
-export type VariantIANATag = string; // IANA tag, eg. valencia (for cat-ES-valencia)
-
-export type VariantTagDictionary = Record<VariantIANATag, VariantTagData>;
 
 export async function loadIANAVariants(): Promise<VariantTagDictionary | void> {
   return await fetch(`data/iana_variants.txt`)
@@ -118,7 +110,7 @@ export function parseIANAVariant(input: string): VariantTagData | null {
 // TODO support complex variants like zh-Latn-pinyin or oc-lengadoc-grclass
 export function addIANAVariantLocales(
   languagesBCP: LanguageDictionary,
-  locales: Record<BCP47LocaleCode, LocaleData>,
+  locales: Record<StandardLocaleCode, LocaleData>,
   variants: VariantTagDictionary | void,
 ): void {
   if (!variants) return;
@@ -144,7 +136,7 @@ export function addIANAVariantLocales(
 
 function addVariantLocale(
   localeTags: LocaleTags,
-  locales: Record<BCP47LocaleCode, LocaleData>,
+  locales: Record<StandardLocaleCode, LocaleData>,
 ): void {
   const localeCode = getLocaleCodeFromTags(localeTags, LocaleSeparator.Underscore);
   if (!localeCode.includes('_')) return; // Don't add language-only locales
@@ -166,7 +158,7 @@ function addVariantLocale(
 export function connectVariantTags(
   variantTags: VariantTagDictionary,
   languages: LanguageDictionary,
-  locales: Record<BCP47LocaleCode, LocaleData>,
+  locales: Record<StandardLocaleCode, LocaleData>,
 ): void {
   // Link variants to languages and link languages back to variants
   Object.values(variantTags).forEach((variant) => {

--- a/src/features/data/load/supplemental/UnicodeData.tsx
+++ b/src/features/data/load/supplemental/UnicodeData.tsx
@@ -5,8 +5,8 @@ import { ObjectType } from '@features/params/PageParamTypes';
 
 import { CensusCollectorType, CensusData } from '@entities/census/CensusTypes';
 import { LanguageData, LanguagesBySource, LanguageScope } from '@entities/language/LanguageTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
 import { CLDRCoverageImport, CLDRCoverageLevel } from '@entities/types/CLDRTypes';
-import { LocaleData } from '@entities/types/DataTypes';
 
 import { DataContextType } from '../../context/useDataContext';
 

--- a/src/features/data/load/supplemental/WikipediaData.tsx
+++ b/src/features/data/load/supplemental/WikipediaData.tsx
@@ -1,11 +1,7 @@
 import { LanguageData } from '@entities/language/LanguageTypes';
-import {
-  BCP47LocaleCode,
-  LocaleData,
-  ScriptCode,
-  WikipediaData,
-  WikipediaStatus,
-} from '@entities/types/DataTypes';
+import { LocaleData, StandardLocaleCode } from '@entities/locale/LocaleTypes';
+import { WikipediaData, WikipediaStatus } from '@entities/types/DataTypes';
+import { ScriptCode } from '@entities/writingsystem/WritingSystemTypes';
 
 import { DataContextType } from '../../context/useDataContext';
 
@@ -33,7 +29,7 @@ function parseWikipediaData(line: string): WikipediaData {
     languageName: parts[3],
     scriptCodes: parts[4] ? (parts[4].split('/') as ScriptCode[]) : [],
     wikipediaSubdomain: parts[5],
-    localeCode: parts[6] as BCP47LocaleCode,
+    localeCode: parts[6] as StandardLocaleCode,
     articles: parseInt(parts[7].replace(/,/g, '')),
     activeUsers: parseInt(parts[8].replace(/,/g, '')),
     url: parts[9],
@@ -66,7 +62,7 @@ export function applyWikipediaData(
     // And some can support multiple scripts eg. zh_Hans and zh_Hant
     if (wiki.scriptCodes.length > 0) {
       wiki.scriptCodes.forEach((script) => {
-        const scriptLocaleCode = `${wiki.localeCode}_${script}` as BCP47LocaleCode;
+        const scriptLocaleCode = `${wiki.localeCode}_${script}` as StandardLocaleCode;
         const scriptLocale = getLocale(scriptLocaleCode);
         if (scriptLocale) {
           scriptLocale.wikipedia = wiki;

--- a/src/features/data/load/supplemental/loadCountryCoordinates.ts
+++ b/src/features/data/load/supplemental/loadCountryCoordinates.ts
@@ -1,4 +1,4 @@
-import { TerritoryCode, TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryCode, TerritoryData } from '@entities/territory/TerritoryTypes';
 
 export function loadCountryCoordinates(
   getTerritory: (id: string) => TerritoryData | undefined,

--- a/src/features/data/load/supplemental/loadLandArea.ts
+++ b/src/features/data/load/supplemental/loadLandArea.ts
@@ -1,4 +1,4 @@
-import { TerritoryCode, TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryCode, TerritoryData } from '@entities/territory/TerritoryTypes';
 
 export function loadLandArea(
   getTerritory: (id: string) => TerritoryData | undefined,

--- a/src/features/data/load/supplemental/loadTerritoryGDPLiteracy.ts
+++ b/src/features/data/load/supplemental/loadTerritoryGDPLiteracy.ts
@@ -1,4 +1,4 @@
-import { TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 const DEBUG = false;
 

--- a/src/features/data/load/supplemental/loadTerritoryNames.ts
+++ b/src/features/data/load/supplemental/loadTerritoryNames.ts
@@ -1,4 +1,4 @@
-import { TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 export function loadTerritoryNames(
   getTerritory: (id: string) => TerritoryData | undefined,

--- a/src/features/map/DrawableData.ts
+++ b/src/features/map/DrawableData.ts
@@ -1,5 +1,5 @@
 import { LanguageData } from '@entities/language/LanguageTypes';
-import { TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 type DrawableData = TerritoryData | LanguageData;
 

--- a/src/features/map/MapTerritories.tsx
+++ b/src/features/map/MapTerritories.tsx
@@ -8,7 +8,7 @@ import usePageParams from '@features/params/usePageParams';
 import { ColoringFunctions } from '@features/transforms/coloring/useColors';
 import Field from '@features/transforms/fields/Field';
 
-import { TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import DrawableData from './DrawableData';
 

--- a/src/features/map/ObjectMap.tsx
+++ b/src/features/map/ObjectMap.tsx
@@ -7,7 +7,8 @@ import useColors from '@features/transforms/coloring/useColors';
 
 import { LanguageData } from '@entities/language/LanguageTypes';
 import { getObjectLocales } from '@entities/lib/getObjectRelatedTerritories';
-import { ObjectData, TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
+import { ObjectData } from '@entities/types/DataTypes';
 
 import { uniqueBy } from '@shared/lib/setUtils';
 

--- a/src/features/params/PageParamTypes.tsx
+++ b/src/features/params/PageParamTypes.tsx
@@ -9,7 +9,7 @@ import {
   VitalityEthnologueCoarse,
   VitalityEthnologueFine,
 } from '@entities/language/vitality/VitalityTypes';
-import { TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
 
 import { ProfileType } from './Profiles';
 

--- a/src/features/params/Profiles.tsx
+++ b/src/features/params/Profiles.tsx
@@ -14,7 +14,7 @@ import Field from '@features/transforms/fields/Field';
 import { SortBehavior } from '@features/transforms/sorting/SortTypes';
 
 import { LanguageScope, LanguageSource } from '@entities/language/LanguageTypes';
-import { TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
 
 import {
   LocaleSeparator,

--- a/src/features/table/UNESCOExport.tsx
+++ b/src/features/table/UNESCOExport.tsx
@@ -7,7 +7,9 @@ import { sortByPopulation } from '@features/transforms/sorting/sort';
 import { CensusCollectorType } from '@entities/census/CensusTypes';
 import { LanguageModality } from '@entities/language/LanguageModality';
 import { EthnologueDigitalSupport } from '@entities/language/LanguageTypes';
-import { LocaleData, ObjectData, OfficialStatus, TerritoryData } from '@entities/types/DataTypes';
+import { LocaleData, OfficialStatus } from '@entities/locale/LocaleTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
+import { ObjectData } from '@entities/types/DataTypes';
 
 // Customized for UNESCO use
 export function prepareUNESCODataForExport(objects: ObjectData[], territoryFilter: string): string {

--- a/src/features/table/__tests__/InteractiveObjectTable.test.tsx
+++ b/src/features/table/__tests__/InteractiveObjectTable.test.tsx
@@ -9,7 +9,8 @@ import * as ConnectionFilters from '@features/transforms/filtering/filterByConne
 import getFilterBySubstring from '@features/transforms/search/getFilterBySubstring';
 import * as SortModule from '@features/transforms/sorting/sort';
 
-import { ObjectData, TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
+import { ObjectData } from '@entities/types/DataTypes';
 
 import { createMockUsePageParams } from '@tests/MockPageParams.test';
 

--- a/src/features/transforms/coloring/ColorBar.tsx
+++ b/src/features/transforms/coloring/ColorBar.tsx
@@ -15,7 +15,7 @@ import {
   VitalityEthnologueCoarse,
   VitalityEthnologueFine,
 } from '@entities/language/vitality/VitalityTypes';
-import { TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
 
 import { numberToSigFigs } from '@shared/lib/numberUtils';
 import { convertAlphaToNumber } from '@shared/lib/stringUtils';

--- a/src/features/transforms/fields/getField.ts
+++ b/src/features/transforms/fields/getField.ts
@@ -24,7 +24,8 @@ import {
   getCountOfChildTerritories,
   getCountOfCountries,
 } from '@entities/lib/getObjectRelatedTerritories';
-import { ObjectData, TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
+import { ObjectData } from '@entities/types/DataTypes';
 
 import enforceExhaustiveSwitch from '@shared/lib/enforceExhaustiveness';
 

--- a/src/features/transforms/fields/rangeUtils.ts
+++ b/src/features/transforms/fields/rangeUtils.ts
@@ -1,7 +1,8 @@
 import { LanguageModality } from '@entities/language/LanguageModality';
 import { LanguageScope } from '@entities/language/LanguageTypes';
 import { VitalityEthnologueCoarse } from '@entities/language/vitality/VitalityTypes';
-import { ObjectData, TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
+import { ObjectData } from '@entities/types/DataTypes';
 
 import enforceExhaustiveSwitch from '@shared/lib/enforceExhaustiveness';
 import { maxBy } from '@shared/lib/setUtils';

--- a/src/features/transforms/filtering/FilterPath.tsx
+++ b/src/features/transforms/filtering/FilterPath.tsx
@@ -15,7 +15,7 @@ import {
   getVitalityEthnologueCoarseLabel,
   getVitalityEthnologueFineLabel,
 } from '@entities/language/vitality/VitalityStrings';
-import { TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
 
 import { areArraysIdentical } from '@shared/lib/setUtils';
 import Deemphasized from '@shared/ui/Deemphasized';

--- a/src/features/transforms/filtering/TerritoryFilterSelector.tsx
+++ b/src/features/transforms/filtering/TerritoryFilterSelector.tsx
@@ -11,7 +11,7 @@ import SelectorLabel from '@features/params/ui/SelectorLabel';
 import TextInput from '@features/params/ui/TextInput';
 import usePageParams from '@features/params/usePageParams';
 
-import { TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import Field from '../fields/Field';
 import { getSortFunctionParameterized } from '../sorting/sort';

--- a/src/features/transforms/filtering/TerritoryScopeSelector.tsx
+++ b/src/features/transforms/filtering/TerritoryScopeSelector.tsx
@@ -4,7 +4,7 @@ import { ObjectType } from '@features/params/PageParamTypes';
 import Selector from '@features/params/ui/Selector';
 import usePageParams from '@features/params/usePageParams';
 
-import { TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
 
 import { getTerritoryScopeLabel } from '@strings/TerritoryScopeStrings';
 

--- a/src/features/transforms/filtering/WritingSystemFilterSelector.tsx
+++ b/src/features/transforms/filtering/WritingSystemFilterSelector.tsx
@@ -11,7 +11,7 @@ import SelectorLabel from '@features/params/ui/SelectorLabel';
 import TextInput from '@features/params/ui/TextInput';
 import usePageParams from '@features/params/usePageParams';
 
-import { WritingSystemScope } from '@entities/types/DataTypes';
+import { WritingSystemScope } from '@entities/writingsystem/WritingSystemTypes';
 
 import Field from '../fields/Field';
 import { getSortFunctionParameterized } from '../sorting/sort';

--- a/src/features/transforms/filtering/__tests__/filter.test.tsx
+++ b/src/features/transforms/filtering/__tests__/filter.test.tsx
@@ -8,7 +8,7 @@ import {
   VitalityEthnologueCoarse,
   VitalityEthnologueFine,
 } from '@entities/language/vitality/VitalityTypes';
-import { TerritoryData, TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryData, TerritoryScope } from '@entities/territory/TerritoryTypes';
 
 import { buildVitalityFilterFunction } from '../filter';
 

--- a/src/features/transforms/filtering/__tests__/mockLanguagesForFilterTest.test.tsx
+++ b/src/features/transforms/filtering/__tests__/mockLanguagesForFilterTest.test.tsx
@@ -4,14 +4,9 @@ import { ObjectType } from '@features/params/PageParamTypes';
 
 import { getBaseLanguageData, LanguageScope } from '@entities/language/LanguageTypes';
 import { VitalityEthnologueFine } from '@entities/language/vitality/VitalityTypes';
-import {
-  LocaleData,
-  LocaleSource,
-  TerritoryData,
-  TerritoryScope,
-  WritingSystemData,
-  WritingSystemScope,
-} from '@entities/types/DataTypes';
+import { LocaleData, LocaleSource } from '@entities/locale/LocaleTypes';
+import { TerritoryData, TerritoryScope } from '@entities/territory/TerritoryTypes';
+import { WritingSystemData, WritingSystemScope } from '@entities/writingsystem/WritingSystemTypes';
 
 export function getMockLanguages() {
   const US: TerritoryData = {

--- a/src/features/transforms/filtering/filterByConnections.tsx
+++ b/src/features/transforms/filtering/filterByConnections.tsx
@@ -8,7 +8,8 @@ import usePageParams from '@features/params/usePageParams';
 import { LanguageData } from '@entities/language/LanguageTypes';
 import { getWritingSystemsInObject } from '@entities/lib/getObjectMiscFields';
 import { getContainingTerritories } from '@entities/lib/getObjectRelatedTerritories';
-import { ObjectData, WritingSystemData } from '@entities/types/DataTypes';
+import { ObjectData } from '@entities/types/DataTypes';
+import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 import { uniqueBy } from '@shared/lib/setUtils';
 import { toTitleCase } from '@shared/lib/stringUtils';

--- a/src/features/transforms/sorting/__tests__/sortVitality.test.tsx
+++ b/src/features/transforms/sorting/__tests__/sortVitality.test.tsx
@@ -10,7 +10,7 @@ import {
   VitalityEthnologueCoarse,
   VitalityEthnologueFine,
 } from '@entities/language/vitality/VitalityTypes';
-import { TerritoryData, TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryData, TerritoryScope } from '@entities/territory/TerritoryTypes';
 
 import { getSortFunctionParameterized } from '../sort';
 import { SortBehavior } from '../SortTypes';

--- a/src/strings/TerritoryScopeStrings.ts
+++ b/src/strings/TerritoryScopeStrings.ts
@@ -1,4 +1,4 @@
-import { TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
 
 export function getTerritoryScopeLabel(scope?: TerritoryScope): string {
   if (scope == null) return 'Territory';

--- a/src/widgets/cardlists/__tests__/CardList.test.tsx
+++ b/src/widgets/cardlists/__tests__/CardList.test.tsx
@@ -7,7 +7,7 @@ import usePageParams from '@features/params/usePageParams';
 import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
 import { sortByPopulation } from '@features/transforms/sorting/sort';
 
-import { TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
 
 import { createMockUsePageParams } from '@tests/MockPageParams.test';
 

--- a/src/widgets/details/LocaleDetails.tsx
+++ b/src/widgets/details/LocaleDetails.tsx
@@ -9,7 +9,7 @@ import LocaleCensusCitation from '@entities/locale/LocaleCensusCitation';
 import LocalePopulationAdjusted from '@entities/locale/LocalePopulationAdjusted';
 import LocalePopulationBreakdown from '@entities/locale/LocalePopulationBreakdown';
 import { getOfficialLabel } from '@entities/locale/LocaleStrings';
-import { LocaleData, LocaleSource } from '@entities/types/DataTypes';
+import { LocaleData, LocaleSource } from '@entities/locale/LocaleTypes';
 import ObjectWikipediaInfo from '@entities/ui/ObjectWikipediaInfo';
 
 import DetailsField from '@shared/containers/DetailsField';

--- a/src/widgets/details/TerritoryDetails.tsx
+++ b/src/widgets/details/TerritoryDetails.tsx
@@ -5,7 +5,7 @@ import TableOfLanguagesInTerritory from '@widgets/tables/TableOfLanguagesInTerri
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import { getSortFunction } from '@features/transforms/sorting/sort';
 
-import { TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import DetailsField from '@shared/containers/DetailsField';
 import DetailsSection from '@shared/containers/DetailsSection';

--- a/src/widgets/details/VariantTagDetails.tsx
+++ b/src/widgets/details/VariantTagDetails.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 
-import { VariantTagData } from '@entities/types/DataTypes';
+import { VariantTagData } from '@entities/varianttag/VariantTagTypes';
 
 import DetailsField from '@shared/containers/DetailsField';
 import DetailsSection from '@shared/containers/DetailsSection';

--- a/src/widgets/details/WritingSystemDetails.tsx
+++ b/src/widgets/details/WritingSystemDetails.tsx
@@ -5,7 +5,7 @@ import PopulationWarning from '@widgets/PopulationWarning';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import { getSortFunction } from '@features/transforms/sorting/sort';
 
-import { WritingSystemData } from '@entities/types/DataTypes';
+import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 import DetailsField from '@shared/containers/DetailsField';
 import DetailsSection from '@shared/containers/DetailsSection';
@@ -32,6 +32,7 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
     territoryOfOrigin,
     unicodeVersion,
   } = writingSystem;
+  const sortFunction = getSortFunction();
 
   return (
     <div className="Details">
@@ -78,7 +79,7 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
           <DetailsField title="Languages">
             <CommaSeparated>
               {Object.values(languages)
-                .sort(getSortFunction())
+                .sort(sortFunction)
                 .map((lang) => (
                   <HoverableObjectName key={lang.ID} object={lang} />
                 ))}
@@ -95,7 +96,7 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
         {localesWhereExplicit && localesWhereExplicit.length > 0 && (
           <DetailsField title="Locales (where writing system is explicit)">
             <CommaSeparated>
-              {localesWhereExplicit.sort(getSortFunction()).map((locale) => (
+              {localesWhereExplicit.sort(sortFunction).map((locale) => (
                 <HoverableObjectName key={locale.ID} object={locale} />
               ))}
             </CommaSeparated>
@@ -110,7 +111,7 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
         {childWritingSystems && childWritingSystems.length > 0 && (
           <DetailsField title="Inspired">
             <CommaSeparated>
-              {childWritingSystems.sort(getSortFunction()).map((writingSystem) => (
+              {childWritingSystems.sort(sortFunction).map((writingSystem) => (
                 <HoverableObjectName key={writingSystem.ID} object={writingSystem} />
               ))}
             </CommaSeparated>
@@ -119,7 +120,7 @@ const WritingSystemDetails: React.FC<Props> = ({ writingSystem }) => {
         {containsWritingSystems && containsWritingSystems.length > 0 && (
           <DetailsField title="Contains">
             <CommaSeparated>
-              {containsWritingSystems.sort(getSortFunction()).map((writingSystem) => (
+              {containsWritingSystems.sort(sortFunction).map((writingSystem) => (
                 <HoverableObjectName key={writingSystem.ID} object={writingSystem} />
               ))}
             </CommaSeparated>

--- a/src/widgets/details/sections/LanguagePopulationDetails.tsx
+++ b/src/widgets/details/sections/LanguagePopulationDetails.tsx
@@ -6,7 +6,7 @@ import { LanguagePopulationEstimate } from '@entities/language/population/Langua
 import LanguagePopulationOfDescendants from '@entities/language/population/LanguagePopulationFromDescendants';
 import LanguagePopulationFromEthnologue from '@entities/language/population/LanguagePopulationFromEthnologue';
 import LanguagePopulationFromLocales from '@entities/language/population/LanguagePopulationFromLocales';
-import { PopulationSourceCategory } from '@entities/types/DataTypes';
+import { PopulationSourceCategory } from '@entities/locale/LocaleTypes';
 import PopulationSourceCategoryDisplay from '@entities/ui/PopulationSourceCategoryDisplay';
 
 import DetailsField from '@shared/containers/DetailsField';

--- a/src/widgets/details/sections/TerritoryAttributes.tsx
+++ b/src/widgets/details/sections/TerritoryAttributes.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import DetailsField from '@shared/containers/DetailsField';
 import DetailsSection from '@shared/containers/DetailsSection';

--- a/src/widgets/details/sections/TerritoryIdentification.tsx
+++ b/src/widgets/details/sections/TerritoryIdentification.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import DetailsField from '@shared/containers/DetailsField';
 import DetailsSection from '@shared/containers/DetailsSection';

--- a/src/widgets/details/sections/TerritoryLocation.tsx
+++ b/src/widgets/details/sections/TerritoryLocation.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import MapContainer from '@features/map/MapContainer';
 import ObjectMap from '@features/map/ObjectMap';
 
-import { TerritoryData, TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryData, TerritoryScope } from '@entities/territory/TerritoryTypes';
 
 import DetailsField from '@shared/containers/DetailsField';
 import DetailsSection from '@shared/containers/DetailsSection';

--- a/src/widgets/pathnav/getParentsAndDescendants.tsx
+++ b/src/widgets/pathnav/getParentsAndDescendants.tsx
@@ -1,7 +1,8 @@
 import { ObjectType } from '@features/params/PageParamTypes';
 
 import { LanguageScope } from '@entities/language/LanguageTypes';
-import { ObjectData, TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
+import { ObjectData } from '@entities/types/DataTypes';
 
 export function getObjectParents(object?: ObjectData): (ObjectData | undefined)[] {
   if (object == null) return [];
@@ -81,13 +82,13 @@ export function getDescendantsName(object: ObjectData, count: number): string {
         case TerritoryScope.Continent:
         case TerritoryScope.Region:
           return 'region' + (count > 1 ? 's' : '');
-        case TerritoryScope.Subcontinent:
-          return 'territor' + (count > 1 ? 'ies' : 'y');
         case TerritoryScope.Country:
         case TerritoryScope.Dependency:
           return 'subdivision' + (count > 1 ? 's' : '');
+        case TerritoryScope.Subcontinent:
+        default:
+          return 'territor' + (count > 1 ? 'ies' : 'y');
       }
-    // eslint-disable-next-line no-fallthrough
     case ObjectType.WritingSystem:
       return 'child writing system' + (count > 1 ? 's' : '');
     case ObjectType.VariantTag:

--- a/src/widgets/reports/LocaleCitationCounts.tsx
+++ b/src/widgets/reports/LocaleCitationCounts.tsx
@@ -5,7 +5,7 @@ import useFilteredObjects from '@features/transforms/filtering/useFilteredObject
 
 import { CensusCollectorType } from '@entities/census/CensusTypes';
 import { LanguageScope } from '@entities/language/LanguageTypes';
-import { TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
 
 import CollapsibleReport from '@shared/containers/CollapsibleReport';
 

--- a/src/widgets/reports/PotentialLocales.tsx
+++ b/src/widgets/reports/PotentialLocales.tsx
@@ -14,15 +14,14 @@ import { getSortFunction, sortByPopulation } from '@features/transforms/sorting/
 import { CensusData } from '@entities/census/CensusTypes';
 import { LanguageCode, LanguageData } from '@entities/language/LanguageTypes';
 import LocaleCensusCitation from '@entities/locale/LocaleCensusCitation';
-import { usePotentialLocaleThreshold } from '@entities/locale/PotentialLocaleThreshold';
 import {
-  BCP47LocaleCode,
-  isTerritoryGroup,
   LocaleData,
   LocaleSource,
   PopulationSourceCategory,
-  TerritoryCode,
-} from '@entities/types/DataTypes';
+  StandardLocaleCode,
+} from '@entities/locale/LocaleTypes';
+import { usePotentialLocaleThreshold } from '@entities/locale/PotentialLocaleThreshold';
+import { isTerritoryGroup, TerritoryCode } from '@entities/territory/TerritoryTypes';
 
 import CollapsibleReport from '@shared/containers/CollapsibleReport';
 
@@ -216,7 +215,7 @@ function getPotentialLocales(
   // Iterate through all censuses and find locales that are not listed
   const allMissingLocales = useMemo(
     () =>
-      censuses.reduce<Record<BCP47LocaleCode, LocaleData>>((missing, census) => {
+      censuses.reduce<Record<StandardLocaleCode, LocaleData>>((missing, census) => {
         Object.entries(census.languageEstimates ?? {})?.forEach(([langID, populationEstimate]) => {
           const localeID = langID + '_' + census.isoRegionCode;
           const lang = getLanguage(langID);

--- a/src/widgets/reports/TableOfCountriesWithCensuses.tsx
+++ b/src/widgets/reports/TableOfCountriesWithCensuses.tsx
@@ -8,7 +8,7 @@ import TableID from '@features/table/TableID';
 import Field from '@features/transforms/fields/Field';
 
 import { CensusCollectorType } from '@entities/census/CensusTypes';
-import { TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import CollapsibleReport from '@shared/containers/CollapsibleReport';
 import CommaSeparated from '@shared/ui/CommaSeparated';

--- a/src/widgets/tables/LocaleTable.tsx
+++ b/src/widgets/tables/LocaleTable.tsx
@@ -16,7 +16,7 @@ import {
 import { getCountriesInObject } from '@entities/lib/getObjectRelatedTerritories';
 import LocaleNameWithFilters from '@entities/locale/LocaleNameWithFilters';
 import { getOfficialLabel } from '@entities/locale/LocaleStrings';
-import { LocaleData } from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
 import ObjectWikipediaInfo from '@entities/ui/ObjectWikipediaInfo';
 
 import { toSentenceCase } from '@shared/lib/stringUtils';

--- a/src/widgets/tables/TableOfLanguagesInCensus.tsx
+++ b/src/widgets/tables/TableOfLanguagesInCensus.tsx
@@ -19,7 +19,8 @@ import {
   getLanguageRootLanguageFamily,
   getLanguageRootMacrolanguage,
 } from '@entities/language/LanguageFamilyUtils';
-import { LocaleData, TerritoryScope } from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
 
 import Deemphasized from '@shared/ui/Deemphasized';
 import { PercentageDifference } from '@shared/ui/PercentageDifference';

--- a/src/widgets/tables/TableOfLanguagesInTerritory.tsx
+++ b/src/widgets/tables/TableOfLanguagesInTerritory.tsx
@@ -9,7 +9,8 @@ import Field from '@features/transforms/fields/Field';
 
 import LocaleCensusCitation from '@entities/locale/LocaleCensusCitation';
 import { getOfficialLabel } from '@entities/locale/LocaleStrings';
-import { LocaleData, TerritoryData } from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import Deemphasized from '@shared/ui/Deemphasized';
 

--- a/src/widgets/tables/TerritoryTable.tsx
+++ b/src/widgets/tables/TerritoryTable.tsx
@@ -17,7 +17,7 @@ import {
   getTerritoryChildren,
   getTerritoryCountries,
 } from '@entities/lib/getObjectRelatedTerritories';
-import { TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import { numberToSigFigs } from '@shared/lib/numberUtils';
 import { sumBy } from '@shared/lib/setUtils';

--- a/src/widgets/tables/VariantTagTable.tsx
+++ b/src/widgets/tables/VariantTagTable.tsx
@@ -12,7 +12,7 @@ import Field from '@features/transforms/fields/Field';
 import { getWritingSystemsInObject } from '@entities/lib/getObjectMiscFields';
 import { getObjectPopulation } from '@entities/lib/getObjectPopulation';
 import { getChildTerritoriesInObject } from '@entities/lib/getObjectRelatedTerritories';
-import { VariantTagData } from '@entities/types/DataTypes';
+import { VariantTagData } from '@entities/varianttag/VariantTagTypes';
 
 import CommaSeparated from '@shared/ui/CommaSeparated';
 

--- a/src/widgets/tables/WritingSystemTable.tsx
+++ b/src/widgets/tables/WritingSystemTable.tsx
@@ -10,7 +10,7 @@ import Field from '@features/transforms/fields/Field';
 import { sortByPopulation } from '@features/transforms/sorting/sort';
 
 import { getCountriesInObject } from '@entities/lib/getObjectRelatedTerritories';
-import { WritingSystemData } from '@entities/types/DataTypes';
+import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 import CommaSeparated from '@shared/ui/CommaSeparated';
 

--- a/src/widgets/tables/columns/LocalePopulationColumns.tsx
+++ b/src/widgets/tables/columns/LocalePopulationColumns.tsx
@@ -4,7 +4,7 @@ import Field from '@features/transforms/fields/Field';
 import CensusCountForLocale from '@entities/census/CensusCountForLocale';
 import LocaleCensusCitation from '@entities/locale/LocaleCensusCitation';
 import LocalePopulationAdjusted from '@entities/locale/LocalePopulationAdjusted';
-import { LocaleData } from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
 
 export const LocalePopulationColumns: TableColumn<LocaleData>[] = [
   {

--- a/src/widgets/tables/columns/LocaleRelatedLocalesColumns.tsx
+++ b/src/widgets/tables/columns/LocaleRelatedLocalesColumns.tsx
@@ -1,7 +1,7 @@
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import TableColumn from '@features/table/TableColumn';
 
-import { LocaleData } from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
 
 import CommaSeparated from '@shared/ui/CommaSeparated';
 

--- a/src/widgets/treelists/CensusHierarchy.tsx
+++ b/src/widgets/treelists/CensusHierarchy.tsx
@@ -8,7 +8,8 @@ import { TreeNodeData } from '@features/treelist/TreeListNode';
 import TreeListPageBody from '@features/treelist/TreeListPageBody';
 
 import { CensusData } from '@entities/census/CensusTypes';
-import { ObjectData, TerritoryData } from '@entities/types/DataTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
+import { ObjectData } from '@entities/types/DataTypes';
 
 export const CensusHierarchy: React.FC = () => {
   const { territories } = useDataContext();

--- a/src/widgets/treelists/LocaleHierarchy.tsx
+++ b/src/widgets/treelists/LocaleHierarchy.tsx
@@ -8,7 +8,9 @@ import { TreeNodeData } from '@features/treelist/TreeListNode';
 import TreeListPageBody from '@features/treelist/TreeListPageBody';
 
 import { LanguageCode, LanguageData } from '@entities/language/LanguageTypes';
-import { LocaleData, ObjectData, WritingSystemData } from '@entities/types/DataTypes';
+import { LocaleData } from '@entities/locale/LocaleTypes';
+import { ObjectData } from '@entities/types/DataTypes';
+import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 export const LocaleHierarchy: React.FC = () => {
   const { languagesInSelectedSource } = useDataContext();

--- a/src/widgets/treelists/TerritoryHierarchy.tsx
+++ b/src/widgets/treelists/TerritoryHierarchy.tsx
@@ -7,7 +7,8 @@ import { getSortFunction } from '@features/transforms/sorting/sort';
 import { TreeNodeData } from '@features/treelist/TreeListNode';
 import TreeListPageBody from '@features/treelist/TreeListPageBody';
 
-import { ObjectData, TerritoryData, TerritoryScope } from '@entities/types/DataTypes';
+import { TerritoryData, TerritoryScope } from '@entities/territory/TerritoryTypes';
+import { ObjectData } from '@entities/types/DataTypes';
 
 export const TerritoryHierarchy: React.FC = () => {
   const { territories } = useDataContext();

--- a/src/widgets/treelists/VariantTagHierarchy.tsx
+++ b/src/widgets/treelists/VariantTagHierarchy.tsx
@@ -7,7 +7,8 @@ import { TreeNodeData } from '@features/treelist/TreeListNode';
 import TreeListPageBody from '@features/treelist/TreeListPageBody';
 
 import getObjectFromID from '@entities/lib/getObjectFromID';
-import { ObjectData, VariantTagData } from '@entities/types/DataTypes';
+import { ObjectData } from '@entities/types/DataTypes';
+import { VariantTagData } from '@entities/varianttag/VariantTagTypes';
 
 export const VariantTagHierarchy: React.FC = () => {
   const { variantTags } = useDataContext();

--- a/src/widgets/treelists/WritingSystemHierarchy.tsx
+++ b/src/widgets/treelists/WritingSystemHierarchy.tsx
@@ -6,7 +6,8 @@ import { getSortFunction } from '@features/transforms/sorting/sort';
 import { TreeNodeData } from '@features/treelist/TreeListNode';
 import TreeListPageBody from '@features/treelist/TreeListPageBody';
 
-import { ObjectData, WritingSystemData } from '@entities/types/DataTypes';
+import { ObjectData } from '@entities/types/DataTypes';
+import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 export const WritingSystemHierarchy: React.FC = () => {
   const { writingSystems } = useDataContext();


### PR DESCRIPTION
Fixes #470 

Summary: `DataTypes` was getting too big. This PR breaks up the file into ones for each entity type.

### Changes
 
- Refactors
  - Makes `TerritoryTypes`, `LocaleTypes`, `WritingSystemTypes`, and `VariantTypes` out of `DataTypes` and redo all imports
- Data
  - Added some new locales relevant to the indigenous project

Out of scope/Future work: Rename ObjectData -> EntityData

### Test Plan and Screenshots

Build, lint & test