### PR TITLE
Reports: Add census input tool

### DIFF
--- a/src/entities/census/CensusTypes.tsx
+++ b/src/entities/census/CensusTypes.tsx
@@ -26,6 +26,52 @@ export enum CensusLanguageMode {
   Ethnicity = 'Ethnicity',
 }
 
+export enum CensusField {
+  codeDisplay = 'codeDisplay',
+  nameDisplay = 'nameDisplay',
+  isoRegionCode = 'isoRegionCode',
+  yearCollected = 'yearCollected',
+
+  // Kind of language data collected
+  mode = 'mode',
+  proficiency = 'proficiency',
+  acquisitionOrder = 'acquisitionOrder',
+  domain = 'domain',
+
+  // Population
+  populationEligible = 'populationEligible',
+  popualtionSource = 'populationSource',
+  populationSurveyed = 'populationSurveyed',
+  populationWithPositiveResponses = 'populationWithPositiveResponses',
+  sampleRate = 'sampleRate',
+  responsesPerIndividual = 'responsesPerIndividual',
+
+  // Data constraints
+  languagesIncluded = 'languagesIncluded',
+  geographicScope = 'geographicScope',
+  age = 'age',
+  gender = 'gender',
+  nationality = 'nationality',
+  residentLocation = 'residentLocation',
+  quantity = 'quantity',
+  notes = 'notes',
+
+  // Author
+  collectorType = 'collectorType',
+  collectorName = 'collectorName',
+  collectorNameShort = 'collectorNameShort',
+  author = 'author',
+
+  // Source
+  url = 'url',
+  datePublished = 'datePublished',
+  dateAccessed = 'dateAccessed',
+  documentName = 'documentName',
+  tableName = 'tableName',
+  columnName = 'columnName',
+  citation = 'citation',
+}
+
 export interface CensusData extends ObjectBase {
   type: ObjectType.Census;
   ID: CensusID;
@@ -42,6 +88,7 @@ export interface CensusData extends ObjectBase {
 
   // Population
   populationEligible: number; // The total number of qualified individuals
+  populationSource?: string; // The URL specifically for the population source
   populationSurveyed?: number; // The number of individuals surveyed (if different from eligible)
   populationWithPositiveResponses?: number; // The number of individuals who gave a response about their language
   sampleRate?: number | string; // eg. .1, .25, 1 (for 10%, 25%, 100%)

--- a/src/entities/census/CensusTypes.tsx
+++ b/src/entities/census/CensusTypes.tsx
@@ -26,52 +26,6 @@ export enum CensusLanguageMode {
   Ethnicity = 'Ethnicity',
 }
 
-export enum CensusField {
-  codeDisplay = 'codeDisplay',
-  nameDisplay = 'nameDisplay',
-  isoRegionCode = 'isoRegionCode',
-  yearCollected = 'yearCollected',
-
-  // Kind of language data collected
-  mode = 'mode',
-  proficiency = 'proficiency',
-  acquisitionOrder = 'acquisitionOrder',
-  domain = 'domain',
-
-  // Population
-  populationEligible = 'populationEligible',
-  popualtionSource = 'populationSource',
-  populationSurveyed = 'populationSurveyed',
-  populationWithPositiveResponses = 'populationWithPositiveResponses',
-  sampleRate = 'sampleRate',
-  responsesPerIndividual = 'responsesPerIndividual',
-
-  // Data constraints
-  languagesIncluded = 'languagesIncluded',
-  geographicScope = 'geographicScope',
-  age = 'age',
-  gender = 'gender',
-  nationality = 'nationality',
-  residentLocation = 'residentLocation',
-  quantity = 'quantity',
-  notes = 'notes',
-
-  // Author
-  collectorType = 'collectorType',
-  collectorName = 'collectorName',
-  collectorNameShort = 'collectorNameShort',
-  author = 'author',
-
-  // Source
-  url = 'url',
-  datePublished = 'datePublished',
-  dateAccessed = 'dateAccessed',
-  documentName = 'documentName',
-  tableName = 'tableName',
-  columnName = 'columnName',
-  citation = 'citation',
-}
-
 export interface CensusData extends ObjectBase {
   type: ObjectType.Census;
   ID: CensusID;

--- a/src/features/data/load/extra_entities/loadCensusData.tsx
+++ b/src/features/data/load/extra_entities/loadCensusData.tsx
@@ -41,7 +41,7 @@ export type CensusImport = {
   languageNames: Record<LanguageCode, string>;
 };
 
-function parseCensusImport(fileInput: string, filePath: string): CensusImport {
+export function parseCensusImport(fileInput: string, filePath: string): CensusImport {
   const lines = fileInput.split('\n');
   const filename = filePath.match(/\/([^/]+)\.tsv$/)?.[1] || 'census';
 
@@ -58,8 +58,9 @@ function parseCensusImport(fileInput: string, filePath: string): CensusImport {
       return tsvColumnNumber + 2; // +2 to account for the skipped columns
     })
     .filter((col) => col !== null);
-  if (tsvColumnsWithData.length <= 0)
-    throw new Error(`No census data found in the file ${filename}.`);
+  if (tsvColumnsWithData.length <= 0) {
+    throw new Error('No census data found' + (filePath ? ` in the file: "${filename}".` : '.'));
+  }
 
   const censuses: CensusData[] = tsvColumnsWithData.map((_tsvColumnNumber, index) => ({
     type: ObjectType.Census,

--- a/src/features/pagination/VisibleItemsMeter.tsx
+++ b/src/features/pagination/VisibleItemsMeter.tsx
@@ -72,7 +72,7 @@ const VisibleItemsMeter: React.FC<Props> = ({ objects, shouldFilterUsingSearchBa
               </div>
             }
           >
-            {nShown.toLocaleString()}
+            {nShown?.toLocaleString()}
           </Hoverable>
           {nFiltered > nShown && <> of {<strong>{nFiltered.toLocaleString()}</strong>}</>} results.
         </div>
@@ -108,7 +108,7 @@ const HighLimitWarning: React.FC<{ nShown: number }> = ({ nShown }) => {
   return (
     <div>
       <TriangleAlertIcon size="1em" style={{ color: 'var(--color-yellow)' }} />
-      There are <strong>{nShown.toLocaleString()}</strong> items visible, this may impact page
+      There are <strong>{nShown?.toLocaleString()}</strong> items visible, this may impact page
       performance. Consider reducing the limit to{' '}
       <HoverableButton
         onClick={() => updatePageParams({ limit: threshold })}

--- a/src/shared/containers/ErrorBoundary.tsx
+++ b/src/shared/containers/ErrorBoundary.tsx
@@ -1,25 +1,42 @@
 import React from 'react';
 
-const ErrorBoundary: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
 
-  React.useEffect(() => {
-    const handleError = (event: ErrorEvent) => {
-      setErrorMessage(event.message);
+interface ErrorBoundaryState {
+  hasError: boolean;
+  errorMessage: string | null;
+}
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = {
+      hasError: false,
+      errorMessage: null,
     };
-
-    window.addEventListener('error', handleError);
-    return () => {
-      window.removeEventListener('error', handleError);
-    };
-  }, []);
-
-  if (errorMessage) {
-    return <ErrorFallback message={errorMessage} />;
   }
 
-  return <>{children}</>;
-};
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return {
+      hasError: true,
+      errorMessage: error.message,
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error('Error caught by boundary:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <ErrorFallback message={this.state.errorMessage || 'An unknown error occurred'} />;
+    }
+
+    return this.props.children;
+  }
+}
 
 const ErrorFallback: React.FC<{ message: string }> = ({ message }) => {
   return (
@@ -27,6 +44,9 @@ const ErrorFallback: React.FC<{ message: string }> = ({ message }) => {
       <h2>Something went wrong.</h2>
       <p>Please try refreshing the page or contact support if the issue persists.</p>
       <p>{message}</p>
+      <button onClick={() => window.location.reload()} style={{ padding: '0.5em 1em' }}>
+        Refresh Page
+      </button>
     </div>
   );
 };

--- a/src/widgets/details/CensusDetails.tsx
+++ b/src/widgets/details/CensusDetails.tsx
@@ -57,6 +57,7 @@ function CensusPopulationCharacteristics({ census }: { census: CensusData }) {
     languagesIncluded,
     notes,
     populationEligible,
+    populationSource,
     populationSurveyed,
     populationWithPositiveResponses,
     quantity,
@@ -66,7 +67,14 @@ function CensusPopulationCharacteristics({ census }: { census: CensusData }) {
 
   return (
     <DetailsSection title="Population Characteristics">
-      <DetailsField title="Eligible Population">{populationEligible.toLocaleString()}</DetailsField>
+      <DetailsField title="Overall eligible population">
+        {populationEligible.toLocaleString()}
+      </DetailsField>
+      {populationSource && (
+        <DetailsField title="Source for overall population">
+          <ExternalLink href={populationSource} />
+        </DetailsField>
+      )}
       {populationWithPositiveResponses && (
         <DetailsField title="Responding Population">
           {populationWithPositiveResponses.toLocaleString()}

--- a/src/widgets/reports/Report.tsx
+++ b/src/widgets/reports/Report.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import ContainErrorsAndSuspense from '@shared/containers/ContainErrorsAndSuspense';
 import enforceExhaustiveSwitch from '@shared/lib/enforceExhaustiveness';
 
+import ReportCensusInputTool from './ReportCensusInputTool';
 import ReportID from './ReportID';
 
 const LocaleIndigeneityReport = React.lazy(
@@ -35,10 +36,12 @@ const Report: React.FC<{ reportID: ReportID }> = ({ reportID }) => {
 
 const SpecificReport: React.FC<{ reportID: ReportID }> = ({ reportID }) => {
   switch (reportID) {
-    case ReportID.EntitiesMissingFields:
-      return <ReportEntitiesMissingFields />;
     case ReportID.CensusCountries:
       return <ReportCensusCountries />;
+    case ReportID.CensusInputTool:
+      return <ReportCensusInputTool />;
+    case ReportID.EntitiesMissingFields:
+      return <ReportEntitiesMissingFields />;
     case ReportID.LanguagePaths:
       return <ReportLanguagePaths />;
     case ReportID.LanguageDescendants:
@@ -49,12 +52,12 @@ const SpecificReport: React.FC<{ reportID: ReportID }> = ({ reportID }) => {
       return <ReportLanguagesDubious />;
     case ReportID.LocaleCitationCompleteness:
       return <ReportLocaleCitationCompleteness />;
-    case ReportID.WritingSystemsLanguagesWithout:
-      return <ReportWritingSystemsLanguagesWithout />;
     case ReportID.LocaleIndigeneity:
       return <LocaleIndigeneityReport />;
     case ReportID.LocalesPotential:
       return <ReportLocalesPotential />;
+    case ReportID.WritingSystemsLanguagesWithout:
+      return <ReportWritingSystemsLanguagesWithout />;
     case ReportID.VariantsAnnotationTool:
       return <ReportVariantsAnnotationTool />;
     default:

--- a/src/widgets/reports/Report.tsx
+++ b/src/widgets/reports/Report.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 import ContainErrorsAndSuspense from '@shared/containers/ContainErrorsAndSuspense';
 import enforceExhaustiveSwitch from '@shared/lib/enforceExhaustiveness';
 
-import ReportCensusInputTool from './ReportCensusInputTool';
 import ReportID from './ReportID';
 
 const LocaleIndigeneityReport = React.lazy(
   () => import('@entities/locale/localstatus/LocaleIndigeneityReport'),
 );
 const ReportCensusCountries = React.lazy(() => import('./ReportCensusCountries'));
+const ReportCensusInputTool = React.lazy(() => import('./ReportCensusInputTool'));
 const ReportEntitiesMissingFields = React.lazy(() => import('./ReportEntitiesMissingFields'));
 const ReportLanguageDescendants = React.lazy(() => import('./ReportLanguageDescendants'));
 const ReportLanguagePaths = React.lazy(() => import('./ReportLanguagePaths'));

--- a/src/widgets/reports/ReportCensusInputTool.tsx
+++ b/src/widgets/reports/ReportCensusInputTool.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useState } from 'react';
+
+import CensusDetails from '@widgets/details/CensusDetails';
+
+import { useDataContext } from '@features/data/context/useDataContext';
+import { parseCensusImport } from '@features/data/load/extra_entities/loadCensusData';
+import PaginationControls from '@features/pagination/PaginationControls';
+import LocalParamsProvider from '@features/params/LocalParamsProvider';
+import usePageParams from '@features/params/usePageParams';
+
+import { CensusData } from '@entities/census/CensusTypes';
+import ObjectTitle from '@entities/ui/ObjectTitle';
+
+import ContainErrorsAndSuspense from '@shared/containers/ContainErrorsAndSuspense';
+
+const ReportCensusInputTool: React.FC = () => {
+  const { getTerritory } = useDataContext();
+  const [tsv, setTSV] = useState('');
+  const [censuses, setCensuses] = useState<CensusData[]>([]);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  useEffect(() => {
+    try {
+      const { censuses } = parseCensusImport(tsv, '');
+      censuses.forEach((census) => {
+        if (!census.nameDisplay) census.nameDisplay = 'MISSING NAME';
+        census.territory = getTerritory(census.isoRegionCode) || undefined;
+      });
+      setCensuses(censuses);
+      setErrorMessage(null);
+    } catch (e) {
+      setErrorMessage((e as Error).message);
+    }
+  }, [tsv]);
+
+  return (
+    <div>
+      <h2>TSV file</h2>
+      <div>
+        Copy-paste work-in-progress TSV files to load the data and see if it is correct. You can
+        edit changes inline to test them out. Changes update after clicking away.
+      </div>
+      <textarea
+        onChange={() => {}}
+        onBlur={(e) => setTSV(e.target.value)}
+        style={{ width: '100%', minHeight: '10em', marginTop: '1em' }}
+      />
+      {errorMessage && <div style={{ color: 'var(--color-red)' }}>{errorMessage}</div>}
+      <LocalParamsProvider overrides={{ page: 1, limit: 1 }}>
+        <ContainErrorsAndSuspense>
+          <CensusPreview censuses={censuses} />
+        </ContainErrorsAndSuspense>
+      </LocalParamsProvider>
+    </div>
+  );
+};
+
+const CensusPreview: React.FC<{ censuses: CensusData[] }> = ({ censuses }) => {
+  const { page } = usePageParams();
+  return (
+    <>
+      <h2>Census Preview</h2>
+      <div>
+        Please check over this data to make sure it makes sense. Check that the metadata makes
+        sense. Check the population numbers, percent in territory, language names, language codes.
+      </div>
+      <div>
+        {censuses.length} census tables found. <PaginationControls itemCount={censuses.length} />
+      </div>
+      <div
+        style={{
+          padding: '1em',
+          margin: '1em 3em',
+          border: '2px solid var(--color-button-primary)',
+          borderRadius: '0.5em',
+        }}
+      >
+        {censuses.length > 0 && page <= censuses.length && censuses[page - 1] && (
+          <LocalParamsProvider overrides={{ page: 1, limit: 5 }}>
+            <ContainErrorsAndSuspense>
+              <h2>
+                <ObjectTitle object={censuses[page - 1]} highlightSearchMatches={false} />
+              </h2>
+              <CensusDetails census={censuses[page - 1]} />
+            </ContainErrorsAndSuspense>
+          </LocalParamsProvider>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default ReportCensusInputTool;

--- a/src/widgets/reports/ReportCensusInputTool.tsx
+++ b/src/widgets/reports/ReportCensusInputTool.tsx
@@ -30,7 +30,7 @@ const ReportCensusInputTool: React.FC = () => {
     } catch (e) {
       setErrorMessage((e as Error).message);
     }
-  }, [tsv]);
+  }, [tsv, getTerritory]);
 
   return (
     <div>

--- a/src/widgets/reports/ReportID.ts
+++ b/src/widgets/reports/ReportID.ts
@@ -2,6 +2,7 @@
 enum ReportID {
   EntitiesMissingFields, // fixed at 0 since it is always there. All others should be alphabetic
   CensusCountries,
+  CensusInputTool,
   LanguagesWithAmbiguousNames,
   LanguagesDubious,
   LanguageDescendants,

--- a/src/widgets/reports/ReportLabels.tsx
+++ b/src/widgets/reports/ReportLabels.tsx
@@ -2,6 +2,7 @@ import ReportID from './ReportID';
 
 const ReportLabels: Record<ReportID, string> = {
   [ReportID.CensusCountries]: 'Countries',
+  [ReportID.CensusInputTool]: 'Input Tool',
   [ReportID.EntitiesMissingFields]: 'Missing Fields',
   [ReportID.LanguageDescendants]: 'Descendants',
   [ReportID.LanguagePaths]: 'Paths',

--- a/src/widgets/reports/getReportIDsForEntityType.ts
+++ b/src/widgets/reports/getReportIDsForEntityType.ts
@@ -23,7 +23,7 @@ function getReportIDsForEntityType(entityType: ObjectType): ReportID[] {
     case ObjectType.WritingSystem:
       return [ReportID.WritingSystemsLanguagesWithout];
     case ObjectType.Census:
-      return [ReportID.CensusCountries];
+      return [ReportID.CensusCountries, ReportID.CensusInputTool];
     case ObjectType.Keyboard:
       return [];
     case ObjectType.Territory:


### PR DESCRIPTION
Fixes #587 

Summary: Our data team could use help validating their TSV submissions -- so this adds a public way to parse submissions

### Changes

- User experience
  - New Report
- Logical changes
  - Fixed the error boundary to work better
- Data
  - n/a
- Refactors
  - n/a

Out of scope/Future work: ...

### Test Plan and Screenshots

How to test the changes in this PR: See the new report

http://localhost:5173/lang-nav/data?objectType=Census&view=Reports&reportID=2

<img width="1117" height="992" alt="Screenshot 2026-04-09 at 09 41 53" src="https://github.com/user-attachments/assets/44213424-2e54-48c5-8420-2629a1b3d65d" />
<img width="1141" height="684" alt="Screenshot 2026-04-09 at 09 28 42" src="https://github.com/user-attachments/assets/0ae33c82-c1e6-4f7b-8c15-b13d67116486" />
