### PR TITLE
Colorbar: Show enums better

### DIFF
--- a/src/features/transforms/coloring/ColorBar.tsx
+++ b/src/features/transforms/coloring/ColorBar.tsx
@@ -219,20 +219,12 @@ function getSuffixForField(field: Field): string {
 }
 
 function isFieldWholeNumbersOnly(field: Field): boolean {
-  switch (field) {
-    case Field.CountOfLanguages:
-    case Field.CountOfWritingSystems:
-    case Field.CountOfCountries:
-    case Field.CountOfChildTerritories:
-    case Field.CountOfCensuses:
-    case Field.Depth:
-    case Field.Population:
-    case Field.PopulationDirectlySourced:
-    case Field.PopulationOfDescendants:
-      return true;
-    default:
-      return false;
-  }
+  const valueType = getFieldValueType(field);
+  return (
+    valueType === TableValueType.Count ||
+    valueType === TableValueType.Enum ||
+    valueType === TableValueType.Population
+  );
 }
 
 function pickDistributedTicksFromRange<T>(range: T[], count: number): T[] {


### PR DESCRIPTION
Fixes #544

Summary: When I was making screenshots I noticed that oddly the colorbar was showing continuous colors for enums -- it should show blocks instead.

### Changes

- User experience
  - Colorbars show up better for enums
- Logical changes
  - Simplified isWholeNumber logic

### Test Plan and Screenshots

How to test the changes in this PR: Try out coloring the map with different enums

| Page/View with link | Description of Changes | Screenshot Before | Screenshot After |
| ------------------- | ---------------------- | ----------------- | ---------------- |
|[Map view showing an enum](https://translation-commons.github.io/lang-nav/data?view=Map&limit=-1&colorBy=Language+Scope&languageScopes=5%2C4%2C3%2C2)|You can see |<img width="1394" height="950" alt="Screenshot 2026-03-18 at 16 53 51" src="https://github.com/user-attachments/assets/e48543f7-0af2-4d80-a5fa-d8ff900cf7a5" />|<img width="1384" height="951" alt="Screenshot 2026-03-18 at 16 57 12" src="https://github.com/user-attachments/assets/bcfa978e-6e3e-4342-858e-09baaa8eae1c" />
