### PR TITLE
Update: Change Language Subtitle to Endonym, bump Scope to CardField

### DIFF
--- a/src/entities/language/LanguageCard.tsx
+++ b/src/entities/language/LanguageCard.tsx
@@ -3,6 +3,7 @@ import {
   MapPinIcon,
   MapPinnedIcon,
   MessageCircleIcon,
+  NetworkIcon,
   UsersIcon,
 } from 'lucide-react';
 import React from 'react';
@@ -20,6 +21,8 @@ import ObjectTitle from '@entities/ui/ObjectTitle';
 import CardField from '@shared/containers/CardField';
 import { uniqueBy } from '@shared/lib/setUtils';
 import CommaSeparated from '@shared/ui/CommaSeparated';
+
+import { getLanguageScopeLabel } from '@strings/LanguageScopeStrings';
 
 import { getModalityLabel } from './LanguageModalityDisplay';
 import { LanguagePopulationEstimate } from './population/LanguagePopulationEstimate';
@@ -45,6 +48,14 @@ const LanguageCard: React.FC<Props> = ({ lang }) => {
         <ObjectTitle object={lang} />
         <ObjectSubtitle object={lang} />
       </div>
+
+      <CardField
+        title="Language Type"
+        icon={NetworkIcon}
+        description="Whether this is a Language Family, Macrolanguage, Individual Language, or Dialect."
+      >
+        {getLanguageScopeLabel(lang.scope)}
+      </CardField>
 
       {populationEstimate != null && (
         <CardField

--- a/src/entities/lib/getObjectName.ts
+++ b/src/entities/lib/getObjectName.ts
@@ -1,9 +1,6 @@
 import { ObjectType } from '@features/params/PageParamTypes';
 
-import { LanguageData } from '@entities/language/LanguageTypes';
 import { ObjectData } from '@entities/types/DataTypes';
-
-import { getLanguageScopeLabel } from '@strings/LanguageScopeStrings';
 
 export function getObjectSubtitle(object: ObjectData): string | undefined {
   switch (object.type) {
@@ -17,7 +14,7 @@ export function getObjectSubtitle(object: ObjectData): string | undefined {
         .filter((c) => c != null && c != 'Any')
         .join(', ');
     case ObjectType.Language:
-      return getLanguageSubtitle(object);
+      return object.nameEndonym ?? object.nameSubtitle ?? undefined;
     case ObjectType.WritingSystem:
       return object.nameDisplay != object.nameFull ? object.nameFull : undefined;
     case ObjectType.Locale:
@@ -26,13 +23,6 @@ export function getObjectSubtitle(object: ObjectData): string | undefined {
     case ObjectType.Keyboard:
       return undefined;
   }
-}
-
-function getLanguageSubtitle(lang: LanguageData): string | undefined {
-  const composite = [getLanguageScopeLabel(lang.scope), lang.nameSubtitle]
-    .filter(Boolean)
-    .join(', ');
-  return composite !== '' ? composite : undefined;
 }
 
 export function getObjectTypeLabelPlural(objectType: ObjectType) {

--- a/src/entities/ui/ObjectTitle.tsx
+++ b/src/entities/ui/ObjectTitle.tsx
@@ -11,13 +11,12 @@ type Props = {
 };
 
 const ObjectTitle: React.FC<Props> = ({ object, highlightSearchMatches = true }) => {
-  const { codeDisplay, nameDisplay, nameEndonym } = object;
+  const { codeDisplay, nameDisplay } = object;
 
   if (!highlightSearchMatches) {
     return (
       <>
-        <strong>{nameDisplay}</strong>
-        {nameEndonym && nameDisplay != nameEndonym && ' ' + nameEndonym} [{codeDisplay}]
+        <strong>{nameDisplay}</strong> [{codeDisplay}]
       </>
     );
   }
@@ -27,12 +26,6 @@ const ObjectTitle: React.FC<Props> = ({ object, highlightSearchMatches = true })
       <strong>
         <ObjectFieldHighlightedByPageSearch object={object} field={SearchableField.NameDisplay} />
       </strong>{' '}
-      {nameDisplay != nameEndonym && (
-        <div style={{ display: 'inline-block' }}>
-          {/* placed in its own div to prevent right-to-left names from breaking */}
-          <ObjectFieldHighlightedByPageSearch object={object} field={SearchableField.NameEndonym} />
-        </div>
-      )}{' '}
       [
       <ObjectFieldHighlightedByPageSearch object={object} field={SearchableField.Code} />]
     </>

--- a/src/features/transforms/filtering/__tests__/FilterBreakdown.test.tsx
+++ b/src/features/transforms/filtering/__tests__/FilterBreakdown.test.tsx
@@ -68,7 +68,7 @@ describe('FilterBreakdown', () => {
     const { container } = render(<FilterBreakdown objects={objects} />);
 
     // Expected all of the filters to be shown
-    expect(screen.getByText(/Not macrolanguage or language:/i)).toBeTruthy();
+    expect(screen.getByText(/Not macrolanguage or individual language:/i)).toBeTruthy();
     expect(screen.getByText(/Not found in territory with code "US":/i)).toBeTruthy();
     expect(screen.getByText(/Not written in script with code "Latn":/i)).toBeTruthy();
     expect(screen.getByText(/Not related to language with code "ine":/i)).toBeTruthy();
@@ -132,7 +132,7 @@ describe('FilterBreakdown', () => {
     const { container } = render(<FilterBreakdown objects={objects} />);
 
     // No filters are applied, so no breakdown should be shown
-    expect(screen.queryByText(/Not macrolanguage or language:/i)).toBeTruthy(); // ine
+    expect(screen.queryByText(/Not macrolanguage or individual language:/i)).toBeTruthy(); // ine
     expect(screen.queryByText(/Not found in territory/i)).toBeNull(); // not active
     expect(screen.queryByText(/Not written in/i)).toBeNull(); // not active
     expect(screen.queryByText(/Not related to/i)).toBeNull(); // not active
@@ -158,7 +158,7 @@ describe('FilterBreakdown', () => {
     const { container } = render(<FilterBreakdown objects={objects} />);
 
     // Expected all of the filters to be shown
-    expect(screen.getByText(/Not macrolanguage or language:/i)).toBeTruthy();
+    expect(screen.getByText(/Not macrolanguage or individual language:/i)).toBeTruthy();
     expect(screen.getByText(/Not found in United States:/i)).toBeTruthy();
     expect(screen.getByText(/Not written in Latin:/i)).toBeTruthy();
     expect(screen.getByText(/Not related to Indo-European:/i)).toBeTruthy();

--- a/src/features/transforms/filtering/selectors/__tests__/LanguageFilterSelector.test.tsx
+++ b/src/features/transforms/filtering/selectors/__tests__/LanguageFilterSelector.test.tsx
@@ -67,7 +67,7 @@ describe('LanguageFilterSelector', () => {
     expect(items[6]).toHaveTextContent('Russian');
     expect(items[7]).toHaveTextContent('Navajo');
     expect(items[8]).toHaveTextContent('Chinese');
-    expect(items[9]).toHaveTextContent('not macrolanguage or language');
+    expect(items[9]).toHaveTextContent('not macrolanguage or individual language');
     expect(items[10]).toHaveTextContent('Indo-European languages');
     expect(items[11]).toHaveTextContent('Germanic');
     // User types in German, suggestions should filter to German and Germanic
@@ -75,7 +75,7 @@ describe('LanguageFilterSelector', () => {
     expect(items.length).toBe(4);
     expect(items[0]).toHaveTextContent('Pick a suggestion or press [enter] to filter by "German"');
     expect(items[1]).toHaveTextContent('German');
-    expect(items[2]).toHaveTextContent('not macrolanguage or language');
+    expect(items[2]).toHaveTextContent('not macrolanguage or individual language');
     expect(items[3]).toHaveTextContent('Germanic');
     expect(updatePageParams).not.toHaveBeenCalled(); // it is no longer automatically called after input
 


### PR DESCRIPTION
Fixes #400 

Summary: Moves the language scope label (e.g. "Macrolanguage", "Individual Language") from the card subtitle into an explicit Language Type (`CardField`) with a `NetworkIcon`. The subtitle now shows the language's endonym (native name) instead. Endonyms are also removed from `ObjectTitle` across all entity types to reduce visual clutter and make card heights consistent.

### Changes

- User experience
  - Language cards now show scope as a dedicated field row with a network/hierarchy icon, rather than as italicized subtitle text
  - Language card subtitles display the endonym instead of the scope label
  - Card heights are more uniform since the variable-length scope text no longer affects subtitle size
  - Endonyms removed from `ObjectTitle` for all entity types (Languages, Locales, Territories, etc.) — title now shows only display name + code

- Logical changes
  - Added NetworkIcon import and a new `Language Type` CardField calling `getLanguageScopeLabel()`
  - Removed `getLanguageSubtitle()` from `getObjectName.ts`, language subtitle now returns `nameEndonym ?? nameSubtitle`
  - Removed endonym rendering from `ObjectTitle.tsx` (both highlighted and non-highlighted paths)
- Data
  - ...
- Refactors
  - Removed unused `LanguageData` and `getLanguageScopeLabel` imports from `getObjectName.ts`
  - Tests
     - Updated assertions in [FilterBreakdown.test.tsx](src/features/transforms/filtering/__tests__/FilterBreakdown.test.tsx) and [LanguageFilterSelector.test.tsx](src/features/transforms/filtering/selectors/__tests__/LanguageFilterSelector.test.tsx).
     - These tests verify the filter breakdown labels and search suggestions, which include scope names dynamically generated via [getLanguageScopeLabel()].
     -  Since [LanguageScope.Language] already returns `Individual Language`, the filter text changed from `not macrolanguage or language` to `not macrolanguage or individual language`. The test expectations were updated to match this corrected wording.

Out of scope/Future work: 
  - Revising territory and writing system subtitles (separate task)
  - Other card layout changes from [@LuoZihYuan's ](https://www.figma.com/proto/ZGJOgi5MnvtrKeaBJFrtZa/Language-Navigator?node-id=361-3&t=ae2PI8RkLX7axmzm-1&scaling=contain&content-scaling=fixed&page-id=361%3A2&starting-point-node-id=361%3A3) design (population formatting, writing system pills, digital support badges, etc.)

### Test Plan and Screenshots

How to test the changes in this PR: 
1. Navigate to `/data` with Languages in Card view
2. Verify language cards show a `Language Type` field with a network icon (hover to see tooltip)
3. Compare English (no subtitle — endonym matches display name) vs Chinese (subtitle shows 中文)
4. Check that `Macrolanguage` / `Individual Language` no longer appear in the italic subtitle
5. Confirm `endonyms `no longer appear inline in the bold title for any entity type

| Page/View with link | Description of Changes | Screenshot Before | Screenshot After |
| ------------------- | ---------------------- | ----------------- | ---------------- |
|  /data  |  Scope moved from subtitle to CardField + endonym now in subtitle + endonym removed from title  | <img width="1500" height="900" alt="Screenshot 2026-03-04 at 23 45 33" src="https://github.com/user-attachments/assets/f16ccdac-948e-4c74-89a6-b094b0a52dfc" /> | <img width="1500" height="900" alt="Screenshot 2026-03-04 at 23 40 21" src="https://github.com/user-attachments/assets/9632daee-171f-4d0f-a1ee-167b4930cff4" /> |

# Checklist

Feel free to check off or just delete items in this section as you have completed them.

## Summary

- [x] Clear description of what and why
- [x] Scope kept focused; note follow-ups if any
- [x] Set yourself as assignee
- [x] Mention the issue
  - [ ] If there is no issue, create one in [the repository issues page](https://github.com/Translation-Commons/lang-nav/issues) and link it here.

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test`
  - [x] Tests added or updated for changed logic
- [x] `npm run dev` -- tried out the website directly
  - [x] Include screenshots as noted below
  - [x] Write comments on manual testing

## Changes

### Visual changes

- [x] Add screenshots to the table template at the top of this file. You can include images inside the table
  - [x] Drag and drop images in the GitHub PR comment box to upload screenshots
- [ ] Purely new views can just include the "after" screenshot.
- [ ] Since more views can be reproduced by just sharing the URL -- add links (eg. [link](https://translation-commons.github.io/lang-nav/data)) to the relevant page and/or conditions to reproduce the view.

### Data changes

- [ ] TSV, SVG, etc. edits in `public/data/`
- [ ] Corresponding readmes updated in `public/data/`
- [ ] Load/connect/compute updates in `src/features/data/` including how we aggregate data or compute derived values

### Internal changes

- [x] Logical changes
- [ ] Refactors, moving files around
- [x] If you notice any changes that require explanations, make sure to include the explanations in the code as well.

## Docs

- [x] Code is self-documenting, or if not, comments are added where needed.
- [ ] Updated markdown readme files documenting how the code behaves or how to develop in case there are any relevant changes to make.
