### PR TITLE
Add filter panel context and UI controls

### DIFF
--- a/src/features/pagination/ResultCount.tsx
+++ b/src/features/pagination/ResultCount.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
+
+const ResultCount: React.FC = () => {
+  const { filteredObjects } = useFilteredObjects({});
+  return (
+    <span style={{ fontSize: '0.9em', color: 'var(--color-text)', whiteSpace: 'nowrap' }}>
+      {filteredObjects.length} Results
+    </span>
+  );
+};
+
+export default ResultCount;

--- a/src/pages/DataPage.tsx
+++ b/src/pages/DataPage.tsx
@@ -5,6 +5,7 @@ import Loading from '@widgets/Loading';
 
 import HoverCardProvider from '@features/layers/hovercard/HoverCardProvider';
 
+const FilterPanelProvider = React.lazy(() => import('@widgets/controls/FilterPanelProvider'));
 const PageParamsProvider = React.lazy(() => import('@features/params/PageParamsProvider'));
 const DataProvider = React.lazy(() => import('@features/data/context/DataProvider'));
 const DataPageBody = React.lazy(() => import('./DataPageBody'));
@@ -19,11 +20,13 @@ const DataPage: React.FC = () => {
         <HoverCardProvider>
           {/* HoverCardProvider is re-declared so it has access to page parameters, there may be a better way to organize it */}
           <DataProvider>
-            <div style={{ display: 'flex', height: '100vh' }}>
-              <OptionsPanel />
-              <DataPageBody />
-              <DetailsPanel />
-            </div>
+            <FilterPanelProvider>
+              <div style={{ display: 'flex', height: '100vh' }}>
+                <OptionsPanel />
+                <DataPageBody />
+                <DetailsPanel />
+              </div>
+            </FilterPanelProvider>
             <ViewModal />
           </DataProvider>
         </HoverCardProvider>

--- a/src/pages/DataPageBody.tsx
+++ b/src/pages/DataPageBody.tsx
@@ -1,8 +1,12 @@
+import { SlidersHorizontalIcon } from 'lucide-react';
 import React, { Suspense } from 'react';
 
+import useFilterPanel from '@widgets/controls/useFilterPanel';
 import Loading from '@widgets/Loading';
 import PathNav from '@widgets/pathnav/PathNav';
 
+import HoverableButton from '@features/layers/hovercard/HoverableButton';
+import ResultCount from '@features/pagination/ResultCount';
 import SearchBar from '@features/transforms/search/SearchBar';
 
 import EntityTypeTabs from './dataviews/EntityTypeTabs';
@@ -10,12 +14,35 @@ import EntityTypeTabs from './dataviews/EntityTypeTabs';
 const DataViews = React.lazy(() => import('./dataviews/DataViews'));
 
 const DataPageBody: React.FC = () => {
+  const { isOpen, setIsOpen } = useFilterPanel();
+
   return (
     <main style={{ padding: '1em', flex: 1, overflow: 'auto', width: '100%' }}>
       <div style={{ display: 'flex', alignItems: 'center', flexDirection: 'column' }}>
         <SearchBar />
         <EntityTypeTabs />
-        <PathNav />
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.5em' }}>
+            <HoverableButton
+              className={isOpen ? 'selected primary' : 'primary'}
+              hoverContent={isOpen ? 'Close filters panel' : 'Open filters panel'}
+              onClick={() => setIsOpen((open) => !open)}
+              style={{ padding: '0.4em', borderRadius: '0.5em', display: 'flex' }}
+              aria-label={isOpen ? 'Close filters panel' : 'Open filters panel'}
+            >
+              <SlidersHorizontalIcon size="1.2em" />
+            </HoverableButton>
+            <ResultCount />
+          </div>
+          <PathNav />
+        </div>
       </div>
       <div
         style={{

--- a/src/widgets/controls/FilterPanelContext.tsx
+++ b/src/widgets/controls/FilterPanelContext.tsx
@@ -1,0 +1,8 @@
+import React, { createContext } from 'react';
+
+export type FilterPanelContextType = {
+  isOpen: boolean;
+  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export const FilterPanelContext = createContext<FilterPanelContextType | null>(null);

--- a/src/widgets/controls/FilterPanelProvider.tsx
+++ b/src/widgets/controls/FilterPanelProvider.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect, useState } from 'react';
+
+import usePageParams from '@features/params/usePageParams';
+
+import { FilterPanelContext } from './FilterPanelContext';
+
+const FilterPanelProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(true);
+  const { objectID } = usePageParams();
+
+  useEffect(() => {
+    if (objectID) setIsOpen(false);
+  }, [objectID]);
+
+  return (
+    <FilterPanelContext.Provider value={{ isOpen, setIsOpen }}>
+      {children}
+    </FilterPanelContext.Provider>
+  );
+};
+
+export default FilterPanelProvider;

--- a/src/widgets/controls/ResizablePanel.tsx
+++ b/src/widgets/controls/ResizablePanel.tsx
@@ -3,6 +3,7 @@ import React, { ReactNode, useCallback, useEffect } from 'react';
 import usePageParams from '@features/params/usePageParams';
 
 import SidePanelToggleButton from './SidePanelToggleButton';
+import useFilterPanel from './useFilterPanel';
 
 type Props = {
   purpose: 'filters' | 'details'; // filters on left, details on right
@@ -17,14 +18,20 @@ const ResizablePanel: React.FC<React.PropsWithChildren<Props>> = ({
   title,
 }) => {
   const { objectID } = usePageParams();
-  const [isOpen, setIsOpen] = React.useState(purpose === 'filters');
-  const [panelWidth, setPanelWidth] = React.useState(defaultWidth); // but will change to pixels on resize
+  const filterPanel = useFilterPanel();
+
+  // For filters, use shared context state; for details, use local state
+  const [localIsOpen, setLocalIsOpen] = React.useState(false);
+  const isOpen = purpose === 'filters' ? filterPanel.isOpen : localIsOpen;
+  const setIsOpen = purpose === 'filters' ? filterPanel.setIsOpen : setLocalIsOpen;
+
+  const [panelWidth, setPanelWidth] = React.useState(defaultWidth);
   const panelSide = purpose === 'filters' ? 'left' : 'right';
   const [shouldEaseTransition, setShouldEaseTransition] = React.useState(false);
 
   useEffect(() => {
-    // When an object is set, close the side panel
-    if (objectID) setIsOpen(purpose === 'details');
+    // When an object is set, open the details panel
+    if (objectID && purpose === 'details') setLocalIsOpen(true);
   }, [objectID, purpose]);
 
   return (
@@ -70,12 +77,15 @@ const ResizablePanel: React.FC<React.PropsWithChildren<Props>> = ({
         </div>
       </div>
 
-      <SidePanelToggleButton
-        isOpen={isOpen}
-        onClick={() => setIsOpen((open) => !open)}
-        panelWidth={panelWidth}
-        purpose={purpose}
-      />
+      {/* Only show the floating toggle button for the details panel */}
+      {purpose === 'details' && (
+        <SidePanelToggleButton
+          isOpen={isOpen}
+          onClick={() => setIsOpen((open) => !open)}
+          panelWidth={panelWidth}
+          purpose={purpose}
+        />
+      )}
     </aside>
   );
 };

--- a/src/widgets/controls/useFilterPanel.tsx
+++ b/src/widgets/controls/useFilterPanel.tsx
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+
+import { FilterPanelContext, FilterPanelContextType } from './FilterPanelContext';
+
+const useFilterPanel = (): FilterPanelContextType => {
+  const ctx = useContext(FilterPanelContext);
+  if (!ctx) throw new Error('useFilterPanel must be used within FilterPanelProvider');
+  return ctx;
+};
+
+export default useFilterPanel;


### PR DESCRIPTION
Fixes #484

  Summary: Introduce FilterPanelContext, FilterPanelProvider and useFilterPanel hook and wire them into DataPage/DataPageBody. Update ResizablePanel to use shared state for the filters panel and keep a local toggle for the details panel. Selecting an object now closes filters and opens details. Also add ResultCount and a filter toggle button (Sliders icon) in the page header to show the current filtered count.

  ### Changes

  - User experience
    - Filter panel can now be toggled from a SlidersHorizontal icon button in the content area header (left-aligned, below search bar and entity tabs)
    - Filtered result count ("X Results") is displayed next to the toggle button
    - PathNav breadcrumb moved to the right side of the same row
    - Selecting an object closes the filters panel and opens the details panel
    - Floating filter toggle button removed from the panel edge (details panel keeps its floating toggle)
  - Logical changes
    - New `FilterPanelContext` / `FilterPanelProvider` / `useFilterPanel` to share filter panel open/close state between `ResizablePanel` and `DataPageBody`
    - `ResizablePanel` uses shared context state for `purpose === 'filters'` and local state for `purpose === 'details'`
    - New `ResultCount` component uses `useFilteredObjects` to display the current filtered count
  - Refactors
    - Split filter panel state into context/provider/hook files following the same pattern as `PageParamsContext` / `PageParamsProvider` / `usePageParams`
    - `FilterPanelProvider` is lazy-loaded in `DataPage` consistent with other providers


  ### Test Plan and Screenshots

  How to test the changes in this PR:
  1. Open the data page: filter toggle button and result count should appear below the entity tabs, left-aligned
  2. Click the sliders icon: filters panel should toggle open/close
  3. PathNav should appear on the right side of the same row
  4. Click on an object: filters panel should close, details panel should open
  5. The floating toggle button on the filter panel edge should be gone; the details panel floating toggle should still work

  | Page/View with link | Description of Changes | Screenshot Before | Screenshot After |
  | ------------------- | ---------------------- | ----------------- | ---------------- |
  | /data               | Filter toggle + result count in header, PathNav right-aligned | <img width="1910" height="968" alt="image" src="https://github.com/user-attachments/assets/af7e385c-9d47-4f28-8ccb-7ed4aad53b93" /> | <img width="1911" height="969" alt="image" src="https://github.com/user-attachments/assets/5f32e75f-4b3a-48c0-9f0a-37f0dee4a178" />  |
  | /data?objectID=eng  | Selecting object closes filters, opens details |    <img width="1912" height="970" alt="image" src="https://github.com/user-attachments/assets/6d36af09-ea4f-4073-ba3d-1ecc4299c911" />   |    <img width="1913" height="971" alt="image" src="https://github.com/user-attachments/assets/65b89827-af87-48d5-ad81-d89bb9bfe406" /> |

  # Checklist

- [x] Clear description of what and why
- [x] Scope kept focused; note follow-ups if any
- [x] Mention the issue

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run dev` -- tried out the website directly
	- [x] Include screenshots as noted below

- [x] Logical changes
- [x] Refactors, moving files around
- [x] Code is self-documenting