### PR TITLE
Population: Add Population (writing) as a separate field

### DIFF
--- a/src/features/__tests__/MockObjects.tsx
+++ b/src/features/__tests__/MockObjects.tsx
@@ -159,7 +159,10 @@ export function getDisconnectedMockedObjects(): ObjectDictionary {
     localeSource: LocaleSource.StableDatabase,
     languageCode: 'sjn',
     territoryCode: 'BE',
-    pop: { speaking: { unadjusted: 9000, percent: 75, census: be0590 }, writing: {} },
+    pop: {
+      speaking: { unadjusted: 9000, percent: 75, census: be0590 },
+      writing: { unadjusted: 8000 },
+    },
   };
   const sjn_ER: LocaleData = {
     type: ObjectType.Locale,
@@ -170,7 +173,7 @@ export function getDisconnectedMockedObjects(): ObjectDictionary {
     localeSource: LocaleSource.StableDatabase,
     languageCode: 'sjn',
     territoryCode: 'ER',
-    pop: { speaking: { unadjusted: 1920, percent: 80 }, writing: {} },
+    pop: { speaking: { unadjusted: 1920, percent: 80 }, writing: { unadjusted: 1920 } },
   };
   const dori0123_ER: LocaleData = {
     type: ObjectType.Locale,
@@ -181,7 +184,7 @@ export function getDisconnectedMockedObjects(): ObjectDictionary {
     localeSource: LocaleSource.StableDatabase,
     languageCode: 'dori0123',
     territoryCode: 'ER',
-    pop: { speaking: { unadjusted: 1800, percent: 75 }, writing: {} },
+    pop: { speaking: { unadjusted: 1800, percent: 75 }, writing: { unadjusted: 0 } },
   };
 
   // Writing Systems

--- a/src/features/table/TableColumnName.tsx
+++ b/src/features/table/TableColumnName.tsx
@@ -20,7 +20,9 @@ function TableColumnName<T extends EntityData>({ column, appearance }: Props<T>)
 
   return (
     <HoverableContainer column={column} appearance={appearance}>
-      {column.label ?? column.key}{' '}
+      {(appearance === 'text' ? column.labelInColumnGroup : undefined) ??
+        column.label ??
+        column.key}{' '}
       {sortBy === column.field || secondarySortBy === column.field ? (
         <ArrowUpDownIcon
           size={14}

--- a/src/features/table/getValueType.ts
+++ b/src/features/table/getValueType.ts
@@ -10,6 +10,7 @@ export function getFieldValueType(field?: Field): TableValueType {
   switch (field) {
     case Field.Population:
     case Field.PopulationDirectlySourced:
+    case Field.PopulationWriting:
     case Field.PopulationOfDescendants:
       return TableValueType.Population;
 

--- a/src/features/transforms/coloring/getColorGradientForField.ts
+++ b/src/features/transforms/coloring/getColorGradientForField.ts
@@ -9,6 +9,7 @@ function getColorGradientForField(colorBy: Field): ColorGradient {
     case Field.None:
     case Field.Population:
     case Field.PopulationDirectlySourced:
+    case Field.PopulationWriting:
     case Field.PopulationOfDescendants:
     case Field.PopulationPercentInBiggestDescendantLanguage:
     case Field.PercentOfOverallLanguageSpeakers:

--- a/src/features/transforms/coloring/useColors.tsx
+++ b/src/features/transforms/coloring/useColors.tsx
@@ -99,6 +99,7 @@ function shouldUseLogarithmicScale(colorBy: Field): boolean {
   switch (colorBy) {
     case Field.Population:
     case Field.PopulationDirectlySourced:
+    case Field.PopulationWriting:
     case Field.PopulationOfDescendants:
     case Field.PopulationPercentInBiggestDescendantLanguage:
     case Field.CountOfLanguages:

--- a/src/features/transforms/fields/Field.ts
+++ b/src/features/transforms/fields/Field.ts
@@ -62,6 +62,7 @@ enum Field {
 
   // Quantity - Population
   PopulationDirectlySourced = 'Population Directly Sourced',
+  PopulationWriting = 'Population (Writing)',
   PopulationOfDescendants = 'Population of Descendants',
 
   // Quantity - Population Percent

--- a/src/features/transforms/fields/FieldApplicability.ts
+++ b/src/features/transforms/fields/FieldApplicability.ts
@@ -78,6 +78,7 @@ function getSpecificFieldsForObjectType(objectType: ObjectType): Field[] {
         Field.VitalityEthnologueFine,
 
         Field.PopulationDirectlySourced,
+        Field.PopulationWriting,
         Field.Literacy,
         Field.PercentOfOverallLanguageSpeakers,
         Field.PercentOfTerritoryPopulation,

--- a/src/features/transforms/fields/FieldGroup.ts
+++ b/src/features/transforms/fields/FieldGroup.ts
@@ -71,6 +71,7 @@ export function getFieldGroup(field: Field): FieldGroup {
       return FieldGroup.Quantity;
     case Field.Population:
     case Field.PopulationDirectlySourced:
+    case Field.PopulationWriting:
     case Field.PopulationOfDescendants:
       return FieldGroup.Quantity; // Population
     case Field.PercentOfTerritoryPopulation:

--- a/src/features/transforms/fields/FieldIcon.tsx
+++ b/src/features/transforms/fields/FieldIcon.tsx
@@ -33,6 +33,7 @@ import {
   ScrollTextIcon,
   TextIcon,
   UserCheckIcon,
+  UserPenIcon,
   UsersIcon,
   WholeWordIcon,
 } from 'lucide-react';
@@ -137,6 +138,8 @@ export function getFieldIcon(field: Field): LucideIcon {
       return UsersIcon;
     case Field.PopulationDirectlySourced:
       return UserCheckIcon;
+    case Field.PopulationWriting:
+      return UserPenIcon;
     case Field.PopulationOfDescendants:
       return BabyIcon;
     case Field.PercentOfTerritoryPopulation:

--- a/src/features/transforms/fields/ObjectFieldDisplay.tsx
+++ b/src/features/transforms/fields/ObjectFieldDisplay.tsx
@@ -34,6 +34,7 @@ const ObjectFieldDisplay: React.FC<Props> = ({ object, field }) => {
   switch (field) {
     case Field.Population:
     case Field.PopulationDirectlySourced:
+    case Field.PopulationWriting:
     case Field.PopulationOfDescendants:
     case Field.PopulationPercentInBiggestDescendantLanguage:
       if (typeof fieldValue === 'number') return <CountOfPeople count={fieldValue as number} />;

--- a/src/features/transforms/fields/getField.ts
+++ b/src/features/transforms/fields/getField.ts
@@ -157,6 +157,9 @@ function getField(object: ObjectData, field: Field): string | number | undefined
       return getObjectPopulation(object);
     case Field.PopulationDirectlySourced:
       return getObjectPopulationDirectlySourced(object);
+    case Field.PopulationWriting:
+      if (object.type === ObjectType.Locale) return object.pop.writing.unadjusted;
+      return undefined;
     case Field.PopulationOfDescendants:
       return getObjectPopulationOfDescendants(object);
     case Field.PopulationPercentInBiggestDescendantLanguage:

--- a/src/features/transforms/fields/rangeUtils.ts
+++ b/src/features/transforms/fields/rangeUtils.ts
@@ -27,6 +27,7 @@ export function getMinimumValue(field?: Field, populationMin?: number): number {
     case Field.Population:
       return populationMin ?? -1;
     case Field.PopulationDirectlySourced:
+    case Field.PopulationWriting:
     case Field.PopulationOfDescendants:
     case Field.PopulationPercentInBiggestDescendantLanguage:
     case Field.PercentOfOverallLanguageSpeakers:
@@ -125,6 +126,7 @@ export function getMaximumValue(objects: ObjectData[], field?: Field): number {
     case Field.CountOfVariants:
     case Field.Population:
     case Field.PopulationDirectlySourced:
+    case Field.PopulationWriting:
     case Field.PopulationOfDescendants:
     case Field.PopulationPercentInBiggestDescendantLanguage:
     case Field.Area:

--- a/src/features/transforms/filtering/useFilters.tsx
+++ b/src/features/transforms/filtering/useFilters.tsx
@@ -122,6 +122,7 @@ function useFilters(): Record<Field, FilterFunctionType> {
     [Field.CountOfVariants]: alwaysTrue,
 
     [Field.PopulationDirectlySourced]: alwaysTrue,
+    [Field.PopulationWriting]: alwaysTrue,
     [Field.PopulationOfDescendants]: alwaysTrue,
     [Field.PercentOfTerritoryPopulation]: alwaysTrue,
     [Field.PercentOfOverallLanguageSpeakers]: alwaysTrue,

--- a/src/features/transforms/sorting/__tests__/sortMocks.test.tsx
+++ b/src/features/transforms/sorting/__tests__/sortMocks.test.tsx
@@ -245,6 +245,35 @@ describe('getSortByParameterized', () => {
     ]);
   });
 
+  it('sortBy: Population (Writing)', () => {
+    const objects = Object.values(mockedObjects) as ObjectData[];
+    const sort = getSortFunctionParameterized(Field.PopulationWriting, SortBehavior.Normal);
+    expect(objects.sort(sort).map((obj) => obj.ID)).toEqual([
+      'sjn_123',
+      'sjn_001',
+      'sjn_BE',
+      'sjn_Teng_BE',
+      'sjn_Teng_123',
+      'sjn_Teng_001',
+      'sjn_ER',
+      'dori0123_ER',
+      'dori0123_123',
+      'dori0123_001',
+      // Written population unavailable for these data types
+      '123',
+      'sjn',
+      'dori0123',
+      'BE',
+      'ER',
+      'HA',
+      'AM',
+      '001',
+      'be0590',
+      'Teng',
+      'tolkorth',
+    ]);
+  });
+
   it('sortBy: PopulationOfDescendants', () => {
     const objects = Object.values(mockedObjects) as ObjectData[];
     const sort = getSortFunctionParameterized(Field.PopulationOfDescendants, SortBehavior.Normal);

--- a/src/features/transforms/sorting/sort.tsx
+++ b/src/features/transforms/sorting/sort.tsx
@@ -95,6 +95,7 @@ export function getNormalSortDirection(sortBy: Field): SortDirection {
     case Field.Date:
     case Field.Population:
     case Field.PopulationDirectlySourced:
+    case Field.PopulationWriting:
     case Field.PopulationOfDescendants:
     case Field.PopulationPercentInBiggestDescendantLanguage:
     case Field.PercentOfTerritoryPopulation:

--- a/src/widgets/tables/columns/LocaleColumns.tsx
+++ b/src/widgets/tables/columns/LocaleColumns.tsx
@@ -25,6 +25,7 @@ import { getTerritoryScopeLabel } from '@strings/TerritoryScopeStrings';
 
 import { LocalePopulationColumns } from './LocalePopulationColumns';
 import LocaleRelatedLocalesColumns from './LocaleRelatedLocalesColumns';
+import LocaleWritingColumns from './LocaleWritingColumns';
 
 function getLocaleColumns(): TableColumn<LocaleData>[] {
   return [
@@ -43,47 +44,7 @@ function getLocaleColumns(): TableColumn<LocaleData>[] {
       isInitiallyVisible: false,
     },
     ...LocalePopulationColumns,
-    {
-      key: 'Literacy',
-      render: (object) => object.literacyPercent,
-      isInitiallyVisible: false,
-      field: Field.Literacy,
-      columnGroup: 'Writing',
-    },
-    {
-      key: 'Writing System (specified)',
-      description: (
-        <>
-          Some locales specify a writing system, for instance{' '}
-          <code>
-            zh_<strong>Hant</strong>_TW
-          </code>{' '}
-          means it specifically refers to Traditional Han characters.
-        </>
-      ),
-      render: (object) => <HoverableObjectName object={object.writingSystem} />,
-      isInitiallyVisible: false,
-      columnGroup: 'Writing',
-    },
-    {
-      key: 'Writing System (inferred)',
-      description: (
-        <>
-          Some locales do not include a writing system but it can usually be inferred based on the
-          primary writing system for the language. For instance, <code>zh_CN</code> could be written
-          in <code>Hant</code> or <code>Hans</code> writing. Since the primary writing system in
-          China is the Simplified characters, it can be inferred to be <code>Hans</code>.
-        </>
-      ),
-      render: (object) => (
-        <HoverableObjectName
-          object={object.writingSystem ?? object.language?.primaryWritingSystem}
-        />
-      ),
-      isInitiallyVisible: false,
-      field: Field.WritingSystem,
-      columnGroup: 'Writing',
-    },
+    ...LocaleWritingColumns,
     {
       key: 'Language',
       render: (object) => <HoverableObjectName object={object.language} />,

--- a/src/widgets/tables/columns/LocaleWritingColumns.tsx
+++ b/src/widgets/tables/columns/LocaleWritingColumns.tsx
@@ -1,0 +1,54 @@
+import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
+import TableColumn from '@features/table/TableColumn';
+import Field from '@features/transforms/fields/Field';
+
+import { LocaleData } from '@entities/locale/LocaleTypes';
+
+const columns: TableColumn<LocaleData>[] = [
+  {
+    key: 'Literacy',
+    render: (object) => object.literacyPercent,
+    field: Field.Literacy,
+  },
+  {
+    key: 'Writing System (specified)',
+    description: (
+      <>
+        Some locales specify a writing system, for instance{' '}
+        <code>
+          zh_<strong>Hant</strong>_TW
+        </code>{' '}
+        means it specifically refers to Traditional Han characters.
+      </>
+    ),
+    render: (object) => <HoverableObjectName object={object.writingSystem} />,
+  },
+  {
+    key: 'Writing System (inferred)',
+    description: (
+      <>
+        Some locales do not include a writing system but it can usually be inferred based on the
+        primary writing system for the language. For instance, <code>zh_CN</code> could be written
+        in <code>Hant</code> or <code>Hans</code> writing. Since the primary writing system in China
+        is the Simplified characters, it can be inferred to be <code>Hans</code>.
+      </>
+    ),
+    render: (object) => (
+      <HoverableObjectName object={object.writingSystem ?? object.language?.primaryWritingSystem} />
+    ),
+    field: Field.WritingSystem,
+  },
+  {
+    key: 'Population (Writing)',
+    description:
+      'Coarse estimate, based on the spoken population × overall literacy in country, actual numbers may vary.',
+    render: (object) => object.pop.writing.unadjusted,
+    field: Field.PopulationWriting,
+  },
+];
+
+export default columns.map((col) => ({
+  ...col,
+  isInitiallyVisible: false,
+  columnGroup: 'Writing',
+}));


### PR DESCRIPTION
Fixes #646 

Summary: I'm working to separate "writing" and "speaking" more clearly in the population estimates. This continues the process by adding a specific field for writing population.

### Changes

- User experience
  - New column in the Locale table showing the population in writing
- Logical changes
  - Can sort by this now
- Data
  - n/a
- Refactors
  - Separated Locale writing columns into its own file

Out of scope/Future work: Improve these estimates with better census support

### Test Plan and Screenshots

How to test the changes in this PR: View the locale table

Locale host link: [](http://localhost:5173/lang-nav/data?view=Table&objectType=Locale&columns=2-4ftopf)
<img width="1097" height="665" alt="Screenshot 2026-06-03 at 09 16 58" src="https://github.com/user-attachments/assets/ac08c3ee-62a7-467f-965b-2e835c153ea8" />
