### PR TITLE
Territory Table Fixes

### DIFF
--- a/src/entities/lib/getObjectRelatedTerritories.ts
+++ b/src/entities/lib/getObjectRelatedTerritories.ts
@@ -14,7 +14,7 @@ import { getObjectParents } from '@widgets/pathnav/getParentsAndDescendants';
 import { ObjectType } from '@features/params/PageParamTypes';
 import { sortByPopulation } from '@features/transforms/sorting/sort';
 
-import { LanguageData } from '@entities/language/LanguageTypes';
+import { LanguageData, LanguageScope } from '@entities/language/LanguageTypes';
 import { LocaleData } from '@entities/locale/LocaleTypes';
 import {
   isTerritoryGroup,
@@ -75,8 +75,16 @@ export function getContainingTerritories(object: ObjectData): TerritoryData[] {
   }
 }
 
-export function getTerritoryBiggestLocale(territory: TerritoryData): LocaleData | undefined {
-  return (territory?.locales || []).sort(sortByPopulation)[0];
+/**
+ * By default only returns languages
+ */
+export function getTerritoryBiggestLocale(
+  territory: TerritoryData,
+  scopes: (LanguageScope | undefined)[] = [LanguageScope.Language],
+): LocaleData | undefined {
+  return (territory?.locales || [])
+    .filter((l) => !scopes || scopes?.includes(l.language?.scope))
+    .sort(sortByPopulation)[0];
 }
 
 export function getTerritoryChildren(territory: TerritoryData): TerritoryData[] {

--- a/src/features/__tests__/MockObjects.tsx
+++ b/src/features/__tests__/MockObjects.tsx
@@ -14,6 +14,7 @@ import { LanguageModality } from '@entities/language/LanguageModality';
 import {
   getBaseLanguageData,
   LanguageData,
+  LanguageScope,
   LanguageSource,
 } from '@entities/language/LanguageTypes';
 import { LocaleData, LocaleSource } from '@entities/locale/LocaleTypes';
@@ -30,6 +31,7 @@ export function getDisconnectedMockedObjects(): ObjectDictionary {
     ...getBaseLanguageData('sjn', 'Sindarin'), // sjn
     nameEndonym: 'sɪndarɪn', // using IPA because Tengwar letters aren't usually supported
     names: ['Sindarin', 'sɪndarɪn', '', 'Elvish', 'Elven Tongue', 'Edhellen'],
+    scope: LanguageScope.Language,
     populationEstimate: 14400,
     populationRough: 24000,
     primaryScriptCode: 'Teng',
@@ -41,6 +43,7 @@ export function getDisconnectedMockedObjects(): ObjectDictionary {
     ...getBaseLanguageData('dori0123', 'Doriathrin'), // dori0123
     nameEndonym: 'dorjaθɪn', // using IPA because Tengwar letters aren't usually supported
     names: ['Central Sindarin', 'Doriathrin', '', 'dorjaθɪn'],
+    scope: LanguageScope.Dialect,
     populationEstimate: 2500,
     populationRough: 2500,
     primaryScriptCode: 'Teng',

--- a/src/widgets/tables/TableOfLanguagesInTerritory.tsx
+++ b/src/widgets/tables/TableOfLanguagesInTerritory.tsx
@@ -35,7 +35,7 @@ const TableOfLanguagesInTerritory: React.FC<Props> = ({ territory }) => {
   const hasECRMLData = locales.some((locale) => locale.ecrmlProtection != null);
 
   return (
-    <LocalParamsProvider overrides={{ territoryScopes: [territory.scope] }}>
+    <LocalParamsProvider overrides={{ territoryScopes: [territory.scope], page: 1, limit: 10 }}>
       <InteractiveObjectTable<LocaleData>
         tableID={TableID.LanguagesInTerritory}
         objects={locales}

--- a/src/widgets/tables/columns/TerritoryColumns.tsx
+++ b/src/widgets/tables/columns/TerritoryColumns.tsx
@@ -86,11 +86,7 @@ function getTerritoryColumns(): TableColumn<TerritoryData>[] {
       render: (object) =>
         object.locales &&
         object.locales.length > 0 && (
-          <HoverableObjectName
-            labelSource="language"
-            object={getTerritoryBiggestLocale(object)}
-            style={{ textDecoration: 'none' }}
-          />
+          <HoverableObjectName labelSource="language" object={getTerritoryBiggestLocale(object)} />
         ),
       isInitiallyVisible: false,
       field: Field.Language,
@@ -98,7 +94,7 @@ function getTerritoryColumns(): TableColumn<TerritoryData>[] {
     },
     {
       key: 'Biggest Language %',
-      render: (object) => object.locales?.[0].populationSpeakingPercent,
+      render: (object) => getTerritoryBiggestLocale(object)?.populationSpeakingPercent,
       isInitiallyVisible: false,
       field: Field.PopulationPercentInBiggestDescendantLanguage,
       columnGroup: 'Language',
@@ -115,7 +111,7 @@ function getTerritoryColumns(): TableColumn<TerritoryData>[] {
     },
     {
       key: 'Contained UN Region',
-      render: (object) => object.parentUNRegion?.nameDisplay,
+      render: (object) => <HoverableObjectName object={object.parentUNRegion} />,
       isInitiallyVisible: false,
       field: Field.Region,
       columnGroup: 'Relations',


### PR DESCRIPTION
While I was showing the territory table in the lang-nav meeting I realized there were a few problems with the territory table view. This PR addresses them.

Fixes #615 

### Changes

- User experience
  - Most are changes in the Territory Table
    - Biggest language column filters to only show languages (not language families)
    - Biggest language % fixed too (and no longer just takes the first locale)
    - Parent UN
  - Language table in territory details now starts on page 1 by default (rather than inheriting the global page, so if you open a territory on page 2 the table inside this doesn't also start on page 2. 
- Logical changes
  - Added language scope option to `getTerritoryBiggestLocale`
- Data
  - n/a
- Refactors
  - n/a

Out of scope/Future work: Improvements to the table interface, territory details updates

### Test Plan and Screenshots

How to test the changes in this PR: Localhost link: http://localhost:5173/lang-nav/data?objectType=Territory&objectID=CD&view=Table&columns=3-8p9

| Page/View with link | Description of Changes | Screenshot Before | Screenshot After |
| ------------------- | ---------------------- | ----------------- | ---------------- |
|Territory table|The languages are different and now the parent. regions are blue (hoverable)|<img width="914" height="517" alt="Screenshot 2026-04-28 at 13 46 23" src="https://github.com/user-attachments/assets/afcc12f7-4f59-4336-8ad8-5191bb9b3874" />|<img width="774" height="419" alt="Screenshot 2026-04-28 at 10 51 50" src="https://github.com/user-attachments/assets/8ccb77e9-52c2-4bd5-8534-d36a29505ace" />

