### PR TITLE
fix: move PageParamsProvider to top level for direct URL access

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -7,6 +7,7 @@ import HoverCardProvider from '@features/layers/hovercard/HoverCardProvider';
 import PageParamsProvider from '@features/params/PageParamsProvider';
 
 import PageRoutes from './PageRoutes';
+
 import './index.css';
 
 function App() {


### PR DESCRIPTION
Fixes #539 

#### Changes

- Moved `PageParamsProvider` to the top level of App. `DataProvider` remains deferred.
- Renamed `DeferredDataProviders` to `DeferredDataProvider` 
