### PR TITLE
Search from other pages

### DIFF
--- a/src/app/component_styles.css
+++ b/src/app/component_styles.css
@@ -31,7 +31,7 @@ h4 {
 }
 
 button,
-.button {
+.option {
   border-radius: 8px;
   border: 1px solid transparent;
   padding: 0.5em 0.75em;
@@ -44,26 +44,27 @@ button,
   background-color: var(--color-button-secondary);
 }
 
-.button-inline-icon {
+.option-inline-icon {
   padding: 0.125em 0.25em 0.125em 0.125em;
   vertical-align: sub;
   height: 1em;
   width: 1em;
 }
 
-button.primary {
+button.primary,
+.option.primary {
   color: var(--color-text-on-color);
   background-color: var(--color-button-primary);
 }
 
 button:hover,
-.button:hover {
+.option:hover {
   color: var(--color-text-on-color);
   background: var(--color-button-hover);
 }
 
 button:focus,
-.button:focus {
+.option:focus {
   border-color: var(--color-button-hover);
   background: var(--color-button-hover);
 }
@@ -101,7 +102,8 @@ code {
   background: var(--color-text-highlight);
 }
 
-button:hover .highlighted {
+button:hover .highlighted,
+.option:hover .highlighted {
   color: var(--color-text);
 }
 
@@ -128,7 +130,7 @@ div h3:first-child {
   margin-top: 0px;
 }
 
-.collapsible-report > summary {
+.collapsible-report>summary {
   width: 100%;
   background-color: var(--color-button-secondary);
   padding: 0.5em;
@@ -147,10 +149,6 @@ div h3:first-child {
   border-radius: 0.5em;
   padding: 0 0.25em;
   margin: 0 -0.25em;
-}
-
-.selector .secondaryHoverableText {
-  color: var(--color-text-secondary);
 }
 
 .hoverableText:hover,

--- a/src/app/component_styles.css
+++ b/src/app/component_styles.css
@@ -130,7 +130,7 @@ div h3:first-child {
   margin-top: 0px;
 }
 
-.collapsible-report>summary {
+.collapsible-report > summary {
   width: 100%;
   background-color: var(--color-button-secondary);
   padding: 0.5em;

--- a/src/app/component_styles.css
+++ b/src/app/component_styles.css
@@ -30,7 +30,8 @@ h4 {
   margin-bottom: 4px;
 }
 
-button {
+button,
+.button {
   border-radius: 8px;
   border: 1px solid transparent;
   padding: 0.5em 0.75em;
@@ -55,12 +56,14 @@ button.primary {
   background-color: var(--color-button-primary);
 }
 
-button:hover {
+button:hover,
+.button:hover {
   color: var(--color-text-on-color);
   background: var(--color-button-hover);
 }
 
-button:focus {
+button:focus,
+.button:focus {
   border-color: var(--color-button-hover);
   background: var(--color-button-hover);
 }

--- a/src/app/controls.css
+++ b/src/app/controls.css
@@ -1,7 +1,26 @@
+.selector {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.selector.optionList {
+  flex-direction: column;
+  align-items: start;
+}
+
+.selector.optionGroup {
+  gap: -0.125em;
+}
+
 .selector button,
+.selector .option,
 .selector input,
 .selector label {
-  border: 0.125em solid var(--color-button-primary);
+  border-width: 0.125em;
+  border-color: var(--color-button-primary);
+  border-style: solid;
 }
 
 .selector input {
@@ -10,7 +29,7 @@
 }
 
 .selector button,
-.selector .button {
+.selector .option {
   color: var(--color-button-primary);
   background-color: var(--color-background);
 }
@@ -26,7 +45,7 @@
 }
 
 .selector button:hover,
-.selector .button:hover {
+.selector .option:hover {
   color: var(--color-text-on-color);
   background-color: var(--color-button-hover);
 }
@@ -42,7 +61,14 @@
 }
 
 .selector button:disabled,
-.selector button:disabled:hover {
+.selector button:disabled:hover,
+.selector .option:disabled,
+.selector .option:disabled:hover {
   color: var(--color-text-secondary);
   pointer-events: none;
+}
+
+
+.selector .secondaryHoverableText {
+  color: var(--color-text-secondary);
 }

--- a/src/app/controls.css
+++ b/src/app/controls.css
@@ -9,7 +9,8 @@
   background: var(--color-button-primary);
 }
 
-.selector button {
+.selector button,
+.selector .button {
   color: var(--color-button-primary);
   background-color: var(--color-background);
 }
@@ -24,7 +25,8 @@
   background-color: var(--color-background);
 }
 
-.selector button:hover {
+.selector button:hover,
+.selector .button:hover {
   color: var(--color-text-on-color);
   background-color: var(--color-button-hover);
 }

--- a/src/app/controls.css
+++ b/src/app/controls.css
@@ -5,12 +5,12 @@
   flex-wrap: wrap;
 }
 
-.selector.optionList {
+.selector.buttonList {
   flex-direction: column;
   align-items: start;
 }
 
-.selector.optionGroup {
+.selector.buttonGroup {
   gap: -0.125em;
 }
 

--- a/src/app/controls.css
+++ b/src/app/controls.css
@@ -68,7 +68,6 @@
   pointer-events: none;
 }
 
-
 .selector .secondaryHoverableText {
   color: var(--color-text-secondary);
 }

--- a/src/features/data/load/extra_entities/loadCensusData.tsx
+++ b/src/features/data/load/extra_entities/loadCensusData.tsx
@@ -77,7 +77,7 @@ export function parseCensusImport(fileInput: string, filePath: string): CensusIm
       if (languageName === languageName.toUpperCase()) {
         languageName = toTitleCase(languageName);
       }
-      if (languageName.match(/official|indigenous|native/i)) {
+      if (languageName.match(/official|indigenous|native/i) && languageCodes[0] !== 'aus') {
         warnings.push(
           `Language name "${languageName}" looks like it contains status information that should be removed.`,
         );

--- a/src/features/params/ui/Selector.tsx
+++ b/src/features/params/ui/Selector.tsx
@@ -89,22 +89,9 @@ const SelectorContainer: React.FC<
   const { display: inheritedDisplay } = useSelectorDisplay();
   const display = manualDisplay ?? inheritedDisplay;
 
-  const style: React.CSSProperties = {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
-    flexWrap: 'wrap',
-  };
-  if (display === SelectorDisplay.ButtonList) {
-    style.flexDirection = 'column';
-    style.alignItems = 'start';
-  } else if (display === SelectorDisplay.ButtonGroup) {
-    style.gap = '-0.125em'; // Overlap the buttons slightly
-  }
-
   // Prepare the container. If there was a manual display, then wrap in a provider.
   const container = (
-    <div className={'selector ' + display} style={{ ...style, ...manualStyle }}>
+    <div className={'selector ' + display} style={{ ...manualStyle }}>
       {children}
     </div>
   );

--- a/src/features/params/ui/SelectorDropdown.tsx
+++ b/src/features/params/ui/SelectorDropdown.tsx
@@ -38,6 +38,8 @@ export const SelectorDropdown: React.FC<React.PropsWithChildren<Props>> = ({
             display: 'flex',
             flexDirection: 'column',
             width: 'fit-content',
+            borderRadius: '1em',
+            backgroundColor: 'var(--color-background)',
           }}
         >
           {children}

--- a/src/features/params/ui/SelectorDropdownLabel.tsx
+++ b/src/features/params/ui/SelectorDropdownLabel.tsx
@@ -21,6 +21,7 @@ const SelectorDropdownLabel: React.FC<React.PropsWithChildren<Props>> = ({
       style={{
         ...getOptionStyle(display, false, position),
         lineHeight: '0.5em',
+        cursor: 'default',
       }}
     >
       <span style={{ fontSize: '0.75em' }}>{children}</span>

--- a/src/features/params/ui/SelectorDropdownLabel.tsx
+++ b/src/features/params/ui/SelectorDropdownLabel.tsx
@@ -6,29 +6,25 @@ import { useSelectorDisplay } from './SelectorDisplayContext';
 import { getOptionStyle } from './SelectorOption';
 
 type Props = {
-  disabled?: boolean;
   position?: PositionInGroup;
 };
 
 const SelectorDropdownLabel: React.FC<React.PropsWithChildren<Props>> = ({
   children,
-  disabled = false,
   position = PositionInGroup.Middle,
 }) => {
   const { display } = useSelectorDisplay();
 
   return (
-    <button
-      className="secondaryHoverableText" // grey unless hovered over
-      disabled={disabled}
+    <span
+      className={'option secondaryHoverableText ' + position} // grey unless hovered over
       style={{
         ...getOptionStyle(display, false, position),
         lineHeight: '0.5em',
       }}
-      type="button"
     >
-      <div style={{ fontSize: '0.75em' }}>{children}</div>
-    </button>
+      <span style={{ fontSize: '0.75em' }}>{children}</span>
+    </span>
   );
 };
 

--- a/src/features/params/ui/SelectorOption.tsx
+++ b/src/features/params/ui/SelectorOption.tsx
@@ -118,6 +118,9 @@ export function getOptionStyle(
     lineHeight: '1em',
     padding: '0.5em',
     whiteSpace: 'nowrap',
+    maxWidth: '24em',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
   };
   // Customize based on position and display type
   switch (display) {

--- a/src/features/params/ui/SelectorSuggestionsDropdown.tsx
+++ b/src/features/params/ui/SelectorSuggestionsDropdown.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 
-import HoverableButton from '@features/layers/hovercard/HoverableButton';
+import HoverableInternalLinkButton from '@features/layers/hovercard/HoverableInternalLinkButton';
 
 import { getPositionInGroup, PositionInGroup } from '@shared/lib/PositionInGroup';
 
 import { PageParamKey } from '../PageParamTypes';
-import usePageParams from '../usePageParams';
 
 import { SelectorDisplay } from './SelectorDisplayContext';
 import { SelectorDropdown } from './SelectorDropdown';
@@ -84,8 +83,8 @@ const SuggestionRow: React.FC<SuggestionRowProps> = ({
     position,
   );
   if (pageParameter === PageParamKey.searchString) {
-    // Does not need to update suggestions
-    return <SuggestionRowDetails suggestion={suggestion} style={style} />;
+    // Internal links to open the details page
+    return <SuggestionRowOpenDetails suggestion={suggestion} style={style} />;
   }
 
   return (
@@ -101,25 +100,28 @@ const SuggestionRow: React.FC<SuggestionRowProps> = ({
   );
 };
 
-const SuggestionRowDetails: React.FC<{
+const SuggestionRowOpenDetails: React.FC<{
   suggestion: Suggestion;
   style?: React.CSSProperties;
 }> = ({ style, suggestion }) => {
   const { objectID, searchString, label } = suggestion;
-  const { updatePageParams } = usePageParams();
-
-  const goToDetails = () => {
-    updatePageParams({ objectID, searchString });
-  };
 
   return (
-    <HoverableButton
+    <HoverableInternalLinkButton
+      className="button"
       hoverContent={<>Open the details pane for {searchString}</>}
-      onClick={goToDetails}
-      style={style}
+      keepOldParams={true}
+      params={{ objectID, searchString }}
+      style={{
+        ...style,
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        maxWidth: '23em',
+      }}
     >
       {label}
-    </HoverableButton>
+    </HoverableInternalLinkButton>
   );
 };
 

--- a/src/features/params/ui/SelectorSuggestionsDropdown.tsx
+++ b/src/features/params/ui/SelectorSuggestionsDropdown.tsx
@@ -45,7 +45,7 @@ const SelectorSuggestionsDropdown: React.FC<Props> = ({
       {suggestions.map((s, i) => (
         <React.Fragment key={i}>
           {i > 0 && suggestions[i - 1].group !== s.group && (
-            <SelectorDropdownLabel disabled={true} position={PositionInGroup.Middle}>
+            <SelectorDropdownLabel position={PositionInGroup.Middle}>
               {s.group}
             </SelectorDropdownLabel>
           )}
@@ -88,15 +88,15 @@ const SuggestionRow: React.FC<SuggestionRowProps> = ({
   }
 
   return (
-    <button
+    <a
+      className="option"
       onMouseDown={onKeyDown}
       onClick={() => onClick(suggestion)}
       style={style}
       role="option"
-      type="button"
     >
       {suggestion.label}
-    </button>
+    </a>
   );
 };
 
@@ -108,17 +108,11 @@ const SuggestionRowOpenDetails: React.FC<{
 
   return (
     <HoverableInternalLinkButton
-      className="button"
+      className="option"
       hoverContent={<>Open the details pane for {searchString}</>}
       keepOldParams={true}
       params={{ objectID, searchString }}
-      style={{
-        ...style,
-        overflow: 'hidden',
-        textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
-        maxWidth: '23em',
-      }}
+      style={style}
     >
       {label}
     </HoverableInternalLinkButton>

--- a/src/features/params/ui/TextInput.tsx
+++ b/src/features/params/ui/TextInput.tsx
@@ -64,7 +64,7 @@ const TextInput: React.FC<Props> = ({
           setCurrentValue(value);
           isUpdatingFromSuggestions.current = false;
         }
-      }, 100);
+      }, 200);
       return () => clearTimeout(timer);
     },
     [onSubmit, setShowSuggestions],

--- a/src/features/params/ui/__tests__/TextInput.test.tsx
+++ b/src/features/params/ui/__tests__/TextInput.test.tsx
@@ -19,7 +19,7 @@ describe('TextInput component', () => {
   const createUser = () => userEvent.setup();
   const flushTimers = async () => {
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      await new Promise((resolve) => setTimeout(resolve, 300));
     });
   };
 

--- a/src/features/transforms/filtering/selectors/__tests__/FilterSelector.test.tsx
+++ b/src/features/transforms/filtering/selectors/__tests__/FilterSelector.test.tsx
@@ -16,6 +16,12 @@ vi.mock('@features/params/usePageParams', () => ({
 vi.mock('@features/layers/hovercard/useHoverCard', () => ({
   default: () => ({ hideHoverCard: vi.fn(), showHoverCard: vi.fn() }),
 }));
+vi.mock('react-router-dom', () => ({
+  Navigate: vi.fn(),
+  Route: vi.fn(),
+  Routes: vi.fn(),
+  useLocation: vi.fn(),
+}));
 
 describe('FilterSelector', () => {
   it('renders the correct selector based on the field prop', () => {

--- a/src/features/transforms/search/SearchBar.tsx
+++ b/src/features/transforms/search/SearchBar.tsx
@@ -1,5 +1,6 @@
 import { SearchIcon } from 'lucide-react';
-import React from 'react';
+import React, { useCallback } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { PageParamKey } from '@features/params/PageParamTypes';
 import {
@@ -13,8 +14,15 @@ import useSearchSuggestions from './useSearchSuggestions';
 
 const SearchBar: React.FC = () => {
   const { searchString, updatePageParams } = usePageParams();
+  const location = useLocation();
   const getSearchSuggestions = useSearchSuggestions();
-  const setSearchString = (value: string) => updatePageParams({ searchString: value });
+  const setSearchString = useCallback(
+    (value: string) => {
+      // Only update the searchString param if we're already on the data page
+      if (location.pathname === '/data') updatePageParams({ searchString: value });
+    },
+    [updatePageParams],
+  );
   return (
     <SelectorDisplayProvider display={SelectorDisplay.ButtonList}>
       <form

--- a/src/features/transforms/search/useSearchSuggestions.tsx
+++ b/src/features/transforms/search/useSearchSuggestions.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 
-import { useDataContext } from '@features/data/context/useDataContext';
-import { ObjectType } from '@features/params/PageParamTypes';
+import useEntities from '@features/data/context/useEntities';
 import { Suggestion, SUGGESTION_LIMIT } from '@features/params/ui/SelectorSuggestions';
 import usePageParams from '@features/params/usePageParams';
 
@@ -16,37 +15,10 @@ import getSubstringFilterOnQuery from './getSubstringFilterOnQuery';
 import HighlightedObjectField from './HighlightedObjectField';
 
 export default function useSearchSuggestions(): (query: string) => Promise<Suggestion[]> {
-  const { searchBy, objectType } = usePageParams();
-  const { censuses, territories, languagesInSelectedSource, locales, writingSystems, variants } =
-    useDataContext();
+  const { searchBy } = usePageParams();
+  const pageObjects = useEntities();
   const filterBy = useFilters();
   const filterLabels = getFilterLabels();
-
-  const objects = useMemo(() => {
-    switch (objectType) {
-      case ObjectType.Language:
-        return languagesInSelectedSource;
-      case ObjectType.Locale:
-        return locales;
-      case ObjectType.Territory:
-        return territories;
-      case ObjectType.WritingSystem:
-        return writingSystems;
-      case ObjectType.Census:
-        return Object.values(censuses);
-      case ObjectType.Variant:
-        return variants;
-    }
-  }, [
-    censuses,
-    languagesInSelectedSource,
-    locales,
-    territories,
-    variants,
-    writingSystems,
-    objectType,
-    searchBy,
-  ]);
 
   const [getMatchDistance, getMatchGroup] = useMemo(() => {
     const getMatchDistance = (object: ObjectData): number => {
@@ -83,7 +55,7 @@ export default function useSearchSuggestions(): (query: string) => Promise<Sugge
   const getSuggestions = useCallback(
     async (query: string) => {
       const substringFilter = getSubstringFilterOnQuery(query, searchBy);
-      return (objects || [])
+      return (pageObjects || [])
         .filter(substringFilter)
         .sort((a, b) => getMatchDistance(a) - getMatchDistance(b))
         .slice(0, SUGGESTION_LIMIT)
@@ -100,7 +72,7 @@ export default function useSearchSuggestions(): (query: string) => Promise<Sugge
           return { objectID: object.ID, searchString, label, group: getMatchGroup(object) };
         });
     },
-    [objects, searchBy, getMatchDistance, getMatchGroup],
+    [pageObjects, searchBy, getMatchDistance, getMatchGroup],
   );
 
   return getSuggestions;


### PR DESCRIPTION
Fixes #573

Summary: If you are on the about page or intro page you cannot use the search bar -- which is annoying. This fixes that.

### Changes

- User experience
  - You can use the search bar from other pages now :D
- Logical changes
  - N/a
- Data
  - n/a
- Refactors
  - Some styles moved around
  - 
<img width="1495" height="895" alt="Screenshot 2026-04-15 at 18 42 11" src="https://github.com/user-attachments/assets/35266e74-efce-4dac-95e1-acd3651fd3db" />
