### PR TITLE
Language Families: Estimate coordinates

### DIFF
--- a/public/data/tc/glottocodeToISO.tsv
+++ b/public/data/tc/glottocodeToISO.tsv
@@ -131,3 +131,6 @@ sout2711	ggo	Southern Gondi
 belg1242	bvs	Belgian Sign Language
 arak1255	mhv	Arakanese-Marma
 pale1264	plm	Palembang
+cent2329	est	Estonian
+gbay1279	gba	Gbaya
+nort3241	syr	Syriac

--- a/src/features/data/compute/computeRecursiveLanguageData.ts
+++ b/src/features/data/compute/computeRecursiveLanguageData.ts
@@ -1,6 +1,7 @@
 import { LanguageData } from '@entities/language/LanguageTypes';
 import { getVitalityMetascore } from '@entities/language/vitality/LanguageVitalityComputation';
 
+import averageCoordinates from '@shared/lib/averageCoordinates';
 import { maxBy } from '@shared/lib/setUtils';
 
 /**
@@ -53,6 +54,25 @@ function computeRecursiveDataOnLanguage(lang: LanguageData, depth = 0): void {
   // Compute the meta score and store the results in the language object
   vitality.meta = getVitalityMetascore(lang);
   lang.vitality = vitality;
+
+  // Compute the lat/long coordinates
+  computeCoordinates(lang);
+}
+
+/**
+ * Compute the coordinates for a region based on the coordinates of the contained territories.
+ *
+ * Similar to computeRegionCoordinates used for territory groups
+ *
+ * Coordinates are weighted by the fourth root of the population
+ */
+function computeCoordinates(lang: LanguageData): void {
+  if (lang.latitude != null && lang.longitude != null) return; // Don't override if coordinates already exist
+  const children = lang.childLanguages ?? [];
+  if (children.length === 0) return;
+  const { latitude, longitude } = averageCoordinates(children);
+  lang.latitude = latitude;
+  lang.longitude = longitude;
 }
 
 export default computeRecursiveLanguageData;

--- a/src/features/data/compute/computeTerritoryStats.ts
+++ b/src/features/data/compute/computeTerritoryStats.ts
@@ -48,16 +48,4 @@ function computeRegionCoordinates(terr: TerritoryData): void {
   const { latitude, longitude } = averageCoordinates(terr.containsTerritories ?? []);
   terr.latitude = latitude;
   terr.longitude = longitude;
-
-  // const denominator = sumBy(containsTerritories, (t) => (t.landArea ?? 1) ** 0.25);
-  // const latitude = sumBy(containsTerritories, (t) => (t.latitude ?? 0) * (t.landArea ?? 1) ** 0.25);
-  // const longitude = sumBy(containsTerritories, (t) => {
-  //   // Handle wrap-around at the international date line
-  //   if (t.longitude != null && t.longitude < -120)
-  //     return (t.longitude + 360) * (t.landArea ?? 1) ** 0.25;
-
-  //   return (t.longitude ?? 0) * (t.landArea ?? 1) ** 0.25;
-  // });
-  // terr.latitude = latitude / denominator;
-  // terr.longitude = (longitude > 180 ? -360 + longitude : longitude) / denominator;
 }

--- a/src/features/data/compute/computeTerritoryStats.ts
+++ b/src/features/data/compute/computeTerritoryStats.ts
@@ -1,5 +1,6 @@
 import { isTerritoryGroup, TerritoryData } from '@entities/territory/TerritoryTypes';
 
+import averageCoordinates from '@shared/lib/averageCoordinates';
 import { sumBy } from '@shared/lib/setUtils';
 
 export function computeContainedTerritoryStats(terr: TerritoryData | undefined): void {
@@ -44,17 +45,19 @@ function computeRegionCoordinates(terr: TerritoryData): void {
     return;
   }
 
-  const containsTerritories = terr.containsTerritories ?? [];
+  const { latitude, longitude } = averageCoordinates(terr.containsTerritories ?? []);
+  terr.latitude = latitude;
+  terr.longitude = longitude;
 
-  const denominator = sumBy(containsTerritories, (t) => (t.landArea ?? 1) ** 0.25);
-  const latitude = sumBy(containsTerritories, (t) => (t.latitude ?? 0) * (t.landArea ?? 1) ** 0.25);
-  const longitude = sumBy(containsTerritories, (t) => {
-    // Handle wrap-around at the international date line
-    if (t.longitude != null && t.longitude < -120)
-      return (t.longitude + 360) * (t.landArea ?? 1) ** 0.25;
+  // const denominator = sumBy(containsTerritories, (t) => (t.landArea ?? 1) ** 0.25);
+  // const latitude = sumBy(containsTerritories, (t) => (t.latitude ?? 0) * (t.landArea ?? 1) ** 0.25);
+  // const longitude = sumBy(containsTerritories, (t) => {
+  //   // Handle wrap-around at the international date line
+  //   if (t.longitude != null && t.longitude < -120)
+  //     return (t.longitude + 360) * (t.landArea ?? 1) ** 0.25;
 
-    return (t.longitude ?? 0) * (t.landArea ?? 1) ** 0.25;
-  });
-  terr.latitude = latitude / denominator;
-  terr.longitude = (longitude > 180 ? -360 + longitude : longitude) / denominator;
+  //   return (t.longitude ?? 0) * (t.landArea ?? 1) ** 0.25;
+  // });
+  // terr.latitude = latitude / denominator;
+  // terr.longitude = (longitude > 180 ? -360 + longitude : longitude) / denominator;
 }

--- a/src/features/layers/hovercard/HoverCardProvider.tsx
+++ b/src/features/layers/hovercard/HoverCardProvider.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import ZIndex from '../ZIndex';
 
@@ -24,20 +24,20 @@ const HoverCardProvider: React.FC<{ children: React.ReactNode; zIndex?: number }
   });
   const [leftTriggeringElement, setLeftTriggeringElement] = useState<boolean>(false);
 
-  const showHoverCard = (content: React.ReactNode, x: number, y: number) => {
+  const showHoverCard = useCallback((content: React.ReactNode, x: number, y: number) => {
     setLeftTriggeringElement(false);
     setHoverCard({ content, x, y, visible: true });
-  };
+  }, []);
 
-  const hideHoverCard = () => {
+  const hideHoverCard = useCallback(() => {
     setHoverCard((prev) => ({ ...prev, visible: false }));
-  };
+  }, []);
 
   const cardRef = useRef<HTMLDivElement>(null);
 
-  const onMouseLeaveTriggeringElement = () => {
+  const onMouseLeaveTriggeringElement = useCallback(() => {
     setLeftTriggeringElement(true);
-  };
+  }, []);
 
   // Listen for mouse movements, if the hovercard is visible and the mouse moves too far away from it, hide it
   useEffect(() => {
@@ -84,10 +84,14 @@ const HoverCardProvider: React.FC<{ children: React.ReactNode; zIndex?: number }
     }
   }, [hoverCard.x, hoverCard.y, hoverCard.visible]);
 
+  // Memoize the context value to prevent unnecessary re-renders of consumers
+  const context = useMemo(
+    () => ({ showHoverCard, hideHoverCard, onMouseLeaveTriggeringElement }),
+    [showHoverCard, hideHoverCard, onMouseLeaveTriggeringElement],
+  );
+
   return (
-    <HoverCardContext.Provider
-      value={{ showHoverCard, hideHoverCard, onMouseLeaveTriggeringElement }}
-    >
+    <HoverCardContext.Provider value={context}>
       {children}
       <EmptyHoverCardProvider>
         {/** Prevent hovercard propagation */}

--- a/src/features/map/MapCentroids.tsx
+++ b/src/features/map/MapCentroids.tsx
@@ -6,7 +6,7 @@ import { ObjectType } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 import { ColoringFunctions } from '@features/transforms/coloring/useColors';
 import Field from '@features/transforms/fields/Field';
-import ObjectFieldDisplay from '@features/transforms/fields/ObjectFieldDisplay';
+import { getFieldString } from '@features/transforms/fields/getFieldString';
 import useScale from '@features/transforms/scales/useScale';
 
 import DrawableData from './DrawableData';
@@ -22,7 +22,7 @@ type Props = {
   coloringFunctions: ColoringFunctions;
 };
 
-const MapCircles: React.FC<Props> = ({
+const MapCentroids: React.FC<Props> = ({
   drawableObjects,
   getHoverContent,
   scalar,
@@ -67,7 +67,7 @@ const MapCircles: React.FC<Props> = ({
       }}
     >
       {renderableObjects.map((obj) => (
-        <ObjectPoint
+        <ObjectNode
           key={obj.ID}
           color={colorBy === 'None' ? undefined : (getColor(obj) ?? 'transparent')}
           object={obj}
@@ -80,20 +80,14 @@ const MapCircles: React.FC<Props> = ({
   );
 };
 
-type PointProps = {
+type NodeProps = {
   color?: string;
   object: DrawableData;
   scale: number;
   onMouseEnter: (e: React.MouseEvent) => void;
   onMouseLeave: () => void;
 };
-const ObjectPoint: React.FC<PointProps> = ({
-  object,
-  color,
-  scale,
-  onMouseEnter,
-  onMouseLeave,
-}) => {
+const ObjectNode: React.FC<NodeProps> = ({ object, color, scale, onMouseEnter, onMouseLeave }) => {
   if (object.type !== ObjectType.Language && object.type !== ObjectType.Territory) return null;
   if (object.latitude == null || object.longitude == null) return null;
 
@@ -106,7 +100,7 @@ const ObjectPoint: React.FC<PointProps> = ({
 
   return (
     // ideally x would range -180 to 180 but it appears in practice our SVG is a bit thinner, so 178.5 looks better
-    <g style={{ transform: `translate(${x * 178.5}px, ${y * -90}px)` }}>
+    <g transform={`translate(${x * 178.5}, ${y * -90})`}>
       {showCircle && (
         <Circle
           color={color}
@@ -121,7 +115,7 @@ const ObjectPoint: React.FC<PointProps> = ({
   );
 };
 
-const Circle: React.FC<PointProps> = ({ color, object, scale, onMouseEnter, onMouseLeave }) => {
+const Circle: React.FC<NodeProps> = ({ color, object, scale, onMouseEnter, onMouseLeave }) => {
   const { updatePageParams } = usePageParams();
   return (
     <circle
@@ -146,10 +140,9 @@ const Text: React.FC<TextProps> = ({ object, scale, showCircle }) => {
       textAnchor="middle"
       alignmentBaseline={showCircle ? 'hanging' : 'middle'}
     >
-      {/* Some of these may not render if they are React components and not primitives */}
-      <ObjectFieldDisplay object={object} field={fieldFocus} />
+      {getFieldString(object, fieldFocus)}
     </text>
   );
 };
 
-export default MapCircles;
+export default MapCentroids;

--- a/src/features/map/MapCircles.tsx
+++ b/src/features/map/MapCircles.tsx
@@ -1,15 +1,19 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import useHoverCard from '@features/layers/hovercard/useHoverCard';
 import usePagination from '@features/pagination/usePagination';
 import { ObjectType } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 import { ColoringFunctions } from '@features/transforms/coloring/useColors';
+import Field from '@features/transforms/fields/Field';
+import ObjectFieldDisplay from '@features/transforms/fields/ObjectFieldDisplay';
 import useScale from '@features/transforms/scales/useScale';
 
 import DrawableData from './DrawableData';
 import { getRobinsonCoordinates } from './getRobinsonCoordinates';
 import { MAP_ASPECT_RATIO } from './MapConsts';
+
+import './map.css';
 
 type Props = {
   drawableObjects: DrawableData[];
@@ -34,14 +38,12 @@ const MapCircles: React.FC<Props> = ({
     const currentObjects =
       objectType === ObjectType.Language ? getCurrentObjects(drawableObjects) : drawableObjects;
     const filteredObjects = currentObjects.filter(
-      (obj) =>
-        obj.type === ObjectType.Language ||
-        (obj.type === ObjectType.Territory && (obj.landArea ?? 0) < 20000),
+      (obj) => obj.type === ObjectType.Language || obj.type === ObjectType.Territory,
     );
 
     // Reverse so the "first" objects are drawn on top.
     return filteredObjects.reverse();
-  }, [drawableObjects, getCurrentObjects]);
+  }, [drawableObjects, getCurrentObjects, objectType]);
 
   const buildOnMouseEnter = useCallback(
     (obj: DrawableData) => (e: React.MouseEvent) => {
@@ -49,6 +51,7 @@ const MapCircles: React.FC<Props> = ({
     },
     [showHoverCard, getHoverContent],
   );
+  console.log('rendering map circles');
 
   return (
     <svg
@@ -65,7 +68,7 @@ const MapCircles: React.FC<Props> = ({
       }}
     >
       {renderableObjects.map((obj) => (
-        <HoverableCircle
+        <ObjectPoint
           key={obj.ID}
           color={colorBy === 'None' ? undefined : (getColor(obj) ?? 'transparent')}
           object={obj}
@@ -78,46 +81,76 @@ const MapCircles: React.FC<Props> = ({
   );
 };
 
-const HoverableCircle: React.FC<{
+type PointProps = {
   color?: string;
   object: DrawableData;
   scale: number;
   onMouseEnter: (e: React.MouseEvent) => void;
   onMouseLeave: () => void;
-}> = ({ object, color, scale, onMouseEnter, onMouseLeave }) => {
-  const { updatePageParams } = usePageParams();
-  const [isActive, setIsActive] = useState(false);
+};
+const ObjectPoint: React.FC<PointProps> = ({
+  object,
+  color,
+  scale,
+  onMouseEnter,
+  onMouseLeave,
+}) => {
   if (object.type !== ObjectType.Language && object.type !== ObjectType.Territory) return null;
-  if (object.latitude == null || object.longitude == null) {
-    return null;
-  }
+  if (object.latitude == null || object.longitude == null) return null;
+  // console.log('point');
 
   const { x, y } = getRobinsonCoordinates(
     object.latitude,
     // The map is 12 degrees rotated to preserve land borders
     (object.longitude < -168 ? object.longitude + 360 : object.longitude) - 12,
   );
+  const showCircle = !(object.type === ObjectType.Territory && (object?.landArea || 0) >= 20000);
 
   return (
+    <g style={{ transform: `translate(${x * 180}px, ${y * -90}px)` }}>
+      {showCircle && (
+        <Circle
+          color={color}
+          object={object}
+          scale={scale}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+        />
+      )}
+      <Text object={object} scale={scale} showCircle={showCircle} />
+    </g>
+  );
+};
+
+const Circle: React.FC<PointProps> = ({ color, object, scale, onMouseEnter, onMouseLeave }) => {
+  const { updatePageParams } = usePageParams();
+  // console.log('circle');
+  return (
     <circle
-      cx={x * 180}
-      cy={-y * 90}
       r={scale + 1}
-      fill={color ?? (isActive ? 'var(--color-button-primary)' : 'transparent')}
+      fill={color ?? 'transparent'}
       stroke={color == null ? 'var(--color-button-primary)' : 'transparent'}
-      style={{ transition: 'fill 0.25s, stroke 0.25s', pointerEvents: 'fill', cursor: 'pointer' }}
-      className="object-map-circle"
-      strokeWidth="1px"
       onClick={() => updatePageParams({ objectID: object.ID })}
-      onMouseEnter={(e: React.MouseEvent) => {
-        onMouseEnter(e);
-        setIsActive(true);
-      }}
-      onMouseLeave={() => {
-        onMouseLeave();
-        setIsActive(false);
-      }}
+      onMouseEnter={(e: React.MouseEvent) => onMouseEnter(e)}
+      onMouseLeave={() => onMouseLeave()}
     />
+  );
+};
+
+type TextProps = { object: DrawableData; scale: number; showCircle: boolean };
+const Text: React.FC<TextProps> = ({ object, scale, showCircle }) => {
+  const { fieldFocus } = usePageParams();
+  if (fieldFocus === Field.None) return null;
+  return (
+    <text
+      y={showCircle ? 2 : 0}
+      fontSize={scale / 4 + 'em'}
+      textAnchor="middle"
+      alignmentBaseline={showCircle ? 'hanging' : 'middle'}
+    >
+      {/* Some of these may not render if they are React components and not primitives */}
+      <ObjectFieldDisplay object={object} field={fieldFocus} />
+    </text>
   );
 };
 

--- a/src/features/map/MapCircles.tsx
+++ b/src/features/map/MapCircles.tsx
@@ -51,7 +51,6 @@ const MapCircles: React.FC<Props> = ({
     },
     [showHoverCard, getHoverContent],
   );
-  console.log('rendering map circles');
 
   return (
     <svg
@@ -97,17 +96,17 @@ const ObjectPoint: React.FC<PointProps> = ({
 }) => {
   if (object.type !== ObjectType.Language && object.type !== ObjectType.Territory) return null;
   if (object.latitude == null || object.longitude == null) return null;
-  // console.log('point');
 
   const { x, y } = getRobinsonCoordinates(
     object.latitude,
-    // The map is 12 degrees rotated to preserve land borders
-    (object.longitude < -168 ? object.longitude + 360 : object.longitude) - 12,
+    // The map is 11 degrees rotated to preserve land borders
+    (object.longitude < -169 ? object.longitude + 360 : object.longitude) - 11,
   );
   const showCircle = !(object.type === ObjectType.Territory && (object?.landArea || 0) >= 20000);
 
   return (
-    <g style={{ transform: `translate(${x * 180}px, ${y * -90}px)` }}>
+    // ideally x would range -180 to 180 but it appears in practice our SVG is a bit thinner, so 178.5 looks better
+    <g style={{ transform: `translate(${x * 178.5}px, ${y * -90}px)` }}>
       {showCircle && (
         <Circle
           color={color}
@@ -124,7 +123,6 @@ const ObjectPoint: React.FC<PointProps> = ({
 
 const Circle: React.FC<PointProps> = ({ color, object, scale, onMouseEnter, onMouseLeave }) => {
   const { updatePageParams } = usePageParams();
-  // console.log('circle');
   return (
     <circle
       r={scale + 1}

--- a/src/features/map/ObjectMap.tsx
+++ b/src/features/map/ObjectMap.tsx
@@ -14,7 +14,7 @@ import { ObjectData } from '@entities/types/DataTypes';
 import { uniqueBy } from '@shared/lib/setUtils';
 
 import DrawableData from './DrawableData';
-import MapCircles from './MapCircles';
+import MapCentroids from './MapCentroids';
 import { MAP_ASPECT_RATIO, MAP_INTERNAL_WIDTH } from './MapConsts';
 import MapHoverContent from './MapHoverContent';
 import MapTerritories from './MapTerritories';
@@ -99,7 +99,7 @@ const ObjectMap: React.FC<Props> = ({ objects, maxWidth = 2000 }) => {
               coloringFunctions={coloringFunctions}
             />
           )}
-          <MapCircles
+          <MapCentroids
             drawableObjects={drawableObjects}
             getHoverContent={getHoverContent}
             scalar={1200 / maxWidth}

--- a/src/features/map/map.css
+++ b/src/features/map/map.css
@@ -1,10 +1,12 @@
 circle {
-    transition: fill 0.25s, stroke 0.25s;
-    pointer-events: fill;
-    cursor: pointer;
-    stroke-width: 1px;
+  transition:
+    fill 0.25s,
+    stroke 0.25s;
+  pointer-events: fill;
+  cursor: pointer;
+  stroke-width: 1px;
 }
 
 circle:hover {
-    fill: var(--color-button-primary)
+  fill: var(--color-button-primary);
 }

--- a/src/features/map/map.css
+++ b/src/features/map/map.css
@@ -1,0 +1,10 @@
+circle {
+    transition: fill 0.25s, stroke 0.25s;
+    pointer-events: fill;
+    cursor: pointer;
+    stroke-width: 1px;
+}
+
+circle:hover {
+    fill: var(--color-button-primary)
+}

--- a/src/features/transforms/fields/FieldApplicability.ts
+++ b/src/features/transforms/fields/FieldApplicability.ts
@@ -20,7 +20,6 @@ export const FIELDS_IN_DEVELOPMENT: Field[] = [
   Field.CLDRCoverage,
   Field.DigitalSupport,
   Field.WritingSystemScope,
-  Field.Coordinates,
 ];
 
 /**

--- a/src/features/transforms/fields/FieldApplicability.ts
+++ b/src/features/transforms/fields/FieldApplicability.ts
@@ -268,7 +268,7 @@ function getFieldsForTransform(transform: Transform): Field[] {
   switch (transform) {
     case Transform.Sort:
       // Easier to list fields that aren't sortable than to list all that are, since most are
-      return Object.values(Field).filter((f) => ![Field.None].includes(f));
+      return Object.values(Field).filter((f) => ![Field.None, Field.Coordinates].includes(f));
     case Transform.Color:
       // Ordered by preferred UI grouping: quantitative first, then text fields
       return [

--- a/src/features/transforms/fields/FieldFocusSelector.tsx
+++ b/src/features/transforms/fields/FieldFocusSelector.tsx
@@ -11,7 +11,7 @@ const FieldFocusSelector: React.FC = () => {
   const { fieldFocus, updatePageParams, view, objectType } = usePageParams();
 
   // Only applies to the TreeList view for now, but could be expanded to other views in the future
-  if (view !== View.Hierarchy) return null;
+  if (view !== View.Hierarchy && view !== View.Map) return null;
 
   return (
     <Selector<Field>

--- a/src/features/transforms/fields/ObjectFieldDisplay.tsx
+++ b/src/features/transforms/fields/ObjectFieldDisplay.tsx
@@ -42,9 +42,17 @@ const ObjectFieldDisplay: React.FC<Props> = ({ object, field }) => {
     case Field.Literacy:
     case Field.PercentOfOverallLanguageSpeakers:
     case Field.PercentOfTerritoryPopulation:
+      if (typeof fieldValue === 'number') return <DecimalNumber num={fieldValue} />;
+      return <>{fieldValue}</>;
+
     case Field.Longitude:
     case Field.Latitude:
-      if (typeof fieldValue === 'number') return <DecimalNumber num={fieldValue} />;
+      if (typeof fieldValue === 'number') return fieldValue.toFixed(2);
+      return <>{fieldValue}</>;
+    case Field.Coordinates:
+      if (object.type === ObjectType.Territory || object.type === ObjectType.Language) {
+        return `${object.latitude?.toFixed(1)}, ${object.longitude?.toFixed(1)}`;
+      }
       return <>{fieldValue}</>;
 
     case Field.CountOfLanguages:
@@ -117,7 +125,6 @@ const ObjectFieldDisplay: React.FC<Props> = ({ object, field }) => {
     case Field.DigitalSupport:
     case Field.SourceType:
     case Field.WritingSystemScope:
-    case Field.Coordinates:
     case Field.GovernmentStatus:
     case Field.ECRMLProtection:
     case Field.None:

--- a/src/features/transforms/fields/ObjectFieldDisplay.tsx
+++ b/src/features/transforms/fields/ObjectFieldDisplay.tsx
@@ -47,7 +47,7 @@ const ObjectFieldDisplay: React.FC<Props> = ({ object, field }) => {
 
     case Field.Longitude:
     case Field.Latitude:
-      if (typeof fieldValue === 'number') return fieldValue.toFixed(2);
+      if (typeof fieldValue === 'number') return fieldValue.toFixed(1);
       return <>{fieldValue}</>;
     case Field.Coordinates:
       if (object.type === ObjectType.Territory || object.type === ObjectType.Language) {

--- a/src/features/transforms/fields/getField.ts
+++ b/src/features/transforms/fields/getField.ts
@@ -58,8 +58,12 @@ function getField(object: ObjectData, field: Field): string | number | undefined
     case Field.Literacy:
       return getObjectLiteracy(object);
 
-    case Field.Coordinates:
-      return undefined; // Poorly defined as a single value since its a 2D value
+    case Field.Coordinates: // Not for sorting, only for display
+      return (object.type === ObjectType.Language || object.type === ObjectType.Territory) &&
+        object.latitude != null &&
+        object.longitude != null
+        ? object.latitude?.toFixed(1) + ', ' + object.longitude?.toFixed(1)
+        : undefined;
     case Field.Latitude:
       return object.type === ObjectType.Language || object.type === ObjectType.Territory
         ? object.latitude

--- a/src/features/transforms/fields/getFieldString.ts
+++ b/src/features/transforms/fields/getFieldString.ts
@@ -1,0 +1,58 @@
+import { getFieldValueType } from '@features/table/getValueType';
+import TableValueType from '@features/table/TableValueType';
+
+import { LanguageModality } from '@entities/language/LanguageModality';
+import { getModalityLabel } from '@entities/language/LanguageModalityDisplay';
+import { LanguageScope } from '@entities/language/LanguageTypes';
+import { getLanguageISOStatusLabel } from '@entities/language/vitality/VitalityStrings';
+import { LanguageISOStatus } from '@entities/language/vitality/VitalityTypes';
+import { TerritoryScope } from '@entities/territory/TerritoryTypes';
+import { ObjectData } from '@entities/types/DataTypes';
+
+import { getLanguageScopeLabel } from '@strings/LanguageScopeStrings';
+import { getTerritoryScopeLabel } from '@strings/TerritoryScopeStrings';
+
+import Field from './Field';
+import getField from './getField';
+
+/**
+ * Converts numbers to reasonably formatted strings.
+ *
+ * Converts enum values to their corresponding labels.
+ */
+export function getFieldString(object: ObjectData, field: Field): string | undefined {
+  const value = getField(object, field);
+  if (value == null) return value;
+  switch (getFieldValueType(field)) {
+    case TableValueType.Date:
+      if (typeof value === 'string') return value;
+      return value ? new Date(value).toLocaleDateString() : undefined;
+    case TableValueType.Population:
+    case TableValueType.Count:
+      if (typeof value === 'string') return value;
+      return value.toLocaleString();
+    case TableValueType.Decimal:
+      if (typeof value === 'string') return value;
+      return value.toFixed(1);
+    case TableValueType.Enum:
+      return getFieldEnumLabel(value, field);
+    case TableValueType.String:
+      return value.toString();
+  }
+}
+
+function getFieldEnumLabel(value: string | number | undefined, field: Field): string | undefined {
+  switch (field) {
+    case Field.ISOStatus:
+      return getLanguageISOStatusLabel(value as LanguageISOStatus);
+    case Field.LanguageScope:
+      return getLanguageScopeLabel(value as LanguageScope);
+    case Field.Modality:
+      return getModalityLabel(value as LanguageModality);
+    case Field.TerritoryScope:
+      return getTerritoryScopeLabel(value as TerritoryScope);
+    case Field.WritingSystemScope:
+    default:
+      return value?.toString();
+  }
+}

--- a/src/shared/hooks/useRenderCount.tsx
+++ b/src/shared/hooks/useRenderCount.tsx
@@ -1,0 +1,13 @@
+import { useRef } from 'react';
+
+/**
+ * A hook that logs to the console how many times a component has rendered. Useful for debugging unnecessary re-renders.
+ * Usage: call `useRenderCount('ComponentName')` in your component.
+ * Note: this is not meant to be used in production, only for debugging during development.
+ */
+export function useRenderCount(name: string) {
+  const count = useRef(0);
+  count.current += 1;
+
+  console.log(`${name} render #${count.current}`);
+}

--- a/src/shared/hooks/useWhyDidYouUpdate.tsx
+++ b/src/shared/hooks/useWhyDidYouUpdate.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ *  A hook that logs to the console when a component updates, and what values changed. Useful for debugging unnecessary re-renders.
+ *  Usage: call `useWhyDidYouUpdate('ComponentName', { prop1, prop2, ... })` in your component, passing in the props and state you want to track.
+ *  Note: this is not meant to be used in production, only for debugging during development.
+ */
+export function useWhyDidYouUpdate(name: string, values: Record<string, unknown>) {
+  const previousValues = useRef<Record<string, unknown> | null>(null);
+
+  useEffect(() => {
+    if (previousValues.current == null) {
+      previousValues.current = values;
+      return;
+    }
+
+    const changes: Record<string, { before: unknown; after: unknown }> = {};
+
+    const allKeys = new Set([...Object.keys(previousValues.current), ...Object.keys(values)]);
+
+    for (const key of allKeys) {
+      if (!Object.is(previousValues.current[key], values[key])) {
+        changes[key] = {
+          before: previousValues.current[key],
+          after: values[key],
+        };
+      }
+    }
+
+    if (Object.keys(changes).length > 0) {
+      console.group(`[why-did-you-update] ${name}`);
+      console.table(
+        Object.fromEntries(
+          Object.entries(changes).map(([key, value]) => [
+            key,
+            {
+              beforeType: typeof value.before,
+              afterType: typeof value.after,
+              sameReference: Object.is(value.before, value.after),
+            },
+          ]),
+        ),
+      );
+      console.log(changes);
+      console.groupEnd();
+    }
+
+    previousValues.current = values;
+  });
+}

--- a/src/shared/lib/__tests__/averageCoordinates.test.ts
+++ b/src/shared/lib/__tests__/averageCoordinates.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { getBaseLanguageData } from '@entities/language/LanguageTypes';
+
+import averageCoordinates from '../averageCoordinates';
+
+describe('averageCoordinates', () => {
+  function makeLanguage(lat: number, lng: number) {
+    const lang = getBaseLanguageData(lat + '-' + lng, '');
+    lang.populationEstimate = 1000; // population is needed for the averageCoordinates function to include the language in the average
+    lang.latitude = lat;
+    lang.longitude = lng;
+    return lang;
+  }
+
+  const l10_20 = makeLanguage(10, 20);
+  const l0_0 = makeLanguage(0, 0);
+  const l20_40 = makeLanguage(20, 40);
+  const lNeg10_Neg20 = makeLanguage(-10, -20);
+  const l1p5_2p5 = makeLanguage(1.5, 2.5);
+  const l2p5_3p5 = makeLanguage(2.5, 3.5);
+  const l10_170 = makeLanguage(10, 170);
+  const l10_Neg170 = makeLanguage(10, -170);
+
+  it('should return the average of a single coordinate', () => {
+    const result = averageCoordinates([l10_20]);
+    expect(result.latitude).toBe(10);
+    expect(result.longitude).toBe(20);
+  });
+
+  it('should return the average of multiple coordinates', () => {
+    const result = averageCoordinates([l0_0, l10_20, l20_40]);
+    expect(result.latitude).toBeCloseTo(10.407);
+    expect(result.longitude).toBeCloseTo(19.579);
+  });
+
+  it('should handle negative coordinates', () => {
+    const result = averageCoordinates([lNeg10_Neg20, l10_20]);
+    expect(result.latitude).toBeCloseTo(0);
+    expect(result.longitude).toBeCloseTo(0);
+  });
+
+  it('should handle decimal coordinates', () => {
+    const result = averageCoordinates([l1p5_2p5, l2p5_3p5]);
+    expect(result.latitude).toBeCloseTo(2);
+    expect(result.longitude).toBeCloseTo(3);
+  });
+
+  it('should return zero coordinates for empty array', () => {
+    const result = averageCoordinates([]);
+    expect(result.latitude).toBeUndefined();
+    expect(result.longitude).toBeUndefined();
+  });
+
+  it('when coordinates are on the opposite side of the world should average correctly', () => {
+    const result = averageCoordinates([l10_170, l10_Neg170]);
+    expect(result.latitude).toBeCloseTo(10.15); // Closest point on a sphere is not necessarily the midpoint of the latitudes
+    expect(result.longitude).toBeCloseTo(180);
+  });
+
+  it('weights coordinates by the population', () => {
+    const smaller = makeLanguage(0, -10);
+    smaller.populationEstimate = 1;
+
+    const larger = makeLanguage(0, 10);
+    larger.populationEstimate = 16;
+
+    const result = averageCoordinates([smaller, larger]);
+    // The average should be much closer to l20_40 than l10_20 because it has a much higher population
+    expect(result.latitude).toBeCloseTo(0);
+    expect(result.longitude).toBeCloseTo(3.36);
+  });
+});

--- a/src/shared/lib/averageCoordinates.ts
+++ b/src/shared/lib/averageCoordinates.ts
@@ -1,0 +1,57 @@
+import { ObjectType } from '@features/params/PageParamTypes';
+
+import { LanguageData } from '@entities/language/LanguageTypes';
+import { TerritoryData } from '@entities/territory/TerritoryTypes';
+
+import { sumBy } from './setUtils';
+
+/**
+ * Computes the average latitude and longitude of a set of languages or territories.
+ *
+ * Uses a 3D Cartesian coordinate system to account for the rounded shape of the planet,
+ * averages, then converts back to lat/long.
+ *
+ * Coordinates are weighted by the fourth root of the entity's population (for languages) or land area (for territories).
+ * Ignores any languages/territories without valid coordinates or population/land area data.
+ */
+function averageCoordinates(ents: (LanguageData | TerritoryData)[]) {
+  const validEnts = ents.filter(
+    (child) => child.latitude != null && child.longitude != null && getEntityWeight(child) > 0,
+  );
+  if (validEnts.length === 0) return { latitude: undefined, longitude: undefined };
+
+  const denominator = sumBy(validEnts, getEntityWeight);
+  const weighted3D = validEnts.map((ent) => getWeighted3DCoordinates(ent));
+  const weighted3DSum = {
+    x: sumBy(weighted3D, (coord) => coord.x) / denominator,
+    y: sumBy(weighted3D, (coord) => coord.y) / denominator,
+    z: sumBy(weighted3D, (coord) => coord.z) / denominator,
+  };
+  const hyp = Math.sqrt(weighted3DSum.x ** 2 + weighted3DSum.y ** 2);
+  const latitude = Math.atan2(weighted3DSum.z, hyp) * (180 / Math.PI);
+  const longitude = Math.atan2(weighted3DSum.y, weighted3DSum.x) * (180 / Math.PI);
+  return { latitude, longitude };
+}
+
+function getWeighted3DCoordinates(ent: LanguageData | TerritoryData): {
+  x: number;
+  y: number;
+  z: number;
+} {
+  const weight = getEntityWeight(ent);
+  const latRad = (ent.latitude! * Math.PI) / 180;
+  const longRad = (ent.longitude! * Math.PI) / 180;
+  return {
+    x: Math.cos(latRad) * Math.cos(longRad) * weight,
+    y: Math.cos(latRad) * Math.sin(longRad) * weight,
+    z: Math.sin(latRad) * weight,
+  };
+}
+
+function getEntityWeight(ent: LanguageData | TerritoryData): number {
+  if (ent.type === ObjectType.Language) return (ent.populationEstimate || 0) ** 0.25;
+  if (ent.type === ObjectType.Territory) return (ent.landArea || 0) ** 0.25;
+  return 1;
+}
+
+export default averageCoordinates;

--- a/src/shared/ui/CountOfPeople.tsx
+++ b/src/shared/ui/CountOfPeople.tsx
@@ -19,7 +19,7 @@ const CountOfPeople: React.FC<{ count?: number | boolean | null }> = ({ count })
   if (count === true || (count >= 1 && count <= 10)) return <Deemphasized>≥1</Deemphasized>;
   if (count <= 0) return <Deemphasized>0</Deemphasized>;
   if (count < 1) return <Deemphasized>—</Deemphasized>;
-  return <span>{Math.round(count).toLocaleString()}</span>;
+  return Math.round(count).toLocaleString();
 };
 
 export default CountOfPeople;


### PR DESCRIPTION
Fixes #286 #543 

Summary: This change estimates for the centers of language families. In order to test this out better I also added the ability to show text next to the map centroids

### Changes

- User experience
  - Macrolanguages (and language families) have coordinates now
  - Selecting a field focus now possible for map view -- it shows where the lat/long coordinates are (offset if the circle is shown too)
  - Huge performance improvement for hovercards -- no longer causing so many re-renders.
- Logical changes
  - Coordinate averaging in 3D space so the coordinates are the actual centers. Handles groups that cross the international date line much better.
- Data
  - Added some glottolog/ISO connections for some macrolanguages
- Refactors
  - MapCircles renamed MapCentroids because it may show circles and/or text
  - Moved some hover interactions to css to be more efficient

Out of scope/Future work: There are a number of improvements to the maps that we can do

### Test Plan and Screenshots

How to test the changes in this PR: ...

| Page/View with link | Description of Changes | Screenshot Before | Screenshot After |
| ------------------- | ---------------------- | ----------------- | ---------------- |
|[Macrolanguage map](http://localhost:5173/lang-nav/data?view=Map&fieldFocus=Name&languageScopes=4)|Many more macrolanguages have coordinates (a few contentious ones don't), they also show names now|<img width="1325" height="758" alt="Screenshot 2026-05-09 at 15 43 43" src="https://github.com/user-attachments/assets/d2b64b02-fcdc-48ff-a6ef-ad9cff663686" />|<img width="1345" height="764" alt="Screenshot 2026-05-09 at 15 42 33" src="https://github.com/user-attachments/assets/45c6274f-dce8-451c-b463-73efcda8d4eb" />


