### PR TITLE
ECRML column visual update

### DIFF
--- a/src/widgets/tables/TableOfLanguagesInTerritory.tsx
+++ b/src/widgets/tables/TableOfLanguagesInTerritory.tsx
@@ -32,6 +32,8 @@ const TableOfLanguagesInTerritory: React.FC<Props> = ({ territory }) => {
     return null;
   }
 
+  const hasECRMLData = locales.some((locale) => locale.ecrmlProtection != null);
+
   return (
     <LocalParamsProvider overrides={{ territoryScopes: [territory.scope] }}>
       <InteractiveObjectTable<LocaleData>
@@ -62,7 +64,7 @@ const TableOfLanguagesInTerritory: React.FC<Props> = ({ territory }) => {
             render: (loc) => <LocaleEcrmlCoverage locale={loc} />,
             field: Field.ECRMLProtection,
             valueType: TableValueType.Enum,
-            isInitiallyVisible: false,
+            isInitiallyVisible: hasECRMLData,
           },
           {
             key: 'Population',


### PR DESCRIPTION
Fixes #583

Summary: 
Checking if the ECRML data is present before rendering.
locales per territory is typically small (5-50 languages per territory).
This runs only once during component render.
The operation is memoized by React (won't re-run unless territory changes).

## Testing
- [x] `npm run dev` -- tried out the website directly
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run preview`
  - [x] Include screenshots as noted below

### Visual changes
ECRML Column will only be displayed for the available territories (European).

https://translation-commons.github.io/lang-nav/data?objectID=US&objectType=Territory
<img width="2376" height="1107" alt="image" src="https://github.com/user-attachments/assets/024e8c3b-29b7-4558-b2b0-c056b4cb2bed" />

https://translation-commons.github.io/lang-nav/data?objectID=ES&objectType=Territory&page=3
<img width="2371" height="1142" alt="image" src="https://github.com/user-attachments/assets/2832bb93-27fc-44f3-8bfd-fa2a5f92a31d" />