### PR TITLE
Censuses: Add Singapore census data

### DIFF
--- a/public/data/census/official/censusList.txt
+++ b/public/data/census/official/censusList.txt
@@ -14,6 +14,7 @@ np2021
 pk2023
 py
 ru2020
+sg
 us_asc
 us2023
 yt

--- a/public/data/census/official/sg.tsv
+++ b/public/data/census/official/sg.tsv
@@ -10,6 +10,7 @@
 ### Population Surveyed ###									
 #population		3,105,748	3,399,054	2,556,525	2,797,963	3,459,093	3,596,284	3,596,284	3,596,284
 #populationSource					estimated by comparing ratios, not directly from source document				
+#nationality	residents								
 #responsesPerIndividual		1	1	1+	1+	1	1	1	1
 ### Data Constraints ###									
 #age		15+	5+	15+	5+	15+	5+	5+	5+
@@ -21,12 +22,12 @@
 #presentedBy	Internet Archive								
 ### Source Document ###									
 #url	https://web.archive.org/web/20171122005904/https://www.singstat.gov.sg/docs/default-source/default-document-library/publications/publications_and_papers/cop2010/census_2010_release1/cop2010sr1.pdf					https://web.archive.org/web/20220611051404/https://www.singstat.gov.sg/-/media/files/publications/cop2020/sr1/cop2020sr1.pdf	https://web.archive.org/web/20220611051404/https://www.singstat.gov.sg/-/media/files/publications/cop2020/sr1/cop2020sr1.pdf	https://web.archive.org/web/20220611051404/https://www.singstat.gov.sg/-/media/files/publications/cop2020/sr1/cop2020sr1.pdf	https://web.archive.org/web/20220611051404/https://www.singstat.gov.sg/-/media/files/publications/cop2020/sr1/cop2020sr1.pdf
-#datePublished	2011-01								
+#datePublished	2011-01					2021-06	2021-06	2021-06	2021-06
 #dateAccessed	2017-11-22					2022-06-11	2022-06-11	2022-06-11	2022-06-11
 #documentName	Census of Population 2010 Statistical Release 1 Demographic Characteristics, Education, Language and Religion					Census of Population 2020 Statistical Release 1: Demographic Characteristics, Education, Language and Religion	Census of Population 2020 Statistical Release 1: Demographic Characteristics, Education, Language and Religion	Census of Population 2020 Statistical Release 1: Demographic Characteristics, Education, Language and Religion	Census of Population 2020 Statistical Release 1: Demographic Characteristics, Education, Language and Religion
-#tableName		Table 39 Resident Population Aged 15 Years and Over by Language Literate In, Age Group, Sex and Ethnic Grou	Table 50 Resident Population Aged 5 Years and Over by Language Most Frequently Spoken at Home, Residential Status and Sex	KEY INDICATORS OF THE RESIDENT POPULATION	KEY INDICATORS OF THE RESIDENT POPULATION	Tabble 33 Resident Population Aged 15 Years and Over by Language Literate In, Age Group, Sex and Ethnic Grou	Table 41 Resident Population Aged 5 Years and Over by Language Most / Second Most Frequently Spoken at Home, Age Group and Ethnic Group	Table 41 Resident Population Aged 5 Years and Over by Language Most / Second Most Frequently Spoken at Home, Age Group and Ethnic Group	Table 41 Resident Population Aged 5 Years and Over by Language Most / Second Most Frequently Spoken at Home, Age Group and Ethnic Group
+#tableName		Table 39 Resident Population Aged 15 Years and Over by Language Literate In, Age Group, Sex and Ethnic Group	Table 50 Resident Population Aged 5 Years and Over by Language Most Frequently Spoken at Home, Residential Status and Sex	KEY INDICATORS OF THE RESIDENT POPULATION	KEY INDICATORS OF THE RESIDENT POPULATION	Table 33 Resident Population Aged 15 Years and Over by Language Literate In, Age Group, Sex and Ethnic Group	Table 41 Resident Population Aged 5 Years and Over by Language Most / Second Most Frequently Spoken at Home, Age Group and Ethnic Group	Table 41 Resident Population Aged 5 Years and Over by Language Most / Second Most Frequently Spoken at Home, Age Group and Ethnic Group	Table 41 Resident Population Aged 5 Years and Over by Language Most / Second Most Frequently Spoken at Home, Age Group and Ethnic Group
 #columnName		Language Literate In		Total: 2000	Total: 2000	Language Literate In	Language Most / Second Most Frequently Spoken at Home	Language Most Frequently Spoken at Home	Language Second Most Frequently Spoken at Home
-Language Code	Language	Singapore 2010 Literacy	Singapore 2010 Primary Spoken	Singapore 2000 Literacy	Singapore 2000 Primary Spoken	Singapore 2020 Literacy	Spoken at Hom		
+Language Code	Language	Singapore 2010 Literacy	Singapore 2010 Primary Spoken	Singapore 2000 Literacy	Singapore 2000 Primary Spoken	Singapore 2020 Literacy	Singapore 2020 Primary or Secondary Spoken	Singapore 2020 Primary Spoken	Singapore 2020 Secondary Spoken
 mul	Total	3,105,748	3,399,054			3,459,093	3,596,284		
 	Not Literate	128,661				99,212			
 	Literate	2,977,088				3,359,881			

--- a/public/data/census/official/sg.tsv
+++ b/public/data/census/official/sg.tsv
@@ -1,0 +1,83 @@
+#codeDisplay		sg2010writes	sg2010speaks	sg2000writes	sg2000speaks	sg2020writes	sg2020speaks	sg2020speaks1st	sg2020speaks2nd
+#nameDisplay		Singapore 2010 Literacy	Singapore 2010 Primary Spoken	Singapore 2000 Literacy	Singapore 2000 Primary Spoken	Singapore 2020 Literacy	Singapore 2020 Primary or Secondary Spoken	Singapore 2020 Primary Spoken	Singapore 2020 Secondary Spoken
+#isoRegionCode	SG								
+#yearCollected		2010	2010	2000	2000	2020	2020	2020	2020
+### Language Criteria ###									
+#languageUse		Writes	Speaks	Writes	Speaks	Writes	Speaks	Speaks	Speaks
+#proficiency									
+#acquisitionOrder			L1		L1		Any	L1	L2
+#domain			Home		Home		Home	Home	Home
+### Population Surveyed ###									
+#population		3,105,748	3,399,054	2,556,525	2,797,963	3,459,093	3,596,284	3,596,284	3,596,284
+#populationSource					estimated by comparing ratios, not directly from source document				
+#responsesPerIndividual		1	1	1+	1+	1	1	1	1
+### Data Constraints ###									
+#age		15+	5+	15+	5+	15+	5+	5+	5+
+#quantity		count	count	percent	percent	count	count	count	count
+### Creator ###									
+#collectorType	Government								
+#collectorName	Department of Statistics, Ministry of Trade & Industry, Republic of Singapore								
+#collectorNameShort	SingStat								
+#presentedBy	Internet Archive								
+### Source Document ###									
+#url	https://web.archive.org/web/20171122005904/https://www.singstat.gov.sg/docs/default-source/default-document-library/publications/publications_and_papers/cop2010/census_2010_release1/cop2010sr1.pdf					https://web.archive.org/web/20220611051404/https://www.singstat.gov.sg/-/media/files/publications/cop2020/sr1/cop2020sr1.pdf	https://web.archive.org/web/20220611051404/https://www.singstat.gov.sg/-/media/files/publications/cop2020/sr1/cop2020sr1.pdf	https://web.archive.org/web/20220611051404/https://www.singstat.gov.sg/-/media/files/publications/cop2020/sr1/cop2020sr1.pdf	https://web.archive.org/web/20220611051404/https://www.singstat.gov.sg/-/media/files/publications/cop2020/sr1/cop2020sr1.pdf
+#datePublished	2011-01								
+#dateAccessed	2017-11-22					2022-06-11	2022-06-11	2022-06-11	2022-06-11
+#documentName	Census of Population 2010 Statistical Release 1 Demographic Characteristics, Education, Language and Religion					Census of Population 2020 Statistical Release 1: Demographic Characteristics, Education, Language and Religion	Census of Population 2020 Statistical Release 1: Demographic Characteristics, Education, Language and Religion	Census of Population 2020 Statistical Release 1: Demographic Characteristics, Education, Language and Religion	Census of Population 2020 Statistical Release 1: Demographic Characteristics, Education, Language and Religion
+#tableName		Table 39 Resident Population Aged 15 Years and Over by Language Literate In, Age Group, Sex and Ethnic Grou	Table 50 Resident Population Aged 5 Years and Over by Language Most Frequently Spoken at Home, Residential Status and Sex	KEY INDICATORS OF THE RESIDENT POPULATION	KEY INDICATORS OF THE RESIDENT POPULATION	Tabble 33 Resident Population Aged 15 Years and Over by Language Literate In, Age Group, Sex and Ethnic Grou	Table 41 Resident Population Aged 5 Years and Over by Language Most / Second Most Frequently Spoken at Home, Age Group and Ethnic Group	Table 41 Resident Population Aged 5 Years and Over by Language Most / Second Most Frequently Spoken at Home, Age Group and Ethnic Group	Table 41 Resident Population Aged 5 Years and Over by Language Most / Second Most Frequently Spoken at Home, Age Group and Ethnic Group
+#columnName		Language Literate In		Total: 2000	Total: 2000	Language Literate In	Language Most / Second Most Frequently Spoken at Home	Language Most Frequently Spoken at Home	Language Second Most Frequently Spoken at Home
+Language Code	Language	Singapore 2010 Literacy	Singapore 2010 Primary Spoken	Singapore 2000 Literacy	Singapore 2000 Primary Spoken	Singapore 2020 Literacy	Spoken at Hom		
+mul	Total	3,105,748	3,399,054			3,459,093	3,596,284		
+	Not Literate	128,661				99,212			
+	Literate	2,977,088				3,359,881			
+	#One Language Only	878,214				862,098			
+eng	#English Only	329,194				362,469	229,429		
+zho	#Chinese Only	485,511				438,279			
+zho/cmn	#Mandarin Only						239,997		
+zho/nan/taib1242	#Hokkien Only						46,868		
+zho/nan/chao1238	#Teochew Only						18,601		
+zho/yue	#Cantonese Only						21,423		
+msa/zlm	#Malay Only	47,278				45,753	79,278		
+zho/mul	#Other Chinese Dialects Only						17,359		
+tam	#Tamil Only	10,939				9,600	14,582		
+mul	#Non-Official Language Only	5,292				5,998			
+	#Two Languages Only	1,896,268		56		2,259,548			
+eng/zho	#English & Chinese Only	1,305,705				1,584,180			
+eng/zho/cmn	#English & Mandarin						973,515		
+eng/zho/mul	#English & Chinese Dialect						125,507		
+eng/msa/zlm	#English & Malay Only	390,124				465,744	233,779		
+eng/tam	#English & Tamil Only	104,570				123,308	88,059		
+eng/mul	#English & Non-Official Language Only	82,972				78,208			
+eng/mul	#English & Other Indian Language						44,949		
+eng/mul	#English & Other Language						40,004		
+zho/cmn/eng	#Mandarin & English						239,997		
+zho/cmn/mul	Mandarin & Chinese Dialect						301,328		
+zho/nan/taib1242/eng	Hokkien & English						15,511		
+zho/nan/taib1242/cmn	Hokkien & Mandarin						88,928		
+zho/nan/chao1238/eng	Teochew & English						8,069		
+zho/nan/chao1238/cmn	Teochew & Mandarin						29,369		
+zho/yue/eng	Cantonese & English						19,495		
+zho/yue/cmn	Cantonese & Mandarin						35,467		
+zho/mul/cmn	Other Chinese Dialect & Mandarin						9,657		
+msa/zlm/eng	Malay & English						250,223		
+tam/eng	Tamil & English						72,428		
+mul/eng	Other Indian Language & English						18,872		
+mul/eng	Other Language & English						19,945		
+mul	#Other Two Languages Only	12,898				8,107			
+	#Three or More Languages	202,606				238,235			
+eng/zho/msa/zlm	#English, Chinese & Malay Only	96,660				132,424			
+eng/zho/tam	#English, Chinese & Tamil Only	377							
+eng/msa/zlm/tam	#English, Malay & Tamil Only	16,423				15,516			
+mul	#Other Three or More Languages	89,147				90,295			
+eng	English		1,097,443	70.9	23			1,735,242	644,540
+zho/cmn	Mandarin		1,211,505		35			1,075,172	1,136,936
+zho/mul	Chinese Dialects		487,031		23.8			313,258	125,507
+nan/taib1242	Hokkien		238,843					157,259	
+nan/chao1238	Teochew		94,302					59,424	
+yue	Cantonese		121,136					79,216	
+mul	Other Chinese Dialects		32,750					17,359	
+msa/zlm	Malay		414,475		14.1			332,256	233,779
+mul	Indian Languages		151,000					113,764	
+tam	Tamil		110,667		3.2			89,946	88,059
+mul	Other Indian Languages		40,334					23,818	44,949
+mul	Others		37,600		0.9			26,592	40,004

--- a/public/data/tc/locales.tsv
+++ b/public/data/tc/locales.tsv
@@ -10713,3 +10713,13 @@ tob_PY	Toba (Paraguay)		Official	93241
 gnw_PY	Western Bolivian Guaraní (Paraguay)		Official	46906	
 crq_PY	Iyo'wujwa Chorote (Paraguay)		Official	32034	
 por_PY	Portuguese (Paraguay)		Official	199638	
+calc1235_CL	Diaguita (Chile)		Official	153231	
+lel_GN	Lele (Guinea)		Official	37758	
+cou_GN	Wamey (Guinea)		Official	18879	
+knk_GN	Kuranko (Guinea)		Official	179350	
+aym_CL	Aymara (Chile)		Official	178637	
+cmn_SG	Mandarin Chinese (Singapore)		Official	1211505	
+zlm_SG	Malay (Singapore)		Official	550485	
+nan_SG	Min Nan Chinese (Singapore)		Official	333145	
+yue_SG	Cantonese (Singapore)		Official	121136	
+snk_GN	Soninke (Guinea)		Official	18879	

--- a/src/widgets/details/CensusDetails.tsx
+++ b/src/widgets/details/CensusDetails.tsx
@@ -74,7 +74,11 @@ function CensusPopulationCharacteristics({ census }: { census: CensusData }) {
       <DetailsField title="Overall population">{population.toLocaleString()}</DetailsField>
       {populationSource && (
         <DetailsField title="Source for overall population">
-          <ExternalLink href={populationSource} />
+          {populationSource.startsWith('http') ? (
+            <ExternalLink href={populationSource} />
+          ) : (
+            populationSource
+          )}
         </DetailsField>
       )}
       {populationWithPositiveResponses && (


### PR DESCRIPTION
Summary: Prompted by a [CLDR ticket assigned to me](https://unicode-org.atlassian.net/browse/CLDR-10480) -- I went to get Singapore language data. Here's the updates!

### Changes

- User experience
  - Some languages increased in numbers
- Logical changes
  - Census details no longer assumes populationSource is always a link
- Data
  - Singapore census data
  - Added some locales for Singapore (and a few countries that had updated numbers)
- Refactors
  - n/a


### Test Plan and Screenshots

How to test the changes in this PR: Look at the locales in Singapore and censuses loaded

| Page/View with link | Description of Changes | Screenshot Before | Screenshot After |
| ------------------- | ---------------------- | ----------------- | ---------------- |
|[Locales of Singapore](https://translation-commons.github.io/lang-nav/data?objectID=SG&objectType=Locale&territoryFilter=sg&view=Table)|Some more language variations (eg. Common Malay, Min Nan)|<img width="904" height="394" alt="Screenshot 2026-04-14 at 15 40 24" src="https://github.com/user-attachments/assets/817eaceb-1456-460c-9b7a-2ef13cbca59c" />|<img width="878" height="511" alt="Screenshot 2026-04-14 at 15 39 16" src="https://github.com/user-attachments/assets/e84586fe-a5a8-4a2e-ae38-9bb971be5a00" />

See also new censuses like this:
<img width="808" height="775" alt="Screenshot 2026-04-14 at 15 41 10" src="https://github.com/user-attachments/assets/498e914d-f50e-43e7-a337-6a415b824ab0" />

