### PR TITLE
feat: move search bar into navbar (#482)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6320,11 +6320,10 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/src/features/transforms/search/SearchBar.tsx
+++ b/src/features/transforms/search/SearchBar.tsx
@@ -9,7 +9,6 @@ import {
 import TextInput from '@features/params/ui/TextInput';
 import usePageParams from '@features/params/usePageParams';
 
-import SearchBySelector from './SearchBySelector';
 import useSearchSuggestions from './useSearchSuggestions';
 
 const SearchBar: React.FC = () => {
@@ -23,19 +22,32 @@ const SearchBar: React.FC = () => {
         style={{
           display: 'inline-flex',
           alignItems: 'center',
-          marginBottom: '0.5em',
+          margin: '0 auto',
+          borderRadius: '1em',
+          backgroundColor: 'var(--color-background)',
         }}
       >
         <TextInput
-          label={<SearchIcon size="1em" display="block" style={{ padding: '0.5em' }} />}
-          inputStyle={{ minWidth: '20em', border: 'none' }}
+          label={
+            <SearchIcon
+              size="1em"
+              display="block"
+              style={{ padding: '0.5em', color: 'var(--color-text)' }}
+            />
+          }
+          inputStyle={{
+            minWidth: '20em',
+            border: 'none',
+            backgroundColor: 'var(--color-background)',
+            color: 'var(--color-text)',
+            outline: 'none',
+          }}
           getSuggestions={getSearchSuggestions}
           onSubmit={setSearchString}
           placeholder="search"
           pageParameter={PageParamKey.searchString}
           value={searchString}
         />
-        <SearchBySelector />
       </form>
     </SelectorDisplayProvider>
   );

--- a/src/features/transforms/search/SearchBySelector.tsx
+++ b/src/features/transforms/search/SearchBySelector.tsx
@@ -1,3 +1,4 @@
+import { SlidersHorizontalIcon } from 'lucide-react';
 import React from 'react';
 
 import { SearchableField } from '@features/params/PageParamTypes';
@@ -10,12 +11,12 @@ const SearchBySelector: React.FC = () => {
 
   return (
     <Selector
-      selectorLabel="Search by"
+      selectorLabel={<SlidersHorizontalIcon size="1em" />}
       options={Object.values(SearchableField)}
       onChange={(searchBy) => updatePageParams({ searchBy })}
       selected={searchBy}
       display={SelectorDisplay.Dropdown}
-      selectorStyle={{ marginLeft: '1em', marginBottom: '0em' }}
+      selectorStyle={{ marginBottom: '0em' }}
     />
   );
 };

--- a/src/pages/DataPageBody.tsx
+++ b/src/pages/DataPageBody.tsx
@@ -7,7 +7,7 @@ import { PathContainer } from '@widgets/pathnav/PathNav';
 
 import ResultCount from '@features/pagination/ResultCount';
 import FilterPath from '@features/transforms/filtering/FilterPath';
-import SearchBar from '@features/transforms/search/SearchBar';
+import SearchBySelector from '@features/transforms/search/SearchBySelector';
 import SortBySelector from '@features/transforms/sorting/SortBySelector';
 
 import EntityTypeTabs from './dataviews/EntityTypeTabs';
@@ -17,11 +17,7 @@ const DataViews = React.lazy(() => import('./dataviews/DataViews'));
 const DataPageBody: React.FC = () => {
   return (
     <main style={{ padding: '1em', flex: 1, overflow: 'auto', width: '100%' }}>
-      <div style={{ display: 'flex', alignItems: 'center', flexDirection: 'column' }}>
-        <SearchBar />
-        <EntityTypeTabs />
-      </div>
-
+      <EntityTypeTabs />
       <div
         style={{
           display: 'flex',
@@ -46,6 +42,7 @@ const DataPageBody: React.FC = () => {
             gap: '0.5rem',
           }}
         >
+          <SearchBySelector />
           <SortBySelector showLabel={false} />
           <ViewSelector />
         </div>

--- a/src/widgets/PageFooter.tsx
+++ b/src/widgets/PageFooter.tsx
@@ -7,8 +7,8 @@ const PageFooter: React.FC = () => (
   <footer>
     <div>{/* Empty right side for alignment */}</div>
     <p>
-      © {new Date().getFullYear()} <a href="https://translationcommons.org">Translation Commons</a>.
-      Docs: <Link to="about">About</Link> | <Link to="about#license">License</Link> |{' '}
+      © {new Date().getFullYear()} <a href="https://translationcommons.org">Translation Commons</a>
+      . Docs: <Link to="about">About</Link> | <Link to="about#license">License</Link> |{' '}
       <Link to="privacy-policy">Privacy Policy</Link>.
     </p>
     <CreativeCommonsLicense />

--- a/src/widgets/PageNavBar.tsx
+++ b/src/widgets/PageNavBar.tsx
@@ -4,6 +4,7 @@ import { Link, NavLink } from 'react-router-dom';
 import { LangNavPageName } from '@app/PageRoutes';
 
 import { FeedbackForm } from '@features/feedback/FeedbackForm';
+import SearchBar from '@features/transforms/search/SearchBar';
 
 import { usePageBrightness } from '@shared/hooks/usePageBrightness';
 
@@ -26,10 +27,13 @@ const PageNavBar: React.FC = () => {
       <NavBarLink path={'/' + LangNavPageName.Intro}>Intro</NavBarLink>
       <NavBarLink path={'/' + LangNavPageName.Data}>Data</NavBarLink>
       <NavBarLink path={'/' + LangNavPageName.Docs}>Docs</NavBarLink>
+      <div style={{ display: 'flex', flexGrow: 1 }}>
+        <SearchBar />
+      </div>
       <button
         className="primary"
         type="button"
-        style={{ marginLeft: 'auto', padding: '0.5em .5em', marginRight: '0.5em' }}
+        style={{ padding: '0.5em', whiteSpace: 'nowrap' }}
         onClick={() => setFeedbackOpen(true)}
       >
         Feedback


### PR DESCRIPTION
Fixes #482 
Move the search bar from `DataPageBody` into the `NavBar`, centered between the nav links and Feedback button.

Changes:
- Add SearchBar to PageNavBar
- Remove SearchBar from DataPageBody  
- Integrate SearchBar and SearchBySelector into a single unified search input with shared white container
- Remove"Search by" text 
- Remove TextInput border and hide clear button when empty via CSS


<img width="1252" height="190" alt="截屏2026-03-23 下午1 52 46" src="https://github.com/user-attachments/assets/c2bd7877-267d-48e6-8031-87240ca134a3" />
