### PR TITLE
Fields: Add Language Family Field

### DIFF
--- a/public/data/tc/languages.tsv
+++ b/public/data/tc/languages.tsv
@@ -31,7 +31,7 @@ wuu	wuch1236	Wu Chinese	吳語	Mostly Spoken	Hans	77,216,330	zho	wuhu1234	Yes	Es
 ita	ital1282	Italian	Italiano	Spoken & Written	Latn	70,677,996		ital1287	Yes	
 jav	java1254	Javanese	Jawa	Mostly Spoken	Latn	68,500,495		glob1245	Yes	
 guj	guja1252	Gujarati	ગુજરાતી	Spoken & Written	Gujr	62,854,955		guja1256	Yes	
-arz	egyp1253	Egyptian Arabic	arz	Mostly Spoken	Arab	62,300,000	ara	egyp1254	Yes, with caveat	To distinguish spoken dialect
+arz	egyp1253	Egyptian Arabic		Mostly Spoken	Arab	62,300,000	ara	egyp1254	Yes, with caveat	To distinguish spoken dialect
 pus	nucl1276	Pashto	پښتو	Spoken & Written	Arab	61,809,847		pash1269	Yes	
 kan	nucl1305	Kannada	ಕನ್ನಡ	Spoken & Written	Knda	58,854,873		kann1255	Yes	
 hau	haus1257	Hausa	Hausa	Spoken & Written	Latn	57,514,625		west2718	Yes	

--- a/src/entities/language/LanguageFamilyUtils.tsx
+++ b/src/entities/language/LanguageFamilyUtils.tsx
@@ -1,6 +1,17 @@
+import { getLanguageForEntity } from '@features/transforms/fields/getEntityConnection';
+
+import { EntityData } from '@entities/types/DataTypes';
+
 import { LanguageData, LanguageScope } from './LanguageTypes';
 
 export function getLanguageRootLanguageFamily(lang: LanguageData): LanguageData {
+  if (lang.parentLanguage) return getLanguageRootLanguageFamily(lang.parentLanguage);
+  return lang;
+}
+
+export function getRootLanguageFamilyForEntity(ent: EntityData): LanguageData | undefined {
+  const lang = getLanguageForEntity(ent);
+  if (!lang) return undefined;
   if (lang.parentLanguage) return getLanguageRootLanguageFamily(lang.parentLanguage);
   return lang;
 }

--- a/src/entities/language/LanguageFamilyUtils.tsx
+++ b/src/entities/language/LanguageFamilyUtils.tsx
@@ -4,16 +4,16 @@ import { EntityData } from '@entities/types/DataTypes';
 
 import { LanguageData, LanguageScope } from './LanguageTypes';
 
-export function getLanguageRootLanguageFamily(lang: LanguageData): LanguageData {
-  if (lang.parentLanguage) return getLanguageRootLanguageFamily(lang.parentLanguage);
+export function getLanguageRootLanguageFamily(lang: LanguageData, depth = 0): LanguageData {
+  if (depth > 30) return lang; // Prevent possible infinite loops in case of circular references
+  if (lang.parentLanguage) return getLanguageRootLanguageFamily(lang.parentLanguage, depth + 1);
   return lang;
 }
 
 export function getRootLanguageFamilyForEntity(ent: EntityData): LanguageData | undefined {
   const lang = getLanguageForEntity(ent);
   if (!lang) return undefined;
-  if (lang.parentLanguage) return getLanguageRootLanguageFamily(lang.parentLanguage);
-  return lang;
+  return getLanguageRootLanguageFamily(lang);
 }
 
 export function getLanguageRootMacrolanguage(

--- a/src/features/transforms/fields/FieldApplicability.ts
+++ b/src/features/transforms/fields/FieldApplicability.ts
@@ -19,7 +19,6 @@ export const FIELDS_IN_DEVELOPMENT: Field[] = [
   Field.Indigeneity,
   Field.CLDRCoverage,
   Field.DigitalSupport,
-  Field.LanguageFamily,
   Field.WritingSystemScope,
   Field.Coordinates,
 ];
@@ -145,6 +144,7 @@ function getSpecificFieldsForObjectType(objectType: ObjectType): Field[] {
         Field.VitalityEthnologueCoarse,
 
         Field.Language, // Equivalent to DisplayName for languages
+        Field.LanguageFamily,
         Field.WritingSystem,
         Field.Territory,
         Field.SourceForPopulation,

--- a/src/features/transforms/fields/__tests__/getApplicableFields.test.ts
+++ b/src/features/transforms/fields/__tests__/getApplicableFields.test.ts
@@ -1,5 +1,3 @@
-import { Transform } from 'stream';
-
 import { describe, expect, it } from 'vitest';
 
 import { getFullyInstantiatedMockedObjects } from '@features/__tests__/MockObjects';
@@ -12,6 +10,7 @@ import {
   UNINTERESTING_FIELD_COMBINATIONS,
 } from '@features/transforms/fields/FieldApplicability';
 import getField from '@features/transforms/fields/getField';
+import TransformEnum from '@features/transforms/TransformEnum';
 
 describe('getApplicableFields', () => {
   it('should not return duplicate Fields values for any ObjectType', () => {
@@ -50,7 +49,7 @@ describe('getApplicableFields', () => {
 
   it('getApplicableFields matches isFieldApplicable', () => {
     Object.values(ObjectType).forEach((objectType) => {
-      Object.values(Transform).forEach((transform) => {
+      Object.values(TransformEnum).forEach((transform) => {
         const applicableFields = getApplicableFields(transform, objectType);
 
         Object.values(Field).forEach((field) => {

--- a/src/features/transforms/fields/getField.ts
+++ b/src/features/transforms/fields/getField.ts
@@ -1,5 +1,6 @@
 import { ObjectType } from '@features/params/PageParamTypes';
 
+import { getRootLanguageFamilyForEntity } from '@entities/language/LanguageFamilyUtils';
 import {
   getCountOfCensuses,
   getCountOfLanguages,
@@ -112,7 +113,7 @@ function getField(object: ObjectData, field: Field): string | number | undefined
     case Field.Language:
       return getObjectMostImportantLanguageName(object);
     case Field.LanguageFamily:
-      return undefined; // Not yet defined
+      return getRootLanguageFamilyForEntity(object)?.nameDisplay;
     case Field.WritingSystem:
       return getWritingSystemsInObject(object)?.[0]?.nameDisplay;
     case Field.OutputScript:

--- a/src/features/transforms/sorting/__tests__/sortMocks.test.tsx
+++ b/src/features/transforms/sorting/__tests__/sortMocks.test.tsx
@@ -694,4 +694,35 @@ describe('getSortByParameterized', () => {
       'tolkorth',
     ]);
   });
+
+  it('sortBy: Language Family', () => {
+    const objects = Object.values(mockedObjects) as ObjectData[];
+    const sort = getSortFunctionParameterized(Field.LanguageFamily, SortBehavior.Normal);
+    expect(objects.sort(sort).map((obj) => obj.ID)).toEqual([
+      // Sindarin is the root language for the 2 languages and their locales
+      'sjn',
+      'dori0123',
+      'sjn_BE',
+      'sjn_ER',
+      'dori0123_ER',
+      'sjn_Teng_BE',
+      'sjn_123',
+      'sjn_Teng_123',
+      'dori0123_123',
+      'sjn_001',
+      'sjn_Teng_001',
+      'dori0123_001',
+
+      // Other objects don't have a language family, stable to input order
+      '123',
+      'BE',
+      'ER',
+      'HA',
+      'AM',
+      '001',
+      'be0590',
+      'Teng',
+      'tolkorth',
+    ]);
+  });
 });

--- a/src/widgets/tables/TableOfLanguagesInCensus.tsx
+++ b/src/widgets/tables/TableOfLanguagesInCensus.tsx
@@ -173,6 +173,7 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
               loc.language && (
                 <HoverableObjectName object={getLanguageRootLanguageFamily(loc.language)} />
               ),
+            field: Field.LanguageFamily,
             isInitiallyVisible: false,
           },
           {

--- a/src/widgets/tables/columns/LanguageColumns.tsx
+++ b/src/widgets/tables/columns/LanguageColumns.tsx
@@ -92,6 +92,7 @@ function getLanguageColumns(): TableColumn<LanguageData>[] {
       key: 'Language Family',
       render: (lang) => <HoverableObjectName object={getLanguageRootLanguageFamily(lang)} />,
       isInitiallyVisible: false,
+      field: Field.LanguageFamily,
       columnGroup: 'Relations',
     },
     {


### PR DESCRIPTION
This adds information so we can sort languages and locales by their language family.

Fixes #514

### Changes

- User experience
  - Not much has changed, but you can sort by language family in the Language and Locale tables (also the languages in census table)
- Logical changes
  - n/a
- Data
  - While doing this I realized we had an incorrect endonym for Egyptian Arabic
- Refactors
  - n/a

Out of scope/Future work: Language family filter will come up next.

### Test Plan and Screenshots

How to test the changes in this PR: Added tests but also see for yourself in the UI https://translation-commons.github.io/lang-nav/data?view=Table&columns=1-1z144sjl&sortBy=Language+Family

| Page/View with link | Description of Changes | Screenshot Before | Screenshot After |
| ------------------- | ---------------------- | ----------------- | ---------------- |
|Language table|New sorting button available|<img width="987" height="525" alt="Screenshot 2026-04-24 at 20 44 15" src="https://github.com/user-attachments/assets/2c19a34d-077e-4c24-9069-0a72f3f991f1" />|<img width="1001" height="428" alt="Screenshot 2026-04-24 at 20 36 11" src="https://github.com/user-attachments/assets/b62f6e7c-a183-4e10-aee8-86ef1a65b804" />|
|Language table sorted by language family|Now it is possible to sort by the language family name|Not possible|<img width="981" height="466" alt="Screenshot 2026-04-24 at 20 36 25" src="https://github.com/user-attachments/assets/e636b553-a4a1-42d0-a1ef-3d03fab7d0ae" />|



