### PR TITLE
Map: fix node size during zoom

### DIFF
--- a/src/features/map/MapCentroids.tsx
+++ b/src/features/map/MapCentroids.tsx
@@ -19,6 +19,7 @@ type Props = {
   drawableObjects: DrawableData[];
   openCard: (obj: DrawableData, x: number, y: number) => void;
   scalar: number;
+  zoomFactor: number;
   coloringFunctions: ColoringFunctions;
 };
 
@@ -26,6 +27,7 @@ const MapCentroids: React.FC<Props> = ({
   drawableObjects,
   openCard,
   scalar,
+  zoomFactor,
   coloringFunctions: { getColor, colorBy },
 }) => {
   const { scaleBy, objectType } = usePageParams();
@@ -78,6 +80,7 @@ const MapCentroids: React.FC<Props> = ({
           color={colorBy === 'None' ? undefined : (getColor(obj) ?? 'transparent')}
           object={obj}
           scale={scalar * getScale(obj)}
+          zoomFactor={zoomFactor}
           openCard={openCard}
           onMouseEnter={buildOnMouseEnter(obj)}
           onMouseLeave={onMouseLeaveTriggeringElement}
@@ -91,6 +94,7 @@ type NodeProps = {
   color?: string;
   object: DrawableData;
   scale: number;
+  zoomFactor: number;
   openCard: (obj: DrawableData, x: number, y: number) => void;
   onMouseEnter: (e: React.MouseEvent) => void;
   onMouseLeave: () => void;
@@ -100,6 +104,7 @@ const ObjectNode: React.FC<NodeProps> = ({
   object,
   color,
   scale,
+  zoomFactor,
   openCard,
   onMouseEnter,
   onMouseLeave,
@@ -115,18 +120,19 @@ const ObjectNode: React.FC<NodeProps> = ({
   const showCircle = !(object.type === ObjectType.Territory && (object?.landArea || 0) >= 20000);
 
   return (
-    <g transform={`translate(${x * 178.5}, ${y * -90})`}>
+    <g transform={`translate(${x * 178.5}, ${y * -90}) scale(${1 / zoomFactor})`}>
       {showCircle && (
         <Circle
           color={color}
           object={object}
           scale={scale}
+          zoomFactor={zoomFactor}
           openCard={openCard}
           onMouseEnter={onMouseEnter}
           onMouseLeave={onMouseLeave}
         />
       )}
-      <Text object={object} scale={scale} showCircle={showCircle} />
+      <Text object={object} scale={scale} showCircle={showCircle} zoomFactor={zoomFactor} />
     </g>
   );
 };
@@ -140,7 +146,8 @@ const Circle: React.FC<NodeProps> = ({
   onMouseLeave,
 }) => (
   <circle
-    r={scale + 1}
+    r={scale + 1.5}
+    strokeWidth={0.4}
     fill={color ?? 'transparent'}
     stroke={color == null ? 'var(--color-button-primary)' : 'transparent'}
     onClick={(e) => {
@@ -156,17 +163,19 @@ type TextProps = {
   object: DrawableData;
   scale: number;
   showCircle: boolean;
+  zoomFactor: number;
 };
 
-const Text: React.FC<TextProps> = ({ object, scale, showCircle }) => {
+const Text: React.FC<TextProps> = ({ object, scale, showCircle, zoomFactor }) => {
   const { fieldFocus } = usePageParams();
 
   if (fieldFocus === Field.None) return null;
+  if (zoomFactor < 1.5) return null;
 
   return (
     <text
-      y={showCircle ? 2 : 0}
-      fontSize={scale / 4 + 'em'}
+      y={showCircle ? scale + 2.5 : 0}
+      fontSize={scale / 3 + 'em'}
       textAnchor="middle"
       alignmentBaseline={showCircle ? 'hanging' : 'middle'}
     >

--- a/src/features/map/ObjectMap.tsx
+++ b/src/features/map/ObjectMap.tsx
@@ -36,9 +36,12 @@ type FloatingCard = {
 const ObjectMap: React.FC<Props> = ({ objects, maxWidth = 2000 }) => {
   const mapHeight = MAP_INTERNAL_WIDTH / MAP_ASPECT_RATIO;
 
+  const [zoomFactor, setZoomFactor] = useState(1);
+
   const { containerRef, contentRef, zoomIn, zoomOut, resetTransform } = useMapZoom({
     mapWidth: MAP_INTERNAL_WIDTH,
     mapHeight,
+    onZoom: setZoomFactor,
   });
 
   const { colorBy, objectType } = usePageParams();
@@ -168,6 +171,7 @@ const ObjectMap: React.FC<Props> = ({ objects, maxWidth = 2000 }) => {
             drawableObjects={drawableObjects}
             openCard={openCard}
             scalar={1200 / maxWidth}
+            zoomFactor={zoomFactor}
             coloringFunctions={coloringFunctions}
           />
           {floatingCards.map((card) => (

--- a/src/features/map/UseMapZoom.tsx
+++ b/src/features/map/UseMapZoom.tsx
@@ -25,6 +25,7 @@ type UseMapZoomOptions = {
   mapHeight: number;
   /** Maximum zoom multiplier (default: 8) */
   maxZoomMultiplier?: number;
+  onZoom?: (zoomFactor: number) => void;
 };
 
 /** Zoom control handlers - shared with ZoomControls component */
@@ -68,6 +69,7 @@ export const useMapZoom = ({
   mapWidth,
   mapHeight,
   maxZoomMultiplier = 8,
+  onZoom,
 }: UseMapZoomOptions): UseMapZoomReturn => {
   // ---------------------------------------------------------------------------
   // REFS
@@ -138,6 +140,9 @@ export const useMapZoom = ({
         // Apply CSS transform directly to the content element
         content.style.transform = `translate(${transform.x}px, ${transform.y}px) scale(${transform.k})`;
         content.style.transformOrigin = '0 0';
+
+        const baseScale = container.clientWidth / mapWidth;
+        onZoom?.(transform.k / baseScale);
 
         // Update visibleRange based on current transform
         const containerWidth = container.clientWidth;


### PR DESCRIPTION
Fixes #636 
## Summary
- Added an onZoom callback to useMapZoom that exposes the zoom factor relative to the initial map fit.
- Applied scale(1 / zoomFactor) to node groups 
- Tuned circle radius and stroke width, and hid text labels below 1.5× zoom to reduce clutter in the full-world view.

<p align="center">
  <img src="https://github.com/user-attachments/assets/df719be1-aa33-4386-94b4-8618b2c2fb65" width="49%" />
  <img src="https://github.com/user-attachments/assets/b631f1e8-a8e2-4e62-8d86-0967264149bc" width="49%" />
</p>
