### PR TITLE
Move table column selector from accordion to modal

### DIFF
--- a/src/features/layers/modal/ViewModal.tsx
+++ b/src/features/layers/modal/ViewModal.tsx
@@ -1,48 +1,48 @@
 import { XIcon } from 'lucide-react';
 import React, { useEffect } from 'react';
 
-import usePageParams from '@features/params/usePageParams';
-
 import { useClickOutside } from '@shared/hooks/useClickOutside';
 
 import HoverableButton from '../hovercard/HoverableButton';
 
 import './modal.css';
 
-// This modal is not used right now but the code and functionality is left in to be re-adapted for other purposes.
-const ViewModal: React.FC = () => {
-  const { objectID, updatePageParams } = usePageParams();
-  const onClose = () => updatePageParams({ objectID: undefined });
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: React.ReactNode;
+  children: React.ReactNode;
+  bodyStyle?: React.CSSProperties;
+}
 
+const ViewModal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, bodyStyle }) => {
   const modalRef = useClickOutside(onClose);
 
   useEffect(() => {
-    // TODO there is a problem with this changing the page parameters beyond the modal object
+    if (!isOpen) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         onClose();
       }
     };
-
     document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
 
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [onClose]);
-
-  if (objectID !== 'modal_test') return null;
+  if (!isOpen) return <></>;
 
   return (
     <div className="ModalOverlay">
       <div className="Modal" aria-modal="true" role="dialog" ref={modalRef}>
         <div className="ModalHeader">
-          <div className="ModalTitle">Modal test active</div>
+          <div className="ModalTitle">{title}</div>
           <HoverableButton buttonType="reset" hoverContent="Close modal" onClick={onClose}>
             <XIcon size="1.5em" display="block" />
           </HoverableButton>
         </div>
-        <div className="ModalBody">content</div>
+        <div className="ModalBody" style={bodyStyle}>
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/src/features/layers/modal/__tests__/ViewModal.test.tsx
+++ b/src/features/layers/modal/__tests__/ViewModal.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ViewModal from '../ViewModal';
+
+vi.mock('@features/layers/hovercard/useHoverCard', () => ({
+  default: vi.fn().mockReturnValue({ showHoverCard: vi.fn(), hideHoverCard: vi.fn() }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cleanup();
+});
+
+describe('ViewModal', () => {
+  it('renders nothing when isOpen is false', () => {
+    render(
+      <ViewModal isOpen={false} onClose={vi.fn()} title="Test Modal">
+        <p>Modal content</p>
+      </ViewModal>,
+    );
+
+    expect(screen.queryByText('Test Modal')).toBeNull();
+    expect(screen.queryByText('Modal content')).toBeNull();
+  });
+
+  it('renders title and children when isOpen is true', () => {
+    render(
+      <ViewModal isOpen={true} onClose={vi.fn()} title="Test Modal">
+        <p>Modal content</p>
+      </ViewModal>,
+    );
+
+    expect(screen.getByText('Test Modal')).toBeTruthy();
+    expect(screen.getByText('Modal content')).toBeTruthy();
+  });
+
+  it('renders with aria-modal and dialog role', () => {
+    render(
+      <ViewModal isOpen={true} onClose={vi.fn()} title="Test Modal">
+        <p>Content</p>
+      </ViewModal>,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeTruthy();
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <ViewModal isOpen={true} onClose={onClose} title="Test Modal">
+        <p>Content</p>
+      </ViewModal>,
+    );
+
+    const closeButton = screen.getByRole('button');
+    fireEvent.click(closeButton);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when Escape key is pressed', () => {
+    const onClose = vi.fn();
+    render(
+      <ViewModal isOpen={true} onClose={onClose} title="Test Modal">
+        <p>Content</p>
+      </ViewModal>,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when clicking outside the modal', () => {
+    const onClose = vi.fn();
+    render(
+      <ViewModal isOpen={true} onClose={onClose} title="Test Modal">
+        <p>Content</p>
+      </ViewModal>,
+    );
+
+    // mousedown on the overlay (outside the modal)
+    const overlay = screen.getByText('Test Modal').closest('.ModalOverlay')!;
+    fireEvent.mouseDown(overlay);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('applies bodyStyle to the modal body', () => {
+    render(
+      <ViewModal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Test Modal"
+        bodyStyle={{ maxWidth: 'none', padding: '2em' }}
+      >
+        <p>Content</p>
+      </ViewModal>,
+    );
+
+    const body = screen.getByText('Content').closest('.ModalBody') as HTMLElement;
+    expect(body.style.maxWidth).toBe('none');
+    expect(body.style.padding).toBe('2em');
+  });
+});

--- a/src/features/layers/modal/modal.css
+++ b/src/features/layers/modal/modal.css
@@ -17,7 +17,9 @@
   background-color: var(--color-background);
   border-radius: 10px;
   box-shadow: var(--color-shadow) 0 0 2em 1em;
-  max-height: 100%;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .ModalHeader {
@@ -41,9 +43,10 @@
 }
 
 .ModalBody {
-  overflow: scroll;
+  overflow: auto;
   padding: 0 2em 0 2em;
-  max-height: 800px;
+  flex: 1;
+  min-height: 0;
   max-width: 600px;
 }
 .ModalBody .Details {

--- a/src/features/table/TableColumnSelector.tsx
+++ b/src/features/table/TableColumnSelector.tsx
@@ -1,8 +1,9 @@
 import { InfoIcon, SquareCheckIcon, SquareIcon, SquareMinusIcon } from 'lucide-react';
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import Hoverable from '@features/layers/hovercard/Hoverable';
 import HoverableButton from '@features/layers/hovercard/HoverableButton';
+import ViewModal from '@features/layers/modal/ViewModal';
 
 import { ObjectData } from '@entities/types/DataTypes';
 
@@ -23,33 +24,45 @@ function TableColumnSelector<T extends ObjectData>({
   const { columnVisibility } = visibilityModule;
   const columnsByGroup = groupBy(columns, (column) => column.columnGroup || column.key);
   const nVisible = columns.filter((col) => columnVisibility[col.key]).length;
+  const [isOpen, setIsOpen] = useState(false);
+  const onClose = useCallback(() => setIsOpen(false), []);
 
   return (
-    <details style={{ margin: '.5em 0 1em 0', gap: '.5em 1em' }}>
-      <summary style={{ cursor: 'pointer' }}>
-        {nVisible}/{columns.length} columns visible, click here to toggle.
-      </summary>
-      <div
-        style={{
-          display: 'flex',
-          flexWrap: 'wrap',
-          gap: '.5em',
-          backgroundColor: 'var(--color-button-secondary)',
-          padding: '0.5em',
-          borderRadius: '.5em',
-        }}
+    <>
+      <HoverableButton
+        onClick={() => setIsOpen(true)}
+        hoverContent="Select which columns to show or hide"
+        style={{ padding: '0.25em 0.5em' }}
       >
-        {Object.entries(columnsByGroup).map(([group, columns]) => (
-          <ColumnGroup
-            columns={columns}
-            group={group}
-            key={group}
-            visibilityModule={visibilityModule}
-          />
-        ))}
+        {nVisible}/{columns.length} columns visible. Click to configure.
+      </HoverableButton>
+
+      <ViewModal
+        isOpen={isOpen}
+        onClose={onClose}
+        title="Select Columns"
+        bodyStyle={{ width: '90vw', maxWidth: '85em', padding: '1em' }}
+      >
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(12em, 1fr))',
+            gap: '1em',
+            padding: '0.5em',
+          }}
+        >
+          {Object.entries(columnsByGroup).map(([group, columns]) => (
+            <ColumnGroup
+              columns={columns}
+              group={group}
+              key={group}
+              visibilityModule={visibilityModule}
+            />
+          ))}
+        </div>
         <GlobalControls visibilityModule={visibilityModule} columns={columns} />
-      </div>
-    </details>
+      </ViewModal>
+    </>
   );
 }
 
@@ -85,9 +98,7 @@ function ColumnGroup<T extends ObjectData>({
       style={{
         display: 'flex',
         flexDirection: 'column',
-        marginRight: '1em',
         textAlign: 'start',
-        maxWidth: '12em',
       }}
     >
       {columns.length > 1 && (
@@ -169,11 +180,10 @@ function GlobalControls<T extends ObjectData>({
     <div
       style={{
         display: 'flex',
-        flexDirection: 'column',
-        justifySelf: 'end',
-        alignSelf: 'end',
-        height: 'fit-content',
-        alignItems: 'end',
+        flexDirection: 'row',
+        justifyContent: 'end',
+        gap: '0.5em',
+        padding: '0.5em',
       }}
     >
       <HoverableButton

--- a/src/features/table/__tests__/InteractiveObjectTable.test.tsx
+++ b/src/features/table/__tests__/InteractiveObjectTable.test.tsx
@@ -39,7 +39,10 @@ vi.mock('@features/transforms/sorting/sort', () => ({
 }));
 
 vi.mock('@features/layers/hovercard/useHoverCard', () => ({
-  default: vi.fn().mockReturnValue({}),
+  default: vi.fn().mockReturnValue({ showHoverCard: vi.fn(), hideHoverCard: vi.fn() }),
+}));
+vi.mock('@shared/hooks/useClickOutside', () => ({
+  useClickOutside: vi.fn().mockReturnValue({ current: null }),
 }));
 vi.mock('@features/params/usePageParams', () => ({ default: vi.fn() }));
 vi.mock('@features/transforms/search/getFilterBySubstring', () => ({ default: vi.fn() }));
@@ -224,7 +227,7 @@ describe('InteractiveObjectTable', () => {
 
     // Open column selector
     act(() => {
-      fireEvent.click(screen.getByText(/2\/2 columns visible, click here to toggle/i));
+      fireEvent.click(screen.getByText(/2\/2 columns visible/i));
     });
 
     // Click checkbox to hide Population column

--- a/src/features/table/__tests__/TableColumnSelector.test.tsx
+++ b/src/features/table/__tests__/TableColumnSelector.test.tsx
@@ -67,6 +67,9 @@ describe('TableColumnSelector', () => {
 
     render(<TableColumnSelector columns={columns} visibilityModule={visibilityModule} />);
 
+    // Open the modal
+    fireEvent.click(screen.getByText(/columns visible/i));
+
     const populationCheckbox = screen.getByLabelText('Population') as HTMLInputElement;
     const nameCheckbox = screen.getByLabelText('Name') as HTMLInputElement;
 
@@ -100,6 +103,9 @@ describe('TableColumnSelector', () => {
     };
 
     render(<TableColumnSelector columns={columns} visibilityModule={visibilityModule} />);
+
+    // Open the modal
+    fireEvent.click(screen.getByText(/columns visible/i));
 
     // Click the first group Hoverable (mocked as button with data-testid "hoverable")
     const hoverables = screen.getAllByTestId('hoverable');

--- a/src/pages/DataPage.tsx
+++ b/src/pages/DataPage.tsx
@@ -6,8 +6,6 @@ import Loading from '@widgets/Loading';
 
 const DataPageBody = React.lazy(() => import('./DataPageBody'));
 const OptionsPanel = React.lazy(() => import('@widgets/controls/OptionsPanel'));
-const ViewModal = React.lazy(() => import('@features/layers/modal/ViewModal'));
-
 const DataPage: React.FC = () => {
   /* Many data components have more lines of code so they are loaded lazily */
   return (
@@ -19,7 +17,6 @@ const DataPage: React.FC = () => {
           <DetailsPanel />
         </div>
       </FilterPanelProvider>
-      <ViewModal />
     </Suspense>
   );
 };


### PR DESCRIPTION
Fixes #535 

Summary: Refactors `ViewModal` from a hardcoded test placeholder into a reusable, generic modal component, and migrates the table column selector from an inline `<details>` accordion to open inside this modal.

### Changes

- User experience
  - Table column selector now opens in a modal dialog instead of an inline accordion
  - Column groups are laid out in a responsive grid (`repeat(auto-fit, minmax(12em, 1fr))`) instead of a wrapped flex row
  - Global controls (show all / hide all) are now horizontal at the bottom of the modal
  - Modal is capped at `90vh` height with flexbox-based scrolling
- Logical changes
  - `ViewModal` is now a generic, prop-driven component accepting `isOpen`, `onClose`, `title`, `children`, and optional `bodyStyle`
  - Removed the `usePageParams` / `objectID === 'modal_test'` coupling from `ViewModal`
  - `TableColumnSelector` manages its own open/close state via `useState`
  - Escape key listener is only attached when the modal is open and properly cleaned up
- Data
  - N/A
- Refactors
  - Removed lazy-loaded `ViewModal` import and render from `DataPage.tsx`
  - Updated `modal.css`: replaced fixed `max-height: 800px` with flex layout, changed `overflow: scroll` to `overflow: auto`

Out of scope/Future work: N/A

### Test Plan and Screenshots

How to test the changes in this PR:
1. Navigate to the data page table view
2. Click the "X/Y columns visible. Click to configure." button in the toolbar
3. Verify the modal opens with column groups in a grid layout
4. Toggle individual columns, group headers, and show/hide all controls
5. Close the modal via the X button, Escape key, or clicking outside
6. Verify column visibility changes persist after closing the modal

| Page/View with link | Description of Changes | Screenshot Before | Screenshot After |
| ------------------- | ---------------------- | ----------------- | ---------------- |
| /data?view=Table  | Column selector moved from accordion to modal |<img width="1904" height="975" alt="image" src="https://github.com/user-attachments/assets/ea216a9f-fff8-4d14-b32b-f3ece611c4b6" />|<img width="1903" height="974" alt="image" src="https://github.com/user-attachments/assets/7f1b97c8-f9ea-434c-a36b-ae102ae732d9" />|

# Checklist

- [x] Clear description of what and why
- [x] Set yourself as assignee
- [x] Mention the issue (usually by writing "Fixes #ISSUE_NUMBER" or "Closes #ISSUE_NUMBER")

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test`
  - [x] Tests added or updated for changed logic (ViewModal.test.tsx added, TableColumnSelector.test.tsx and InteractiveObjectTable.test.tsx updated). Tests were generated with the assistance of Claude (AI tool) and reviewed manually.
- [x] `npm run dev` -- tried out the website directly
  - [x] Include screenshots as noted below
  - [x] Write comments on manual testing

## Changes

### Visual changes

- [x] Add screenshots to the table template at the top of this file

### Internal changes

- [x] Logical changes
- [x] Refactors, moving files around

## Docs

- [x] Code is self-documenting
