### PR TITLE
Fix Combined language hierarchy for ISO-only groupings

### DIFF
--- a/public/data/tc/languageFamilyCombinedOverrides.tsv
+++ b/public/data/tc/languageFamilyCombinedOverrides.tsv
@@ -1,0 +1,9 @@
+# Manual overrides for Combined language family hierarchy.
+# ISO-only groupings that Glottolog does not use need explicit Combined parent/child fixes.
+# rule (empty): set childLanguageCode's Combined.parentLanguageCode to parentLanguageCode
+# rule reparent-children-except:CODE: move direct children of parentLanguageCode to childLanguageCode; CODE and childLanguageCode stay under parentLanguageCode
+parentLanguageCode	childLanguageCode	rule	notes
+sqj	sqi		Albanian family to macrolanguage
+qwe	que		Quechuan family to macrolanguage
+euq	eus		Basque family to language
+map	fox	reparent-children-except:poz	Move Austronesian direct children under Formosan except poz

--- a/src/features/data/load/CoreData.tsx
+++ b/src/features/data/load/CoreData.tsx
@@ -27,6 +27,10 @@ import { loadOrganizations } from './entities/loadOrganizations';
 import { loadTerritories } from './entities/loadTerritories';
 import { loadWritingSystems } from './entities/loadWritingSystems';
 import {
+  applyCombinedFamilyOverrides,
+  loadCombinedFamilyOverrides,
+} from './extra_entities/CombinedFamilyOverrides';
+import {
   addGlottologLanguages,
   loadGlottocodeToISO,
   loadGlottologLanguages,
@@ -94,6 +98,7 @@ export function useCoreData(): {
       ethnologueLangs,
       glottologImport,
       glottocodeToISO,
+      combinedFamilyOverrides,
       territories,
       locales,
       writingSystems,
@@ -111,6 +116,7 @@ export function useCoreData(): {
       loadEthnologueLanguages(),
       loadGlottologLanguages(),
       loadGlottocodeToISO(),
+      loadCombinedFamilyOverrides(),
       loadTerritories(),
       loadLocales(),
       loadWritingSystems(),
@@ -143,6 +149,7 @@ export function useCoreData(): {
     addISOMacrolanguageData(languagesBySource.ISO, macroLangs || []);
     addISORetirementsToLanguages(languagesBySource, isoRetirements || []);
     addGlottologLanguages(languagesBySource, glottologImport || [], glottocodeToISO || {});
+    applyCombinedFamilyOverrides(languagesBySource, combinedFamilyOverrides || []);
     addCLDRLanguageDetails(languagesBySource);
     addIANAVariantLocales(languagesBySource.BCP, locales, variants);
 

--- a/src/features/data/load/extra_entities/CombinedFamilyOverrides.tsx
+++ b/src/features/data/load/extra_entities/CombinedFamilyOverrides.tsx
@@ -1,0 +1,109 @@
+import {
+  LanguageCode,
+  LanguageDictionary,
+  LanguagesBySource,
+} from '@entities/language/LanguageTypes';
+
+export type CombinedFamilyOverride = {
+  parentLanguageCode: LanguageCode;
+  childLanguageCode: LanguageCode;
+  rule?: string;
+};
+
+const REPARENT_CHILDREN_EXCEPT_PREFIX = 'reparent-children-except:';
+const HEADER_PARENT_COLUMN = 'parentLanguageCode';
+
+export async function loadCombinedFamilyOverrides(): Promise<CombinedFamilyOverride[] | void> {
+  return await fetch('data/tc/languageFamilyCombinedOverrides.tsv')
+    .then((res) => res.text())
+    .then((text) =>
+      text
+        .split('\n')
+        .filter((line) => line !== '' && !line.startsWith('#'))
+        .map(parseCombinedFamilyOverrideLine)
+        .filter((override): override is CombinedFamilyOverride => override != null),
+    )
+    .catch((err) => console.error('Error loading TSV:', err));
+}
+
+function parseCombinedFamilyOverrideLine(line: string): CombinedFamilyOverride | null {
+  const parts = line.split('\t');
+  const parentLanguageCode = parts[0];
+  if (parentLanguageCode === HEADER_PARENT_COLUMN) return null;
+
+  const childLanguageCode = parts[1];
+  const rule = parts[2] !== '' ? parts[2] : undefined;
+  return { parentLanguageCode, childLanguageCode, rule };
+}
+
+/**
+ * Apply manual Combined-family overrides after ISO and Glottolog data have been merged.
+ * Only Combined.parentLanguageCode is modified; ISO and Glottolog sources are unchanged.
+ */
+export function applyCombinedFamilyOverrides(
+  languagesBySource: LanguagesBySource,
+  overrides: CombinedFamilyOverride[],
+): void {
+  const combined = languagesBySource.Combined;
+
+  overrides.forEach((override) => {
+    if (override.rule?.startsWith(REPARENT_CHILDREN_EXCEPT_PREFIX)) {
+      const exceptCode = override.rule.slice(REPARENT_CHILDREN_EXCEPT_PREFIX.length);
+      // Apply parent/child link first (e.g. map -> fox), then reparent other direct children.
+      setCombinedParent(combined, override.childLanguageCode, override.parentLanguageCode);
+      reparentDirectChildrenExcept(
+        combined,
+        override.parentLanguageCode,
+        override.childLanguageCode,
+        exceptCode,
+      );
+      return;
+    }
+
+    setCombinedParent(combined, override.childLanguageCode, override.parentLanguageCode);
+  });
+}
+
+function setCombinedParent(
+  combined: LanguageDictionary,
+  childLanguageCode: LanguageCode,
+  parentLanguageCode: LanguageCode,
+): void {
+  const child = combined[childLanguageCode];
+  const parent = combined[parentLanguageCode];
+  if (child == null || parent == null) {
+    console.debug(
+      `Combined family override: child ${childLanguageCode} or parent ${parentLanguageCode} not found`,
+    );
+    return;
+  }
+  if (!child.Combined || !parent.Combined) {
+    console.debug(
+      `Combined family override: missing Combined source for ${childLanguageCode} or ${parentLanguageCode}`,
+    );
+    return;
+  }
+  child.Combined.parentLanguageCode = parentLanguageCode;
+}
+
+/**
+ * Reparent only direct children of fromParent to toParent.
+ * Does not walk descendants recursively.
+ */
+function reparentDirectChildrenExcept(
+  combined: LanguageDictionary,
+  fromParent: LanguageCode,
+  toParent: LanguageCode,
+  exceptCode: LanguageCode,
+): void {
+  Object.values(combined).forEach((lang) => {
+    if (!lang.Combined) return;
+    if (
+      lang.Combined.parentLanguageCode === fromParent &&
+      lang.ID !== exceptCode &&
+      lang.ID !== toParent
+    ) {
+      lang.Combined.parentLanguageCode = toParent;
+    }
+  });
+}

--- a/src/features/data/load/extra_entities/__tests__/CombinedFamilyOverrides.test.ts
+++ b/src/features/data/load/extra_entities/__tests__/CombinedFamilyOverrides.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { EMPTY_LANGUAGES_BY_SCHEMA } from '@features/data/load/CoreData';
+import { getBaseLanguageData, LanguageData, LanguageScope } from '@entities/language/LanguageTypes';
+
+import { applyCombinedFamilyOverrides } from '../CombinedFamilyOverrides';
+
+function makeLang(id: string, parentCode?: string) {
+  const lang = getBaseLanguageData(id, id);
+  lang.Combined.parentLanguageCode = parentCode;
+  lang.ISO.parentLanguageCode = parentCode;
+  lang.Glottolog.parentLanguageCode = parentCode;
+  return lang;
+}
+
+describe('applyCombinedFamilyOverrides', () => {
+  it('sets Combined parent without changing ISO or Glottolog parents', () => {
+    const sqi = makeLang('sqi', 'clas1257');
+    const sqj = makeLang('sqj', 'ine');
+    const languagesBySource = {
+      ...EMPTY_LANGUAGES_BY_SCHEMA,
+      Combined: { sqi, sqj },
+      ISO: { sqi, sqj },
+      Glottolog: { sqi, sqj },
+    };
+
+    applyCombinedFamilyOverrides(languagesBySource, [
+      { parentLanguageCode: 'sqj', childLanguageCode: 'sqi' },
+    ]);
+
+    expect(sqi.Combined.parentLanguageCode).toBe('sqj');
+    expect(sqi.ISO.parentLanguageCode).toBe('clas1257');
+    expect(sqi.Glottolog.parentLanguageCode).toBe('clas1257');
+  });
+
+  it('applies map -> fox before reparenting other direct children of map', () => {
+    const map = makeLang('map');
+    map.scope = LanguageScope.Family;
+    const fox = makeLang('fox');
+    fox.scope = LanguageScope.Family;
+    const poz = makeLang('poz', 'map');
+    poz.scope = LanguageScope.Family;
+    const ami = makeLang('ami', 'map');
+    const mfe = makeLang('mfe', 'poz');
+    const languagesBySource = {
+      ...EMPTY_LANGUAGES_BY_SCHEMA,
+      Combined: { map, fox, poz, ami, mfe },
+    };
+
+    applyCombinedFamilyOverrides(languagesBySource, [
+      {
+        parentLanguageCode: 'map',
+        childLanguageCode: 'fox',
+        rule: 'reparent-children-except:poz',
+      },
+    ]);
+
+    expect(fox.Combined.parentLanguageCode).toBe('map');
+    expect(poz.Combined.parentLanguageCode).toBe('map');
+    expect(ami.Combined.parentLanguageCode).toBe('fox');
+    expect(mfe.Combined.parentLanguageCode).toBe('poz');
+  });
+
+  it('skips entries missing Combined source objects', () => {
+    const child = makeLang('sqi', 'clas1257');
+    const parent = makeLang('sqj', 'ine');
+    (child as LanguageData).Combined = undefined as unknown as LanguageData['Combined'];
+
+    const languagesBySource = {
+      ...EMPTY_LANGUAGES_BY_SCHEMA,
+      Combined: { sqi: child, sqj: parent },
+    };
+
+    applyCombinedFamilyOverrides(languagesBySource, [
+      { parentLanguageCode: 'sqj', childLanguageCode: 'sqi' },
+    ]);
+
+    expect(child.Combined).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `languageFamilyCombinedOverrides.tsv` and loader to adjust **Combined** parent links when ISO has family groupings Glottolog lacks
- Fixes Albanian (`sqj` → `sqi`), Quechuan (`qwe` → `que`), Basque (`euq` → `eus`), and Formosan/Austronesian (`map` → `fox`, with `poz` remaining under `map`)

Fixes #650

## Changes
- `public/data/tc/languageFamilyCombinedOverrides.tsv`
- `src/features/data/load/extra_entities/CombinedFamilyOverrides.tsx`
- `src/features/data/load/extra_entities/__tests__/CombinedFamilyOverrides.test.ts`
- `src/features/data/load/CoreData.tsx` — apply overrides after Glottolog load

## Test plan
- [x] Verified Combined + Hierarchy UI locally for Albanian, Quechuan, Basque, Formosan
- [x] `npm run test:run` for `CombinedFamilyOverrides.test.ts`