### PR TITLE
Report: Show missing fields

### DIFF
--- a/public/data/google/gboards.tsv
+++ b/public/data/google/gboards.tsv
@@ -529,7 +529,7 @@ gboard_mar_Deva	Marathi, Devanagari	mar		Deva	Deva
 gboard_mar_Latn	Marathi, Latin	mar		Latn	Latn	
 gboard_mas_Latn	Maasai	mas		Latn	Latn	
 gboard_max_Latn	North Moluccan Malay	max		Latn	Latn	
-gboard_may_Deva_t_k0_Latn	Marathi, Transliteration	may		Latn	Deva	
+gboard_mar_Deva_t_k0_Latn	Marathi, Transliteration	mar		Latn	Deva	
 gboard_mcn_Latn	Massa	mcn		Latn	Latn	
 gboard_mde_Arab	Maba, Arabic	mde		Arab	Arab	
 gboard_mde_Latn	Maba, Latin	mde		Latn	Latn	

--- a/public/data/languages.tsv
+++ b/public/data/languages.tsv
@@ -3173,7 +3173,7 @@ cbn	nyah1250	Nyahkur			Thai	10,000		moni1258	Yes
 ckm	chak1265	Chakavian			Latn	10,000		sout1528	Yes	
 ckq	kaja1254	Kajakse			Latn	10,000		mubi1247	Yes	
 cmi	embe1262	Emberá-Chamí			Latn	10,000		uppe1440	Yes	
-cnr	mont1282	Montenegrin	crnogorski			10,000	hbs	east2821	Yes, with caveat	Some countries only group this as "Serbo-Croatian" and the member languages are largely intelligible but for political reasons they are separated. Try to categorize these separately if possible
+cnr	mont1282	Montenegrin	crnogorski		Latn	10,000	hbs	east2821	Yes, with caveat	Some countries only group this as "Serbo-Croatian" and the member languages are largely intelligible but for political reasons they are separated. Try to categorize these separately if possible
 csf	cuba1235	Cuba Sign Language		Sign	Zxxx	10,000		deaf1237	Yes	
 dbj	idaa1241	Ida'an			Latn	10,000		nort3172	Yes	
 deg	dege1246	Degema			Latn	10,000		dege1249	Yes	

--- a/public/data/locales.tsv
+++ b/public/data/locales.tsv
@@ -9094,7 +9094,6 @@ djm_ML	Jamsay Dogon (Mali)
 dka_BT	Dakpakha (Bhutan)				
 dkg_NG	Kadung (Nigeria)				
 dks_SS	Southeastern Dinka (South Sudan)				
-dlc_SE	Dalecarlian (Sweden)	#N/A			
 dlm_HR	Dalmatian (Croatia)				
 dma_GA	Duma (Gabon)				
 dmf_NG	Medefaidrin (Nigeria)				
@@ -9129,7 +9128,7 @@ eaa_AU	Karenggapa (Australia)
 ebc_ID	Beginci (Indonesia)	bahasa Beginci			
 ebo_CG	Teke-Ebo (Congo - Brazzaville)				
 ecr_GR	Eteocretan (Greece)				
-eft_US	Efik (United States)	#N/A			
+efi_US	Efik (United States)		2,521		
 egm_TZ	Benamanga (Tanzania)				
 egy_EG	Egyptian (Ancient) (Egypt)	𓂋𓏤𓈖𓆎𓅓𓏏𓊖			
 ehs_JP	Miyakubo Sign Language (Japan)	宮窪手話			
@@ -9836,8 +9835,6 @@ pys_PY	Paraguayan Sign Language (Paraguay)
 pyx_MM	Pyu (Myanmar) (Myanmar)				
 pze_NG	Pesse (Nigeria)				
 pzh_TW	Pazeh (Taiwan)	Pazeh			
-qda_GT	Guazacapán Xinka (Guatemala)	#N/A			
-qhq_GT	Jumaytepeque Xinka (Guatemala)	#N/A			
 qud_EC	Calderón Highland Quichua (Ecuador)				
 quh_BO	South Bolivian Quechua (Bolivia)	Qullasuyu qhichwa simi			
 quq_ES	Quinqui (Spain)				
@@ -10627,3 +10624,4 @@ ido_NL	Ido (Netherlands)
 ido_FR	Ido (France)				
 ina_US	Interlingua (United States)				
 tok_CA	Toki Pona (Canada)				
+myi_IN	Mina (India)				

--- a/src/pages/dataviews/ViewReports.tsx
+++ b/src/pages/dataviews/ViewReports.tsx
@@ -7,6 +7,7 @@ import LanguagesMissingWritingSystems from '@widgets/reports/LanguagesMissingWri
 import LanguagesWithIdenticalNames from '@widgets/reports/LanguagesWithIdenticalNames';
 import LocaleCitationCounts from '@widgets/reports/LocaleCitationCounts';
 import PotentialLocales from '@widgets/reports/PotentialLocales';
+import ReportEntityUnknownFields from '@widgets/reports/ReportEntityUnknownFields';
 import TableOfCountriesWithCensuses from '@widgets/reports/TableOfCountriesWithCensuses';
 
 import { ObjectType } from '@features/params/PageParamTypes';
@@ -20,7 +21,8 @@ const ViewReports: React.FC = () => {
   const { objectType } = usePageParams();
 
   return (
-    <div style={{ textAlign: 'start' }}>
+    <div style={{ textAlign: 'start', display: 'flex', flexDirection: 'column', gap: '1em' }}>
+      <ReportEntityUnknownFields />
       <ReportsForObjectType objectType={objectType} />
     </div>
   );
@@ -54,9 +56,8 @@ const ReportsForObjectType: React.FC<{ objectType: ObjectType }> = ({ objectType
     case ObjectType.Census:
       return <TableOfCountriesWithCensuses />;
     case ObjectType.Territory:
-      return <div>There are no reports for this object type.</div>;
     case ObjectType.VariantTag:
-      return <div>There are no reports for this object type.</div>;
+      return <></>;
   }
 };
 

--- a/src/shared/containers/CollapsibleReport.tsx
+++ b/src/shared/containers/CollapsibleReport.tsx
@@ -15,7 +15,6 @@ const CollapsibleReport: React.FC<{
           cursor: 'pointer',
           textAlign: 'left',
           fontSize: '1.2em',
-          marginBottom: '1em',
         }}
       >
         {title}

--- a/src/widgets/reports/ReportEntityUnknownFields.tsx
+++ b/src/widgets/reports/ReportEntityUnknownFields.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
+import usePageParams from '@features/params/usePageParams';
+import Field from '@features/transforms/fields/Field';
+import { getSortBysApplicableToObjectType } from '@features/transforms/fields/FieldApplicability';
+import getField from '@features/transforms/fields/getField';
+import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
+
+import { ObjectData } from '@entities/types/DataTypes';
+
+import CollapsibleReport from '@shared/containers/CollapsibleReport';
+import CommaSeparated from '@shared/ui/CommaSeparated';
+
+const ReportEntityUnknownFields: React.FC = () => {
+  const { objectType } = usePageParams();
+  const { filteredObjects } = useFilteredObjects({});
+
+  const fields = getSortBysApplicableToObjectType(objectType);
+
+  const countTotal = filteredObjects.length;
+  const resultsByField = fields.reduce(
+    (acc, field) => {
+      const knownCount = filteredObjects.filter((obj) => getField(obj, field) != null).length;
+      const examples = filteredObjects.filter((obj) => getField(obj, field) == null).slice(0, 4);
+      acc[field] = { knownCount, missingCount: countTotal - knownCount, examples };
+      return acc;
+    },
+    {} as Record<Field, { knownCount: number; missingCount: number; examples: ObjectData[] }>,
+  );
+
+  return (
+    <CollapsibleReport title="Unknown Fields">
+      <table>
+        <thead>
+          <tr>
+            <th>Field</th>
+            <th>Known Count</th>
+            <th>Missing Count</th>
+            <th>Examples Missing</th>
+          </tr>
+        </thead>
+        <tbody>
+          {fields
+            .sort((a, b) => resultsByField[b].missingCount - resultsByField[a].missingCount)
+            .map((field) => (
+              <tr key={field}>
+                <td>{field}</td>
+                <td style={{ position: 'relative' }}>
+                  <div
+                    style={{
+                      position: 'absolute',
+                      zIndex: -1,
+                      top: 0,
+                      left: 0,
+                      height: '100%',
+                      width: `${(resultsByField[field].knownCount / countTotal) * 100}%`,
+                      backgroundColor: 'var(--color-button-secondary)',
+                    }}
+                  />
+                  {resultsByField[field].knownCount.toLocaleString()}
+                </td>
+
+                <td style={{ position: 'relative' }}>
+                  <div
+                    style={{
+                      position: 'absolute',
+                      zIndex: -1,
+                      top: 0,
+                      left: 0,
+                      height: '100%',
+                      width: `${(resultsByField[field].missingCount / countTotal) * 100}%`,
+                      backgroundColor: 'var(--color-button-secondary)',
+                    }}
+                  />
+                  {resultsByField[field].missingCount.toLocaleString()}
+                </td>
+                <td>
+                  <CommaSeparated>
+                    {resultsByField[field].examples.map((example, index) => (
+                      <HoverableObjectName key={index} object={example} labelSource="code" />
+                    ))}
+                  </CommaSeparated>
+                </td>
+              </tr>
+            ))}
+        </tbody>
+      </table>
+    </CollapsibleReport>
+  );
+};
+
+export default ReportEntityUnknownFields;


### PR DESCRIPTION
Fixes #489 

Summary: I'm working on adding indigenous language information but there is a lot of data there so I cannot collect it all right now. So I wanted to add a report to track how many fields are unknown.

### Changes

- User experience
  - New reports in Report tab
- Logical changes
  - none
- Data
  - Spurious locales removed, some typos fixed, some basic data provided
- Refactors
  - none

Out of scope/Future work: Adding more data :D

### Test Plan and Screenshots

|What|Screenshot|
|--|--|
|[Locale Report](http://localhost:5173/lang-nav/data?view=Reports&objectType=Locale)|<img width="1343" height="887" alt="Screenshot 2026-02-23 at 10 55 50" src="https://github.com/user-attachments/assets/ab2ed152-cc1f-4542-9c0b-e866db258352" />
|[Variant report](http://localhost:5173/lang-nav/data?view=Reports&objectType=Variant+Tag)|<img width="627" height="638" alt="Screenshot 2026-02-23 at 10 55 24" src="https://github.com/user-attachments/assets/472eadfa-8517-4b25-b452-a2d1dbed0c29" />
