### PR TITLE
Filters: Move Language Source into the filters section

### DIFF
--- a/src/entities/locale/LocaleCard.tsx
+++ b/src/entities/locale/LocaleCard.tsx
@@ -44,7 +44,7 @@ const LocaleCard: React.FC<Props> = ({ locale }) => {
       {populationAdjusted != null && (
         <CardField
           title="Source"
-          field={Field.Source}
+          field={Field.SourceForPopulation}
           description="The source of the population data."
         >
           <LocaleCensusCitation locale={locale} size="short" />

--- a/src/features/table/getValueType.ts
+++ b/src/features/table/getValueType.ts
@@ -47,7 +47,8 @@ export function getFieldValueType(field?: Field): TableValueType {
     case Field.Platform:
     case Field.OutputScript:
     case Field.VariantTag:
-    case Field.Source:
+    case Field.SourceForLanguage:
+    case Field.SourceForPopulation:
     case Field.Description:
     case Field.Example:
     case Field.None:

--- a/src/features/transforms/coloring/getColorGradientForField.ts
+++ b/src/features/transforms/coloring/getColorGradientForField.ts
@@ -70,7 +70,8 @@ function getColorGradientForField(colorBy: Field): ColorGradient {
     case Field.Territory:
     case Field.VariantTag:
     case Field.Platform:
-    case Field.Source:
+    case Field.SourceForLanguage:
+    case Field.SourceForPopulation:
       // These values are the names of related objects, not ideal for coloring with a gradient, but
       // since they are categorical values with no intrinsic order, a scattered gradient is more
       // appropriate than a sequential or diverging one.

--- a/src/features/transforms/fields/Field.ts
+++ b/src/features/transforms/fields/Field.ts
@@ -38,7 +38,8 @@ enum Field {
   Territory = 'Territory',
   VariantTag = 'Variant Tag',
   Platform = 'Platform',
-  Source = 'Source',
+  SourceForPopulation = 'Source for Population',
+  SourceForLanguage = 'Source for Language',
 
   // Relation - Counts
   CountOfLanguages = '# of Languages',

--- a/src/features/transforms/fields/FieldApplicability.ts
+++ b/src/features/transforms/fields/FieldApplicability.ts
@@ -89,7 +89,8 @@ function getSpecificFieldsForObjectType(objectType: ObjectType): Field[] {
         Field.Territory,
         Field.Region,
         // Field.VariantTag, // Data not available yet
-        Field.Source,
+        Field.SourceForPopulation,
+        Field.SourceForLanguage,
 
         Field.CountOfLanguages,
         Field.CountOfWritingSystems,
@@ -146,6 +147,8 @@ function getSpecificFieldsForObjectType(objectType: ObjectType): Field[] {
         Field.Language, // Equivalent to DisplayName for languages
         Field.WritingSystem,
         Field.Territory,
+        Field.SourceForPopulation,
+        Field.SourceForLanguage,
         // Field.Region, // TODO
 
         Field.CountOfLanguages,
@@ -172,7 +175,7 @@ function getSpecificFieldsForObjectType(objectType: ObjectType): Field[] {
 
         Field.Territory,
         Field.Region,
-        Field.Source,
+        Field.SourceForPopulation,
 
         Field.CountOfLanguages,
         Field.CountOfChildTerritories, // 0 or 1
@@ -332,6 +335,7 @@ function getFieldsForTransform(transform: Transform): Field[] {
         Field.Territory,
         Field.WritingSystem,
         Field.Language,
+        Field.SourceForLanguage,
         Field.Modality,
         Field.LanguageScope,
         Field.TerritoryScope,

--- a/src/features/transforms/fields/FieldGroup.ts
+++ b/src/features/transforms/fields/FieldGroup.ts
@@ -48,7 +48,8 @@ export function getFieldGroup(field: Field): FieldGroup {
     case Field.Region:
     case Field.VariantTag:
     case Field.Platform:
-    case Field.Source:
+    case Field.SourceForLanguage:
+    case Field.SourceForPopulation:
       return FieldGroup.Relation;
     case Field.CountOfLanguages:
     case Field.CountOfWritingSystems:

--- a/src/features/transforms/fields/FieldIcon.tsx
+++ b/src/features/transforms/fields/FieldIcon.tsx
@@ -30,6 +30,7 @@ import {
   PercentIcon,
   RulerDimensionLineIcon,
   RulerIcon,
+  ScrollTextIcon,
   TextIcon,
   UserCheckIcon,
   UsersIcon,
@@ -103,7 +104,9 @@ export function getFieldIcon(field: Field): LucideIcon {
       return MonitorSmartphoneIcon;
     case Field.VariantTag:
       return MapPinIcon;
-    case Field.Source:
+    case Field.SourceForLanguage:
+      return ScrollTextIcon;
+    case Field.SourceForPopulation:
       return BracketsIcon;
 
     case Field.CountOfLanguages:

--- a/src/features/transforms/fields/ObjectFieldDisplay.tsx
+++ b/src/features/transforms/fields/ObjectFieldDisplay.tsx
@@ -63,10 +63,13 @@ const ObjectFieldDisplay: React.FC<Props> = ({ object, field }) => {
     case Field.Language:
     case Field.LanguageFamily:
     case Field.WritingSystem:
+    case Field.Region:
     case Field.Territory:
     case Field.Platform:
     case Field.OutputScript:
     case Field.VariantTag:
+    case Field.SourceForLanguage:
+    case Field.SourceForPopulation:
       return <>{fieldValue}</>; // Objects should be displayed using a readable name
 
     case Field.VitalityMetascore:
@@ -109,8 +112,6 @@ const ObjectFieldDisplay: React.FC<Props> = ({ object, field }) => {
     case Field.WritingSystemScope:
     case Field.Coordinates:
     case Field.GovernmentStatus:
-    case Field.Region:
-    case Field.Source:
     case Field.None:
       return undefined;
 

--- a/src/features/transforms/fields/getEntityConnection.ts
+++ b/src/features/transforms/fields/getEntityConnection.ts
@@ -1,0 +1,48 @@
+import { ObjectType } from '@features/params/PageParamTypes';
+
+import { CensusData } from '@entities/census/CensusTypes';
+import { KeyboardData } from '@entities/keyboard/KeyboardTypes';
+import { LanguageData } from '@entities/language/LanguageTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
+import { ObjectData } from '@entities/types/DataTypes';
+import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
+
+export function getLanguageForEntity(object: ObjectData | undefined): LanguageData | undefined {
+  if (!object) return undefined;
+  if (object.type === ObjectType.Language) return object;
+  if (object.type === ObjectType.Locale) return object.language;
+  if (object.type === ObjectType.Keyboard) return object.language;
+  return undefined;
+}
+
+export function getWritingSystemForEntity(
+  object: ObjectData | undefined,
+): WritingSystemData | undefined {
+  if (!object) return undefined;
+  if (object.type === ObjectType.WritingSystem) return object;
+  if (object.type === ObjectType.Locale) return object.writingSystem;
+  if (object.type === ObjectType.Keyboard) return object.inputWritingSystem;
+  return undefined;
+}
+
+export function getTerritoryForEntity(object: ObjectData | undefined): TerritoryData | undefined {
+  if (!object) return undefined;
+  if (object.type === ObjectType.Territory) return object;
+  if (object.type === ObjectType.Locale) return object.territory;
+  if (object.type === ObjectType.Census) return object.territory;
+  if (object.type === ObjectType.Keyboard) return object.territory;
+  return undefined;
+}
+
+export function getCensusForEntity(object: ObjectData | undefined): CensusData | undefined {
+  if (!object) return undefined;
+  if (object.type === ObjectType.Census) return object;
+  if (object.type === ObjectType.Locale) return object.populationCensus;
+  return undefined;
+}
+
+export function getKeyboardForEntity(object: ObjectData | undefined): KeyboardData | undefined {
+  if (!object) return undefined;
+  if (object.type === ObjectType.Keyboard) return object;
+  return undefined;
+}

--- a/src/features/transforms/fields/getField.ts
+++ b/src/features/transforms/fields/getField.ts
@@ -1,8 +1,5 @@
 import { ObjectType } from '@features/params/PageParamTypes';
 
-import { CensusData } from '@entities/census/CensusTypes';
-import { KeyboardData } from '@entities/keyboard/KeyboardTypes';
-import { LanguageData } from '@entities/language/LanguageTypes';
 import {
   getCountOfCensuses,
   getCountOfLanguages,
@@ -26,15 +23,20 @@ import {
   getCountOfChildTerritories,
   getCountOfCountries,
 } from '@entities/lib/getObjectRelatedTerritories';
-import { TerritoryData } from '@entities/territory/TerritoryTypes';
 import { ObjectData } from '@entities/types/DataTypes';
-import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 import enforceExhaustiveSwitch from '@shared/lib/enforceExhaustiveness';
 
 import { getLanguageSourcesForEntity } from '../filtering/filterByEnum';
 
 import Field from './Field';
+import {
+  getCensusForEntity,
+  getKeyboardForEntity,
+  getLanguageForEntity,
+  getTerritoryForEntity,
+  getWritingSystemForEntity,
+} from './getEntityConnection';
 
 // Get's a primitive value for a given object and field, used for sorting and filtering.
 // Returns undefined if the field is not applicable to the object type or if the value is missing.
@@ -175,46 +177,6 @@ function getField(object: ObjectData, field: Field): string | number | undefined
     default:
       enforceExhaustiveSwitch(field);
   }
-}
-
-export function getLanguageForEntity(object: ObjectData | undefined): LanguageData | undefined {
-  if (!object) return undefined;
-  if (object.type === ObjectType.Language) return object;
-  if (object.type === ObjectType.Locale) return object.language;
-  if (object.type === ObjectType.Keyboard) return object.language;
-  return undefined;
-}
-
-export function getWritingSystemForEntity(
-  object: ObjectData | undefined,
-): WritingSystemData | undefined {
-  if (!object) return undefined;
-  if (object.type === ObjectType.WritingSystem) return object;
-  if (object.type === ObjectType.Locale) return object.writingSystem;
-  if (object.type === ObjectType.Keyboard) return object.inputWritingSystem;
-  return undefined;
-}
-
-export function getTerritoryForEntity(object: ObjectData | undefined): TerritoryData | undefined {
-  if (!object) return undefined;
-  if (object.type === ObjectType.Territory) return object;
-  if (object.type === ObjectType.Locale) return object.territory;
-  if (object.type === ObjectType.Census) return object.territory;
-  if (object.type === ObjectType.Keyboard) return object.territory;
-  return undefined;
-}
-
-export function getCensusForEntity(object: ObjectData | undefined): CensusData | undefined {
-  if (!object) return undefined;
-  if (object.type === ObjectType.Census) return object;
-  if (object.type === ObjectType.Locale) return object.populationCensus;
-  return undefined;
-}
-
-export function getKeyboardForEntity(object: ObjectData | undefined): KeyboardData | undefined {
-  if (!object) return undefined;
-  if (object.type === ObjectType.Keyboard) return object;
-  return undefined;
 }
 
 export default getField;

--- a/src/features/transforms/fields/getField.ts
+++ b/src/features/transforms/fields/getField.ts
@@ -32,6 +32,8 @@ import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 import enforceExhaustiveSwitch from '@shared/lib/enforceExhaustiveness';
 
+import { getLanguageSourcesForEntity } from '../filtering/filterByEnum';
+
 import Field from './Field';
 
 // Get's a primitive value for a given object and field, used for sorting and filtering.
@@ -117,8 +119,10 @@ function getField(object: ObjectData, field: Field): string | number | undefined
       return getKeyboardForEntity(object)?.platform;
     case Field.VariantTag:
       return getKeyboardForEntity(object)?.variantTagCode;
-    case Field.Source:
+    case Field.SourceForPopulation:
       return getCensusForEntity(object)?.collectorName;
+    case Field.SourceForLanguage:
+      return getLanguageSourcesForEntity(object)?.join(', ') || undefined;
 
     // Counts of Related Objects
     case Field.CountOfLanguages:

--- a/src/features/transforms/fields/rangeUtils.ts
+++ b/src/features/transforms/fields/rangeUtils.ts
@@ -63,7 +63,8 @@ export function getMinimumValue(field?: Field): number {
     case Field.Platform:
     case Field.OutputScript:
     case Field.VariantTag:
-    case Field.Source:
+    case Field.SourceForLanguage:
+    case Field.SourceForPopulation:
     case Field.Description:
     case Field.Example:
       return convertAlphaToNumber(''); // 0
@@ -136,7 +137,8 @@ export function getMaximumValue(objects: ObjectData[], field?: Field): number {
     case Field.Platform:
     case Field.OutputScript:
     case Field.VariantTag:
-    case Field.Source:
+    case Field.SourceForLanguage:
+    case Field.SourceForPopulation:
     case Field.Description:
     case Field.Example:
       return convertAlphaToNumber('ZZZZZZZZZZ');

--- a/src/features/transforms/filtering/filterByEnum.tsx
+++ b/src/features/transforms/filtering/filterByEnum.tsx
@@ -1,5 +1,5 @@
 import { LanguageModality } from '@entities/language/LanguageModality';
-import { LanguageScope } from '@entities/language/LanguageTypes';
+import { LanguageScope, LanguageSource } from '@entities/language/LanguageTypes';
 import {
   LanguageISOStatus,
   VitalityEthnologueCoarse,
@@ -78,4 +78,29 @@ export function buildFilterByVitalityEthnologueCoarse(
       ethnologueCoarseStatuses.includes(language.vitality.ethCoarse)
     );
   };
+}
+
+export function buildFilterByLanguageSource(languageSource: LanguageSource): FilterFunctionType {
+  if (!languageSource || languageSource === LanguageSource.Combined) return () => true;
+
+  return (object: ObjectData): boolean => {
+    const language = getLanguageForEntity(object);
+    if (!language) return true;
+    const sources = getLanguageSourcesForEntity(object);
+    return sources.includes(languageSource);
+  };
+}
+
+export function getLanguageSourcesForEntity(ent: ObjectData): LanguageSource[] {
+  const language = getLanguageForEntity(ent);
+  if (!language) return [];
+  const sources = [];
+  if (language.ISO.code != null && language.ISO.retirementReason == null) {
+    sources.push(LanguageSource.ISO);
+    sources.push(LanguageSource.BCP);
+  }
+  if (language.Glottolog.code != null) sources.push(LanguageSource.Glottolog);
+  if (language.CLDR.code != null && language.CLDR.dataProvider == null)
+    sources.push(LanguageSource.CLDR);
+  return sources;
 }

--- a/src/features/transforms/filtering/filterByEnum.tsx
+++ b/src/features/transforms/filtering/filterByEnum.tsx
@@ -8,7 +8,7 @@ import {
 import { TerritoryScope } from '@entities/territory/TerritoryTypes';
 import { ObjectData } from '@entities/types/DataTypes';
 
-import { getLanguageForEntity, getTerritoryForEntity } from '../fields/getField';
+import { getLanguageForEntity, getTerritoryForEntity } from '../fields/getEntityConnection';
 
 import { FilterFunctionType } from './filter';
 
@@ -94,7 +94,7 @@ export function buildFilterByLanguageSource(languageSource: LanguageSource): Fil
 export function getLanguageSourcesForEntity(ent: ObjectData): LanguageSource[] {
   const language = getLanguageForEntity(ent);
   if (!language) return [];
-  const sources = [];
+  const sources: LanguageSource[] = [];
   if (language.ISO.code != null && language.ISO.retirementReason == null) {
     sources.push(LanguageSource.ISO);
     sources.push(LanguageSource.BCP);

--- a/src/features/transforms/filtering/selectors/FilterSelector.tsx
+++ b/src/features/transforms/filtering/selectors/FilterSelector.tsx
@@ -4,6 +4,7 @@ import { SelectorDisplay } from '@features/params/ui/SelectorDisplayContext';
 import usePageParams from '@features/params/usePageParams';
 import Field from '@features/transforms/fields/Field';
 import { getApplicableFields } from '@features/transforms/fields/FieldApplicability';
+import LanguageSourceSelector from '@features/transforms/filtering/selectors/LanguageSourceSelector';
 import SearchBar from '@features/transforms/search/SearchBar';
 import TransformEnum from '@features/transforms/TransformEnum';
 
@@ -35,6 +36,8 @@ const FilterSelector: React.FC<Props> = ({ field }) => {
       return <LanguageISOStatusSelector />;
     case Field.Name:
       return <SearchBar />; // Technically correct but not recommended usage
+    case Field.SourceForLanguage:
+      return <LanguageSourceSelector display={SelectorDisplay.ButtonList} />;
     default:
       return null;
   }

--- a/src/features/transforms/filtering/selectors/LanguageSourceSelector.tsx
+++ b/src/features/transforms/filtering/selectors/LanguageSourceSelector.tsx
@@ -39,7 +39,7 @@ function LanguageSourceSelectorDescription() {
     <>
       This determines which authority we use to determine the list of languages shown. Different
       sources also may have different names, IDs, and classifications for languages. For example,
-      let&apos;s look at Chinese through the lens of difference sources:
+      let&apos;s look at Chinese through the lens of different sources:
       <ul>
         <li>
           <strong>Glottolog</strong> features <code>clas1255</code> as &quot;Classical-Middle-Modern
@@ -49,12 +49,12 @@ function LanguageSourceSelectorDescription() {
         </li>
         <li>
           <strong>ISO</strong> uses the code <code>zho</code>, calls it &quot;Chinese&quot; and
-          considers it a macrolanguage. It has direct descendents like Mandarin [<code>cmn</code>]
+          considers it a macrolanguage. It has direct descendants like Mandarin [<code>cmn</code>]
           and Cantonese [<code>yue</code>].
         </li>
         <li>
-          <strong>BCP-47</strong> closely follows ISO usually but when possible users 2-letter
-          codes, so <code>zh</code> for Chinese.
+          <strong>BCP-47</strong> closely follows ISO usually but when possible uses 2-letter codes,
+          so <code>zh</code> for Chinese.
         </li>
         <li>
           <strong>CLDR</strong> treats the language code slightly differently since it is focused on

--- a/src/features/transforms/filtering/selectors/LanguageSourceSelector.tsx
+++ b/src/features/transforms/filtering/selectors/LanguageSourceSelector.tsx
@@ -18,22 +18,11 @@ const values = [
 
 const LanguageSourceSelector: React.FC<Props> = ({ display }) => {
   const { languageSource, updatePageParams } = usePageParams();
-  const selectorDescription = (
-    <>
-      Languages have fuzzy boundaries and different sources categorize potential languages
-      differently. For example, what&apos;s a dialect versus a language, or if a language is even
-      attested. Use this option to change what languages appear and what they are considered (family
-      / individual / dialect). This may also change the language codes, names, and parent/child
-      relationships.
-    </>
-  );
 
   return (
     <Selector
-      selectorLabel={
-        display !== SelectorDisplay.InlineDropdown ? 'Source of the List of Languages' : undefined
-      }
-      selectorDescription={selectorDescription}
+      selectorLabel={display !== SelectorDisplay.InlineDropdown ? 'Language Authority' : undefined}
+      selectorDescription={<LanguageSourceSelectorDescription />}
       options={values}
       onChange={(languageSource: LanguageSource) => updatePageParams({ languageSource })}
       selected={languageSource}
@@ -44,6 +33,46 @@ const LanguageSourceSelector: React.FC<Props> = ({ display }) => {
     />
   );
 };
+
+function LanguageSourceSelectorDescription() {
+  return (
+    <>
+      This determines which authority we use to determine the list of languages shown. Different
+      sources also may have different names, IDs, and classifications for languages. For example,
+      let&apos;s look at Chinese through the lens of difference sources:
+      <ul>
+        <li>
+          <strong>Glottolog</strong> features <code>clas1255</code> as &quot;Classical-Middle-Modern
+          Sinitic&quot;, a language family since it contains multiple language families
+          (Middle-Modern Sinitic [<code>midd1354</code>], ...) and languages in them (Mandarin [
+          <code>mand1415</code>], Cantonese [<code>yuec1235</code>], ...).
+        </li>
+        <li>
+          <strong>ISO</strong> uses the code <code>zho</code>, calls it &quot;Chinese&quot; and
+          considers it a macrolanguage. It has direct descendents like Mandarin [<code>cmn</code>]
+          and Cantonese [<code>yue</code>].
+        </li>
+        <li>
+          <strong>BCP-47</strong> closely follows ISO usually but when possible users 2-letter
+          codes, so <code>zh</code> for Chinese.
+        </li>
+        <li>
+          <strong>CLDR</strong> treats the language code slightly differently since it is focused on
+          lists of translations. Since the macrolanguage encompasses multiple languages, CLDR picks
+          the largest representative (in this case Mandarin) to use the code <code>zh</code>.
+          Technically it does not have information for Chinese as a macrolanguage (you may see it
+          noted as <code>zh*</code>).
+        </li>
+        <li>
+          <strong>Combined</strong> is curated by the Language Navigator team to combine language
+          information from all above sources. We prefer the ISO 639-3 3-letter code when possible
+          (in this case <code>zho</code>) and sometimes have a distinct name, in this case
+          &quot;Chinese languages&quot; to reflect the fact that it is a macrolanguage.
+        </li>
+      </ul>
+    </>
+  );
+}
 
 const LanguageSourceDescription: React.FC<{ languageSource: LanguageSource }> = ({
   languageSource,

--- a/src/features/transforms/filtering/useFilters.tsx
+++ b/src/features/transforms/filtering/useFilters.tsx
@@ -12,6 +12,7 @@ import {
 import {
   buildFilterByISOStatus,
   buildFilterByLanguageScope,
+  buildFilterByLanguageSource,
   buildFilterByModality,
   buildFilterByTerritoryScope,
   buildFilterByVitalityEthnologueCoarse,
@@ -29,6 +30,7 @@ function useFilters(): Record<Field, FilterFunctionType> {
     isoStatus,
     languageFilter,
     languageScopes,
+    languageSource,
     modalityFilter,
     searchBy,
     searchString,
@@ -46,6 +48,7 @@ function useFilters(): Record<Field, FilterFunctionType> {
   const filterByTerritory = buildFilterByTerritory(territoryFilter);
   const filterByLanguage = buildFilterByLanguage(languageFilter);
   const filterByWritingSystem = buildFilterByWritingSystem(writingSystemFilter);
+  const filterByLanguageSource = buildFilterByLanguageSource(languageSource);
 
   // Vitality
   const filterByISOStatus = buildFilterByISOStatus(isoStatus);
@@ -71,13 +74,14 @@ function useFilters(): Record<Field, FilterFunctionType> {
     [Field.WritingSystem]: filterByWritingSystem,
     [Field.Territory]: filterByTerritory,
     [Field.LanguageFamily]: alwaysTrue,
+    [Field.SourceForLanguage]: filterByLanguageSource,
 
     // Filters not yet constructed
     [Field.Region]: alwaysTrue, // TODO
     [Field.Platform]: alwaysTrue, // TODO
     [Field.OutputScript]: alwaysTrue, // TODO
     [Field.VariantTag]: alwaysTrue, // TODO
-    [Field.Source]: alwaysTrue, // TODO
+    [Field.SourceForPopulation]: alwaysTrue, // TODO
 
     [Field.None]: alwaysTrue,
     [Field.Code]: alwaysTrue,

--- a/src/features/transforms/search/SearchBySelector.tsx
+++ b/src/features/transforms/search/SearchBySelector.tsx
@@ -1,4 +1,3 @@
-import { SlidersHorizontalIcon } from 'lucide-react';
 import React from 'react';
 
 import { SearchableField } from '@features/params/PageParamTypes';
@@ -11,7 +10,7 @@ const SearchBySelector: React.FC = () => {
 
   return (
     <Selector
-      selectorLabel={<SlidersHorizontalIcon size="1em" />}
+      selectorLabel="Search by"
       options={Object.values(SearchableField)}
       onChange={(searchBy) => updatePageParams({ searchBy })}
       selected={searchBy}

--- a/src/features/transforms/sorting/sort.tsx
+++ b/src/features/transforms/sorting/sort.tsx
@@ -82,7 +82,8 @@ export function getNormalSortDirection(sortBy: Field): SortDirection {
     case Field.Region:
     case Field.VariantTag:
     case Field.Platform:
-    case Field.Source:
+    case Field.SourceForLanguage:
+    case Field.SourceForPopulation:
     case Field.Coordinates:
     case Field.Longitude:
     case Field.Latitude:

--- a/src/pages/DataPageBody.tsx
+++ b/src/pages/DataPageBody.tsx
@@ -7,7 +7,6 @@ import { PathContainer } from '@widgets/pathnav/PathNav';
 
 import ResultCount from '@features/pagination/ResultCount';
 import FilterPath from '@features/transforms/filtering/FilterPath';
-import SearchBySelector from '@features/transforms/search/SearchBySelector';
 import SortBySelector from '@features/transforms/sorting/SortBySelector';
 
 import EntityTypeTabs from './dataviews/EntityTypeTabs';
@@ -42,7 +41,6 @@ const DataPageBody: React.FC = () => {
             gap: '0.5rem',
           }}
         >
-          <SearchBySelector />
           <SortBySelector showLabel={false} />
           <ViewSelector />
         </div>

--- a/src/pages/LuckySearchPage.tsx
+++ b/src/pages/LuckySearchPage.tsx
@@ -2,19 +2,13 @@ import React, { Suspense } from 'react';
 
 import Loading from '@widgets/Loading';
 
-const PageParamsProvider = React.lazy(() => import('@features/params/PageParamsProvider'));
-const DataProvider = React.lazy(() => import('@features/data/context/DataProvider'));
 const LuckySearchPageBody = React.lazy(() => import('./LuckySearchPageBody'));
 
 const LuckySearchPage: React.FC = () => {
   /* DataProvider and other data components have more lines of code so they are loaded lazily */
   return (
     <Suspense fallback={<Loading />}>
-      <PageParamsProvider>
-        <DataProvider>
-          <LuckySearchPageBody />
-        </DataProvider>
-      </PageParamsProvider>
+      <LuckySearchPageBody />
     </Suspense>
   );
 };

--- a/src/widgets/controls/OptionsPanel.tsx
+++ b/src/widgets/controls/OptionsPanel.tsx
@@ -12,14 +12,12 @@ import ColorGradientSelector from '@features/transforms/coloring/ColorGradientSe
 import FieldFocusSelector from '@features/transforms/fields/FieldFocusSelector';
 import { AllApplicableFilterSelectors } from '@features/transforms/filtering/selectors/FilterSelector';
 import ScaleBySelector from '@features/transforms/scales/ScaleBySelector';
+import SearchBySelector from '@features/transforms/search/SearchBySelector';
 import SecondarySortBySelector from '@features/transforms/sorting/SecondarySortBySelector';
 import SortBySelector from '@features/transforms/sorting/SortBySelector';
 import SortDirectionSelector from '@features/transforms/sorting/SortDirectionSelector';
 
-import { ObjectiveList } from '../CommonObjectives';
-
 import ResizablePanel from './ResizablePanel';
-import LanguageSourceSelector from './selectors/LanguageSourceSelector';
 import LocaleSeparatorSelector from './selectors/LocaleSeparatorSelector';
 import PageBrightnessSelector from './selectors/PageBrightnessSelector';
 import ProfileSelector from './selectors/ProfileSelector';
@@ -33,16 +31,6 @@ const OptionsPanel: React.FC = () => {
   return (
     <ResizablePanel defaultWidth={300} purpose="filters" title="Options">
       <SelectorDisplayProvider display={SelectorDisplay.Dropdown}>
-        <OptionsPanelSection title="Common Actions" optionsName="common actions">
-          <div>{/* intentionally blank */}</div>
-          <ObjectiveList />
-        </OptionsPanelSection>
-
-        <OptionsPanelSection title="Data" optionsName="data options">
-          <LanguageSourceSelector display={SelectorDisplay.ButtonList} />
-          <ProfileSelector />
-        </OptionsPanelSection>
-
         <OptionsPanelSection title="Filter" optionsName="filters">
           <AllApplicableFilterSelectors />
         </OptionsPanelSection>
@@ -59,6 +47,8 @@ const OptionsPanel: React.FC = () => {
           <FieldFocusSelector />
           <LocaleSeparatorSelector />
           <PageBrightnessSelector />
+          <SearchBySelector />
+          <ProfileSelector />
         </OptionsPanelSection>
       </SelectorDisplayProvider>
     </ResizablePanel>

--- a/src/widgets/treelists/LanguageHierarchy.tsx
+++ b/src/widgets/treelists/LanguageHierarchy.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 
-import LanguageSourceSelector from '@widgets/controls/selectors/LanguageSourceSelector';
-
 import { useDataContext } from '@features/data/context/useDataContext';
 import { ObjectType } from '@features/params/PageParamTypes';
 import { SelectorDisplay } from '@features/params/ui/SelectorDisplayContext';
 import usePageParams from '@features/params/usePageParams';
 import { getScopeFilter } from '@features/transforms/filtering/filter';
+import LanguageSourceSelector from '@features/transforms/filtering/selectors/LanguageSourceSelector';
 import { getSortFunction } from '@features/transforms/sorting/sort';
 import { TreeNodeData } from '@features/treelist/TreeListNode';
 import TreeListPageBody from '@features/treelist/TreeListPageBody';


### PR DESCRIPTION
Fixes #570

Summary: I noticed the "SearchBy" control was in the wrong place. So I moved it down to the view options panel.

While I was there I was reflecting on the feedback from @LuoZihYuan that "Language Source" selector filters languages (and causes some visual changes) so it may be better to include it as a filter choice.

### Changes

- User experience
  - Moved Search By and Preset selectors to the View Options selector
  - Moved Language Source selector to the Filter Panel and improve the description
  - Removed "Common objectives" from the choices
- Logical changes
  - LanguageSourceSelector now treated as a filter. There is still some legacy code that we can remove later and formalize its role as a filter better.
- Data
  - n/a
- Refactors
  - Split the `Field.Source` into `SourceForPopulation` and `SourceForLanguage` since both can apply.

Out of scope/Future work: Simplify the data provider to just return languages (eg. don't do the source filter early, do it along with the other filters).

### Test Plan and Screenshots

How to test the changes in this PR: Use the new filter controls https://translation-commons.github.io/lang-nav/data

| Page/View with link | Description of Changes | Screenshot Before | Screenshot After |
| ------------------- | ---------------------- | ----------------- | ---------------- |
|See the new filter panel|Fewer sections|<img width="362" height="884" alt="Screenshot 2026-03-26 at 16 43 43" src="https://github.com/user-attachments/assets/ecf823ef-cb13-48ba-9e82-39b08e04c392" />|<img width="357" height="691" alt="Screenshot 2026-03-26 at 16 44 13" src="https://github.com/user-attachments/assets/902b5878-da00-485a-bcfd-fb25d9f1f804" />|
|LanguageSourceSelector|It's called "Language Authority" now and has a better description|<img width="576" height="150" alt="Screenshot 2026-03-26 at 16 43 51" src="https://github.com/user-attachments/assets/81c8676b-c553-42fc-8e22-b11fd81548b8" />|<img width="565" height="616" alt="Screenshot 2026-03-26 at 16 44 18" src="https://github.com/user-attachments/assets/047c287b-73f2-4418-be0d-87036c9ac0cc" />
