### PR TITLE
Refactor: Rename useFilteredObjects to useFilteredEntities

### DIFF
--- a/src/entities/census/CensusLanguageCheck.tsx
+++ b/src/entities/census/CensusLanguageCheck.tsx
@@ -5,7 +5,7 @@ import { getObjectParents } from '@widgets/pathnav/getParentsAndDescendants';
 import { useDataContext } from '@features/data/context/useDataContext';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import { SearchableField } from '@features/params/PageParamTypes';
-import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
+import useFilteredEntities from '@features/transforms/filtering/useFilteredEntities';
 import getSubstringFilterOnQuery from '@features/transforms/search/getSubstringFilterOnQuery';
 
 import { LanguageData, LanguageScope } from '@entities/language/LanguageTypes';
@@ -39,8 +39,8 @@ const CensusLanguageCheck: React.FC<{ fileInput: string }> = ({ fileInput }) => 
   const lines = fileInput.split('\n');
   const { endOfMetadataLine } = parseCensusMetadata(lines, 'census');
   const { getLanguage, languagesInSelectedSource } = useDataContext();
-  const { filteredObjects: languageEnts } = useFilteredObjects({
-    inputObjects: languagesInSelectedSource,
+  const { filteredEntities: languageEnts } = useFilteredEntities({
+    inputEntities: languagesInSelectedSource,
   });
   const findLanguage = useCallback(
     (searchString: string) => {

--- a/src/entities/language/LanguageTerritoryList.tsx
+++ b/src/entities/language/LanguageTerritoryList.tsx
@@ -4,9 +4,7 @@ import Hoverable from '@features/layers/hovercard/Hoverable';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import LocalParamsProvider from '@features/params/LocalParamsProvider';
 import FilterBreakdown from '@features/transforms/filtering/FilterBreakdown';
-import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
-
-import { LocaleData } from '@entities/locale/LocaleTypes';
+import useFilteredEntities from '@features/transforms/filtering/useFilteredEntities';
 
 import { countBy, uniqueBy } from '@shared/lib/setUtils';
 import CommaSeparated from '@shared/ui/CommaSeparated';
@@ -30,11 +28,11 @@ const LanguageTerritoryList: React.FC<Props> = ({ lang }) => {
 
 const LanguageTerritoryListContents: React.FC<Props> = ({ lang }) => {
   const locales = lang.locales?.filter((loc) => loc.territoryCode != null) ?? [];
-  const filteredLocales = useFilteredObjects({
-    inputObjects: locales,
+  const filteredLocales = useFilteredEntities({
+    inputEntities: locales,
     useSubstring: false,
     useConnections: false,
-  }).filteredObjects as LocaleData[];
+  }).filteredEntities;
 
   if (locales.length === 0) return <Deemphasized>Unknown</Deemphasized>;
   const numberOfTerritories = countBy(locales, (loc) => loc.territoryCode ?? '');

--- a/src/entities/locale/LocalesInTerritoryCard.tsx
+++ b/src/entities/locale/LocalesInTerritoryCard.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
-import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
+import useFilteredEntities from '@features/transforms/filtering/useFilteredEntities';
 
 import { TerritoryData } from '@entities/territory/TerritoryTypes';
-
-import { LocaleData } from './LocaleTypes';
 
 type Props = {
   territory: TerritoryData;
@@ -13,9 +11,7 @@ type Props = {
 
 const LocalesInTerritoryCard: React.FC<Props> = ({ territory }) => {
   const [showAll, setShowAll] = React.useState(false);
-  const locales = useFilteredObjects({
-    inputObjects: territory.locales,
-  }).filteredObjects as LocaleData[];
+  const locales = useFilteredEntities({ inputEntities: territory.locales }).filteredEntities;
 
   return (
     <div>

--- a/src/entities/locale/localstatus/LocaleIndigeneityReport.tsx
+++ b/src/entities/locale/localstatus/LocaleIndigeneityReport.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo } from 'react';
 
 import { ObjectType } from '@features/params/PageParamTypes';
 import Selector from '@features/params/ui/Selector';
-import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
+import useFilteredEntities from '@features/transforms/filtering/useFilteredEntities';
 
 import { LocaleData } from '@entities/locale/LocaleTypes';
 
@@ -18,8 +18,8 @@ enum IncludeCriteria {
 }
 
 const LocaleIndigeneityReport: React.FC = () => {
-  const locales = useFilteredObjects({})
-    .filteredObjects.filter((l) => l.type === ObjectType.Locale)
+  const locales = useFilteredEntities({})
+    .filteredEntities.filter((l) => l.type === ObjectType.Locale)
     .filter((l) => !l.writingSystem && !l.variants && l.territory) as LocaleData[];
 
   const [includeCriteria, setIncludeCriteria] = React.useState(IncludeCriteria.MissingData);

--- a/src/entities/locale/localstatus/LocaleIndigeneityTable.tsx
+++ b/src/entities/locale/localstatus/LocaleIndigeneityTable.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import { NameColumn } from '@features/table/CommonColumns';
-import InteractiveObjectTable from '@features/table/InteractiveObjectTable';
+import InteractiveEntityTable from '@features/table/InteractiveEntityTable';
 import TableID from '@features/table/TableID';
 import TableValueType from '@features/table/TableValueType';
 import Field from '@features/transforms/fields/Field';
@@ -26,9 +26,9 @@ const LocaleIndigeneityTable: React.FC<{
   addToChangedLocales: (locale: LocaleData) => void;
 }> = ({ locales, addToChangedLocales }) => {
   return (
-    <InteractiveObjectTable
+    <InteractiveEntityTable
       tableID={TableID.LocaleIndigeneity}
-      objects={locales}
+      entities={locales}
       columns={[
         {
           key: 'ID',

--- a/src/entities/territory/TerritoryLanguageList.tsx
+++ b/src/entities/territory/TerritoryLanguageList.tsx
@@ -4,9 +4,7 @@ import Hoverable from '@features/layers/hovercard/Hoverable';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import LocalParamsProvider from '@features/params/LocalParamsProvider';
 import FilterBreakdown from '@features/transforms/filtering/FilterBreakdown';
-import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
-
-import { LocaleData } from '@entities/locale/LocaleTypes';
+import useFilteredEntities from '@features/transforms/filtering/useFilteredEntities';
 
 import { countBy, uniqueBy } from '@shared/lib/setUtils';
 import CommaSeparated from '@shared/ui/CommaSeparated';
@@ -28,8 +26,10 @@ const TerritoryLanguageList: React.FC<Props> = ({ territory }) => {
 
 const TerritoryLanguageListContents: React.FC<Props> = ({ territory }) => {
   const locales = territory.locales ?? [];
-  const filteredLocales = useFilteredObjects({ inputObjects: locales, useSubstring: false })
-    .filteredObjects as LocaleData[];
+  const filteredLocales = useFilteredEntities({
+    inputEntities: locales,
+    useSubstring: false,
+  }).filteredEntities;
 
   if (locales.length === 0) return <Deemphasized>Unknown</Deemphasized>;
   const numberOfLanguages = countBy(locales, (loc) => loc.languageCode);

--- a/src/entities/variant/VariantAnnotationTable.tsx
+++ b/src/entities/variant/VariantAnnotationTable.tsx
@@ -4,7 +4,7 @@ import { useDataContext } from '@features/data/context/useDataContext';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import { SearchableField } from '@features/params/PageParamTypes';
 import { CodeColumn, NameColumn } from '@features/table/CommonColumns';
-import InteractiveObjectTable from '@features/table/InteractiveObjectTable';
+import InteractiveEntityTable from '@features/table/InteractiveEntityTable';
 import TableColumn from '@features/table/TableColumn';
 import TableID from '@features/table/TableID';
 import { getLanguagesRelevantToObject } from '@features/transforms/filtering/filterByConnections';
@@ -90,8 +90,8 @@ const VariantAnnotationTable: React.FC<Props> = ({ variants, addToChangedVariant
   );
 
   return (
-    <InteractiveObjectTable
-      objects={variants}
+    <InteractiveEntityTable
+      entities={variants}
       tableID={TableID.VariantAnnotation}
       columns={columns}
     />

--- a/src/features/map/EntityMap.tsx
+++ b/src/features/map/EntityMap.tsx
@@ -22,18 +22,18 @@ import useMapZoom from './UseMapZoom';
 import ZoomControls from './ZoomControls';
 
 type Props = {
-  objects: ObjectData[];
+  entities: ObjectData[];
   maxWidth?: number;
 };
 
 type FloatingCard = {
   id: string;
-  object: DrawableData;
+  entity: DrawableData;
   x: number;
   y: number;
 };
 
-const ObjectMap: React.FC<Props> = ({ objects, maxWidth = 2000 }) => {
+const ObjectMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
   const mapHeight = MAP_INTERNAL_WIDTH / MAP_ASPECT_RATIO;
 
   const [zoomFactor, setZoomFactor] = useState(1);
@@ -55,13 +55,13 @@ const ObjectMap: React.FC<Props> = ({ objects, maxWidth = 2000 }) => {
     setMapScale(rect.width / MAP_INTERNAL_WIDTH);
   }, [contentRef]);
 
-  const drawableObjects = useMemo(() => {
+  const drawableEntities = useMemo(() => {
     if (objectType === ObjectType.Language) {
-      return objects.filter((obj) => obj.type === ObjectType.Language) as LanguageData[];
+      return entities.filter((obj) => obj.type === ObjectType.Language) as LanguageData[];
     }
 
     return uniqueBy(
-      objects
+      entities
         .flatMap((obj) => {
           if (obj.type === ObjectType.Territory) return obj;
           if (obj.type === ObjectType.Locale) return obj.territory;
@@ -73,12 +73,12 @@ const ObjectMap: React.FC<Props> = ({ objects, maxWidth = 2000 }) => {
         .filter((t): t is TerritoryData => t !== undefined),
       (t) => t.ID,
     ) as TerritoryData[];
-  }, [objectType, objects]);
+  }, [objectType, entities]);
 
-  const coloringFunctions = useColors({ objects: drawableObjects });
+  const coloringFunctions = useColors({ objects: drawableEntities });
 
   const openCard = useCallback(
-    (object: DrawableData, clientX: number, clientY: number) => {
+    (entity: DrawableData, clientX: number, clientY: number) => {
       const rect = contentRef.current?.getBoundingClientRect();
       if (!rect) return;
 
@@ -89,8 +89,8 @@ const ObjectMap: React.FC<Props> = ({ objects, maxWidth = 2000 }) => {
       const y = ((clientY - rect.top) / rect.height) * mapHeight;
 
       setFloatingCards((prev) => [
-        ...prev.filter((card) => card.id !== object.ID),
-        { id: object.ID, object, x, y },
+        ...prev.filter((card) => card.id !== entity.ID),
+        { id: entity.ID, entity, x, y },
       ]);
     },
     [contentRef, mapHeight],
@@ -161,14 +161,14 @@ const ObjectMap: React.FC<Props> = ({ objects, maxWidth = 2000 }) => {
 
           {objectType !== ObjectType.Language && (
             <MapTerritories
-              drawableObjects={drawableObjects}
+              drawableEntities={drawableEntities}
               openCard={openCard}
               coloringFunctions={coloringFunctions}
             />
           )}
 
           <MapCentroids
-            drawableObjects={drawableObjects}
+            drawableEntities={drawableEntities}
             openCard={openCard}
             scalar={1200 / maxWidth}
             zoomFactor={zoomFactor}
@@ -189,7 +189,7 @@ const ObjectMap: React.FC<Props> = ({ objects, maxWidth = 2000 }) => {
               onClick={(e) => e.stopPropagation()}
             >
               <MapCard
-                drawnObject={card.object}
+                drawnEntity={card.entity}
                 objectType={objectType}
                 onClose={() => closeCard(card.id)}
               />

--- a/src/features/map/MapCard.tsx
+++ b/src/features/map/MapCard.tsx
@@ -13,27 +13,27 @@ import WritingSystemsInTerritoryCard from '@entities/writingsystem/WritingSystem
 import DrawableData from './DrawableData';
 
 const MapCard: React.FC<{
-  drawnObject: DrawableData;
+  drawnEntity: DrawableData;
   objectType: ObjectType;
   onClose: () => void;
-}> = ({ drawnObject, objectType, onClose }) => {
+}> = ({ drawnEntity, objectType, onClose }) => {
   const { updatePageParams } = usePageParams();
 
   const openDetails = () =>
     updatePageParams(
       objectType === ObjectType.Census || objectType === ObjectType.WritingSystem
-        ? { territoryFilter: drawnObject.ID, view: View.Table }
-        : { objectID: drawnObject.ID },
+        ? { territoryFilter: drawnEntity.ID, view: View.Table }
+        : { objectID: drawnEntity.ID },
     );
 
   let content: React.ReactNode;
-  if (objectType === ObjectType.Census && drawnObject.type === ObjectType.Territory)
-    content = <CensusesInTerritory territory={drawnObject} />;
-  else if (objectType === ObjectType.Locale && drawnObject.type === ObjectType.Territory)
-    content = <LocalesInTerritoryCard territory={drawnObject} />;
-  else if (objectType === ObjectType.WritingSystem && drawnObject.type === ObjectType.Territory)
-    content = <WritingSystemsInTerritoryCard territory={drawnObject} />;
-  else content = <ObjectCard object={drawnObject} />;
+  if (objectType === ObjectType.Census && drawnEntity.type === ObjectType.Territory)
+    content = <CensusesInTerritory territory={drawnEntity} />;
+  else if (objectType === ObjectType.Locale && drawnEntity.type === ObjectType.Territory)
+    content = <LocalesInTerritoryCard territory={drawnEntity} />;
+  else if (objectType === ObjectType.WritingSystem && drawnEntity.type === ObjectType.Territory)
+    content = <WritingSystemsInTerritoryCard territory={drawnEntity} />;
+  else content = <ObjectCard object={drawnEntity} />;
 
   return (
     <div

--- a/src/features/map/MapCentroids.tsx
+++ b/src/features/map/MapCentroids.tsx
@@ -16,7 +16,7 @@ import { MAP_ASPECT_RATIO } from './MapConsts';
 import './map.css';
 
 type Props = {
-  drawableObjects: DrawableData[];
+  drawableEntities: DrawableData[];
   openCard: (obj: DrawableData, x: number, y: number) => void;
   scalar: number;
   zoomFactor: number;
@@ -24,27 +24,27 @@ type Props = {
 };
 
 const MapCentroids: React.FC<Props> = ({
-  drawableObjects,
+  drawableEntities,
   openCard,
   scalar,
   zoomFactor,
   coloringFunctions: { getColor, colorBy },
 }) => {
   const { scaleBy, objectType } = usePageParams();
-  const { getCurrentObjects } = usePagination<DrawableData>();
+  const { getCurrentEntities } = usePagination<DrawableData>();
   const { showHoverCard, onMouseLeaveTriggeringElement } = useHoverCard();
-  const { getScale } = useScale({ objects: drawableObjects, scaleBy });
+  const { getScale } = useScale({ objects: drawableEntities, scaleBy });
 
-  const renderableObjects = useMemo(() => {
-    const currentObjects =
-      objectType === ObjectType.Language ? getCurrentObjects(drawableObjects) : drawableObjects;
+  const renderableEntities = useMemo(() => {
+    const currentEntities =
+      objectType === ObjectType.Language ? getCurrentEntities(drawableEntities) : drawableEntities;
 
-    const filteredObjects = currentObjects.filter(
+    const filteredEntities = currentEntities.filter(
       (obj) => obj.type === ObjectType.Language || obj.type === ObjectType.Territory,
     );
 
-    return filteredObjects.reverse();
-  }, [drawableObjects, getCurrentObjects, objectType]);
+    return filteredEntities.reverse();
+  }, [drawableEntities, getCurrentEntities, objectType]);
 
   const buildOnMouseEnter = useCallback(
     (obj: DrawableData) => (e: React.MouseEvent) => {
@@ -74,7 +74,7 @@ const MapCentroids: React.FC<Props> = ({
         pointerEvents: 'none',
       }}
     >
-      {renderableObjects.map((obj) => (
+      {renderableEntities.map((obj) => (
         <ObjectNode
           key={obj.ID}
           color={colorBy === 'None' ? undefined : (getColor(obj) ?? 'transparent')}

--- a/src/features/map/MapTerritories.tsx
+++ b/src/features/map/MapTerritories.tsx
@@ -11,13 +11,13 @@ import { TerritoryData } from '@entities/territory/TerritoryTypes';
 import DrawableData from './DrawableData';
 
 type Props = {
-  drawableObjects: DrawableData[];
+  drawableEntities: DrawableData[];
   coloringFunctions: ColoringFunctions;
   openCard: (obj: DrawableData, x: number, y: number) => void;
 };
 
 const MapTerritories: React.FC<Props> = ({
-  drawableObjects,
+  drawableEntities,
   coloringFunctions: { colorBy, getColor },
   openCard,
 }) => {
@@ -27,8 +27,8 @@ const MapTerritories: React.FC<Props> = ({
   const { territories } = useDataContext();
 
   const isTerritoryInList = useCallback(
-    (iso: string) => drawableObjects.some((obj) => obj.ID === iso),
-    [drawableObjects],
+    (iso: string) => drawableEntities.some((obj) => obj.ID === iso),
+    [drawableEntities],
   );
 
   function forEachTerritory(func: (territory: TerritoryData, element: SVGElement) => void) {

--- a/src/features/pagination/ResultCount.tsx
+++ b/src/features/pagination/ResultCount.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
+import useFilteredEntities from '@features/transforms/filtering/useFilteredEntities';
 
 const ResultCount: React.FC = () => {
-  const { filteredObjects } = useFilteredObjects({});
+  const { filteredEntities } = useFilteredEntities({});
   return (
     <span style={{ color: 'var(--color-text)', whiteSpace: 'nowrap' }}>
-      {filteredObjects.length.toLocaleString()} Results{' '}
+      {filteredEntities.length.toLocaleString()} Results{' '}
     </span>
   );
 };

--- a/src/features/pagination/usePagination.tsx
+++ b/src/features/pagination/usePagination.tsx
@@ -8,13 +8,13 @@ import usePageParams from '@features/params/usePageParams';
  * Note you do have to indicate the type of data being sliced for typescript.
  *
  * Example usage:
- * const getCurrentObjects = useSliceFunction<ObjectData>();
- * const currentObjects = getCurrentObjects(objects);
+ * const getCurrentEntities = useSliceFunction<ObjectData>();
+ * const currentEntities = getCurrentEntities(objects);
  */
-function usePagination<T>(): { getCurrentObjects: (arr: T[]) => T[] } {
+function usePagination<T>(): { getCurrentEntities: (arr: T[]) => T[] } {
   const { page, limit } = usePageParams();
 
-  const getCurrentObjects = useCallback(
+  const getCurrentEntities = useCallback(
     (arr: T[]) => {
       // If the limit is not a countable number, return all elements
       // Commonly -1 is used as a stand-in for infinity.
@@ -30,7 +30,7 @@ function usePagination<T>(): { getCurrentObjects: (arr: T[]) => T[] } {
     [page, limit],
   );
 
-  return { getCurrentObjects };
+  return { getCurrentEntities };
 }
 
 export default usePagination;

--- a/src/features/table/BaseEntityTable.tsx
+++ b/src/features/table/BaseEntityTable.tsx
@@ -21,7 +21,7 @@ type Props<T> = {
   tableID: TableID;
 };
 
-function BaseObjectTable<T extends ObjectData>({ visibleColumns, objects }: Props<T>) {
+function BaseEntityTable<T extends ObjectData>({ visibleColumns, objects }: Props<T>) {
   return (
     <div style={{ width: '100%', position: 'relative' }}>
       <table style={{ textAlign: 'start', borderCollapse: 'collapse', width: 'max-content' }}>
@@ -96,4 +96,4 @@ const FormattedContent: React.FC<{ content: ReactNode; valueType?: TableValueTyp
   }
 };
 
-export default BaseObjectTable;
+export default BaseEntityTable;

--- a/src/features/table/InteractiveEntityTable.tsx
+++ b/src/features/table/InteractiveEntityTable.tsx
@@ -48,7 +48,7 @@ function InteractiveEntityTable<T extends ObjectData>({
           objects={entities}
           shouldFilterUsingSearchBar={shouldFilterUsingSearchBar}
         />
-        <TableExport visibleColumns={visibilityModule.visibleColumns} entities={entities} />
+        <TableExport visibleColumns={visibilityModule.visibleColumns} entities={filteredEntities} />
       </div>
       <TableColumnSelector columns={columns} visibilityModule={visibilityModule} />
 
@@ -73,7 +73,10 @@ function InteractiveEntityTable<T extends ObjectData>({
             objects={entities}
             shouldFilterUsingSearchBar={shouldFilterUsingSearchBar}
           />
-          <TableExport visibleColumns={visibilityModule.visibleColumns} entities={entities} />
+          <TableExport
+            visibleColumns={visibilityModule.visibleColumns}
+            entities={filteredEntities}
+          />
         </div>
       )}
     </div>

--- a/src/features/table/InteractiveEntityTable.tsx
+++ b/src/features/table/InteractiveEntityTable.tsx
@@ -1,14 +1,12 @@
 import usePagination from '@features/pagination/usePagination';
 import FilterBreakdown from '@features/transforms/filtering/FilterBreakdown';
-import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
+import useFilteredEntities from '@features/transforms/filtering/useFilteredEntities';
 
 import { ObjectData } from '@entities/types/DataTypes';
 
-import { useRenderCount } from '@shared/hooks/useRenderCount';
-
 import VisibleItemsMeter from '../pagination/VisibleItemsMeter';
 
-import BaseObjectTable from './BaseObjectTable';
+import BaseEntityTable from './BaseEntityTable';
 import TableColumn from './TableColumn';
 import TableColumnSelector from './TableColumnSelector';
 import TableExport from './TableExport';
@@ -18,29 +16,28 @@ import useColumnVisibility from './useColumnVisibility';
 import './tableStyles.css';
 
 interface Props<T> {
-  objects: T[];
+  entities: T[];
   columns: TableColumn<T>[];
   shouldFilterUsingSearchBar?: boolean;
   tableID: TableID;
 }
 
-function InteractiveObjectTable<T extends ObjectData>({
-  objects,
+function InteractiveEntityTable<T extends ObjectData>({
+  entities,
   columns,
   shouldFilterUsingSearchBar = true,
   tableID,
 }: Props<T>) {
-  const { getCurrentObjects } = usePagination<T>();
-  const objectsFilteredAndSorted = useFilteredObjects({
+  const { getCurrentEntities } = usePagination<T>();
+  const { filteredEntities } = useFilteredEntities({
     useScope: true,
     useSubstring: shouldFilterUsingSearchBar,
     useConnections: true,
     useVitality: true,
     usePopulation: true,
-    inputObjects: objects,
-  }).filteredObjects;
-  useRenderCount('InteractiveObjectTable');
-  const currentObjects = getCurrentObjects(objectsFilteredAndSorted);
+    inputEntities: entities,
+  });
+  const currentEntities = getCurrentEntities(filteredEntities);
 
   const visibilityModule = useColumnVisibility(columns, tableID);
 
@@ -48,44 +45,38 @@ function InteractiveObjectTable<T extends ObjectData>({
     <div style={{ display: 'flex', flexDirection: 'column', gap: '1em', alignItems: 'center' }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.5em' }}>
         <VisibleItemsMeter
-          objects={objects}
+          objects={entities}
           shouldFilterUsingSearchBar={shouldFilterUsingSearchBar}
         />
-        <TableExport
-          visibleColumns={visibilityModule.visibleColumns}
-          objectsFilteredAndSorted={objectsFilteredAndSorted}
-        />
+        <TableExport visibleColumns={visibilityModule.visibleColumns} entities={entities} />
       </div>
       <TableColumnSelector columns={columns} visibilityModule={visibilityModule} />
 
       {/* The actual <table> component */}
-      <BaseObjectTable
+      <BaseEntityTable
         visibleColumns={visibilityModule.visibleColumns}
-        objects={currentObjects}
+        objects={currentEntities}
         tableID={tableID}
       />
 
-      {currentObjects.length === 0 && (
+      {currentEntities.length === 0 && (
         <div>
           All results are filtered out.
-          <FilterBreakdown objects={objects} />
+          <FilterBreakdown objects={entities} />
         </div>
       )}
 
       {/* Repeat the visible item meter and export button at the bottom for convenience. */}
-      {currentObjects.length > 10 && (
+      {currentEntities.length > 10 && (
         <div style={{ display: 'flex', alignItems: 'center', gap: '0.5em' }}>
           <VisibleItemsMeter
-            objects={objects}
+            objects={entities}
             shouldFilterUsingSearchBar={shouldFilterUsingSearchBar}
           />
-          <TableExport
-            visibleColumns={visibilityModule.visibleColumns}
-            objectsFilteredAndSorted={objectsFilteredAndSorted}
-          />
+          <TableExport visibleColumns={visibilityModule.visibleColumns} entities={entities} />
         </div>
       )}
     </div>
   );
 }
-export default InteractiveObjectTable;
+export default InteractiveEntityTable;

--- a/src/features/table/TableExport.tsx
+++ b/src/features/table/TableExport.tsx
@@ -135,7 +135,7 @@ function TableExport<T extends ObjectData>({ visibleColumns, entities }: Props<T
         }
       })();
     },
-    [handleClipboardExport, handleExportFile, entities.length],
+    [handleClipboardExport, handleExportFile, entities, visibleColumns.length],
   );
   let validExportTypes = Object.values(ExportType).filter((et) => et !== ExportType.Unchosen);
   if (

--- a/src/features/table/TableExport.tsx
+++ b/src/features/table/TableExport.tsx
@@ -19,7 +19,7 @@ import { prepareUNESCODataForExport } from './UNESCOExport';
 
 interface Props<T> {
   visibleColumns: TableColumn<T>[];
-  objectsFilteredAndSorted: T[];
+  entities: T[];
 }
 
 enum ExportType {
@@ -43,7 +43,7 @@ type CopyExportType =
   | ExportType.CopyUNESCO
   | ExportType.CopyCLDR;
 
-function TableExport<T extends ObjectData>({ visibleColumns, objectsFilteredAndSorted }: Props<T>) {
+function TableExport<T extends ObjectData>({ visibleColumns, entities }: Props<T>) {
   // Track when the user initiates an export; used to disable the button while processing
   const [isExporting, setIsExporting] = useState(false);
   const pageParams = usePageParams();
@@ -53,13 +53,13 @@ function TableExport<T extends ObjectData>({ visibleColumns, objectsFilteredAndS
       const separator =
         exportType === ExportType.DownloadCSV || exportType === ExportType.CopyCSV ? ',' : '\t';
       if (exportType === ExportType.DownloadUNESCO || exportType === ExportType.CopyUNESCO) {
-        return prepareUNESCODataForExport(objectsFilteredAndSorted, pageParams.territoryFilter);
+        return prepareUNESCODataForExport(entities, pageParams.territoryFilter);
       }
       if (exportType === ExportType.CopyCLDR) {
-        return prepareCLDRLocalePopulationForExport(objectsFilteredAndSorted);
+        return prepareCLDRLocalePopulationForExport(entities);
       }
       const header = visibleColumns.map((c) => csvEscape(c.key)).join(separator);
-      const rows = objectsFilteredAndSorted.map((obj) => {
+      const rows = entities.map((obj) => {
         return visibleColumns
           .map(({ exportValue, render }) => {
             if (exportValue) return exportValue(obj);
@@ -75,7 +75,7 @@ function TableExport<T extends ObjectData>({ visibleColumns, objectsFilteredAndS
       });
       return [header, ...rows].join('\n');
     },
-    [objectsFilteredAndSorted, pageParams, visibleColumns],
+    [entities, pageParams, visibleColumns],
   );
 
   const handleExportFile = useCallback(
@@ -107,12 +107,12 @@ function TableExport<T extends ObjectData>({ visibleColumns, objectsFilteredAndS
 
   const handleExport = useCallback(
     (exportType: ExportType) => {
-      if (objectsFilteredAndSorted.length === 0) return;
+      if (entities.length === 0) return;
       setIsExporting(true);
       trackEvent('data_exported', {
         export_type: exportType,
         object_type: pageParams.objectType,
-        row_count: objectsFilteredAndSorted.length,
+        row_count: entities.length,
         column_count: visibleColumns.length,
       });
       void (async () => {
@@ -135,7 +135,7 @@ function TableExport<T extends ObjectData>({ visibleColumns, objectsFilteredAndS
         }
       })();
     },
-    [handleClipboardExport, handleExportFile, objectsFilteredAndSorted.length],
+    [handleClipboardExport, handleExportFile, entities.length],
   );
   let validExportTypes = Object.values(ExportType).filter((et) => et !== ExportType.Unchosen);
   if (

--- a/src/features/table/__tests__/InteractiveEntityTable.test.tsx
+++ b/src/features/table/__tests__/InteractiveEntityTable.test.tsx
@@ -178,7 +178,7 @@ describe('InteractiveEntityTable', () => {
     expect(mockSort).toHaveBeenCalled();
   });
 
-  it('handles filtering that excludes all objects', () => {
+  it('handles filtering that excludes all entities', () => {
     vi.mocked(getFilterBySubstring).mockReturnValue(() => false);
 
     renderEntityTable();
@@ -203,7 +203,7 @@ describe('InteractiveEntityTable', () => {
       population: 1234567,
     };
 
-    renderEntityTable({ objects: [numericObject] });
+    renderEntityTable({ entities: [numericObject] });
 
     expect(screen.getByRole('cell', { name: '1,234,567' })).toBeInTheDocument();
   });

--- a/src/features/table/__tests__/InteractiveObjectTable.test.tsx
+++ b/src/features/table/__tests__/InteractiveObjectTable.test.tsx
@@ -14,7 +14,7 @@ import { ObjectData } from '@entities/types/DataTypes';
 
 import { createMockUsePageParams } from '@tests/MockPageParams.test';
 
-import ObjectTable from '../InteractiveObjectTable';
+import EntityTable from '../InteractiveEntityTable';
 import TableColumn from '../TableColumn';
 import TableID from '../TableID';
 
@@ -48,7 +48,7 @@ vi.mock('@shared/hooks/useClickOutside', () => ({
 vi.mock('@features/params/usePageParams', () => ({ default: vi.fn() }));
 vi.mock('@features/transforms/search/getFilterBySubstring', () => ({ default: vi.fn() }));
 
-describe('InteractiveObjectTable', () => {
+describe('InteractiveEntityTable', () => {
   const mockObjects: ObjectData[] = [
     {
       ID: '1',
@@ -105,10 +105,10 @@ describe('InteractiveObjectTable', () => {
   });
 
   // Helper function to eliminate render wrapper duplication
-  const renderObjectTable = (props = {}) => {
+  const renderEntityTable = (props = {}) => {
     return render(
-      <ObjectTable
-        objects={mockObjects}
+      <EntityTable
+        entities={mockObjects}
         columns={mockColumns}
         tableID={TableID.Territories}
         {...props}
@@ -117,10 +117,10 @@ describe('InteractiveObjectTable', () => {
   };
 
   // Helper function to eliminate rerender duplication
-  const rerenderObjectTable = (rerender: (ui: React.ReactElement) => void, props = {}) => {
+  const rerenderEntityTable = (rerender: (ui: React.ReactElement) => void, props = {}) => {
     rerender(
-      <ObjectTable
-        objects={mockObjects}
+      <EntityTable
+        entities={mockObjects}
         columns={mockColumns}
         tableID={TableID.Territories}
         {...props}
@@ -136,7 +136,7 @@ describe('InteractiveObjectTable', () => {
   };
 
   it('renders table with all columns and data', () => {
-    renderObjectTable();
+    renderEntityTable();
 
     // Check column headers
     expectColumnHeaders();
@@ -161,7 +161,7 @@ describe('InteractiveObjectTable', () => {
     vi.mocked(FilterModule.getFilterByVitality).mockReturnValue(mockVitalityFilter);
     vi.mocked(FilterModule.getScopeFilter).mockReturnValue(mockScopeFilter);
 
-    renderObjectTable();
+    renderEntityTable();
 
     expect(mockSubstringFilter).toHaveBeenCalled();
     expect(mockConnectionsFilter).toHaveBeenCalled();
@@ -173,7 +173,7 @@ describe('InteractiveObjectTable', () => {
     const mockSort = vi.fn(() => 0);
     vi.mocked(SortModule.getSortFunction).mockReturnValue(mockSort);
 
-    renderObjectTable();
+    renderEntityTable();
 
     expect(mockSort).toHaveBeenCalled();
   });
@@ -181,7 +181,7 @@ describe('InteractiveObjectTable', () => {
   it('handles filtering that excludes all objects', () => {
     vi.mocked(getFilterBySubstring).mockReturnValue(() => false);
 
-    renderObjectTable();
+    renderEntityTable();
 
     mockObjects.forEach((obj) => {
       expect(screen.queryByText(obj.nameDisplay)).not.toBeInTheDocument();
@@ -191,7 +191,7 @@ describe('InteractiveObjectTable', () => {
   it('applies pagination to filtered results', () => {
     vi.mocked(usePageParams).mockReturnValue(createMockUsePageParams({ limit: 1, page: 2 }));
 
-    renderObjectTable();
+    renderEntityTable();
 
     expect(screen.queryByRole('cell', { name: 'Test Territory 1' })).not.toBeInTheDocument();
     expect(screen.getByRole('cell', { name: 'Test Territory 2' })).toBeInTheDocument();
@@ -203,7 +203,7 @@ describe('InteractiveObjectTable', () => {
       population: 1234567,
     };
 
-    renderObjectTable({ objects: [numericObject] });
+    renderEntityTable({ objects: [numericObject] });
 
     expect(screen.getByRole('cell', { name: '1,234,567' })).toBeInTheDocument();
   });
@@ -212,7 +212,7 @@ describe('InteractiveObjectTable', () => {
     const mockSubstringFilter = vi.fn();
     vi.mocked(getFilterBySubstring).mockReturnValue(mockSubstringFilter);
 
-    renderObjectTable({ shouldFilterUsingSearchBar: false });
+    renderEntityTable({ shouldFilterUsingSearchBar: false });
 
     expect(mockSubstringFilter).not.toHaveBeenCalled();
     mockObjects.forEach((obj) => {
@@ -221,7 +221,7 @@ describe('InteractiveObjectTable', () => {
   });
 
   it('handles column visibility toggling', async () => {
-    const { rerender } = renderObjectTable();
+    const { rerender } = renderEntityTable();
 
     // Initially, both columns should be visible
     expectColumnHeaders();
@@ -242,7 +242,7 @@ describe('InteractiveObjectTable', () => {
     );
 
     // Force rerender to ensure state updates are applied
-    rerenderObjectTable(rerender);
+    rerenderEntityTable(rerender);
 
     // Verify only Name column is visible
     expect(screen.getByRole('columnheader', { name: /Name/i })).toBeInTheDocument();
@@ -259,7 +259,7 @@ describe('InteractiveObjectTable', () => {
     );
 
     // Force rerender to ensure state updates are applied
-    rerenderObjectTable(rerender);
+    rerenderEntityTable(rerender);
 
     // Verify both columns are visible again
     expectColumnHeaders();
@@ -271,7 +271,7 @@ describe('InteractiveObjectTable', () => {
     });
 
     // Force rerender to ensure state updates are applied
-    rerenderObjectTable(rerender);
+    rerenderEntityTable(rerender);
 
     // Both columns should still be visible
     expectColumnHeaders();

--- a/src/features/table/__tests__/TableExport.test.tsx
+++ b/src/features/table/__tests__/TableExport.test.tsx
@@ -31,7 +31,7 @@ describe('TableExport', () => {
   ];
 
   it('export buttons render correctly', async () => {
-    render(<TableExport visibleColumns={columns} objectsFilteredAndSorted={objects} />);
+    render(<TableExport visibleColumns={columns} entities={objects} />);
 
     // The options aren't initially visible, also there is no generic Export option
     expect(screen.queryByText('Copy TSV')).not.toBeTruthy();
@@ -55,7 +55,7 @@ describe('TableExport', () => {
   // so we only test copying to clipboard here.
 
   it('copies tsv format data to clipboard when Copy TSV is clicked', async () => {
-    render(<TableExport visibleColumns={columns} objectsFilteredAndSorted={objects} />);
+    render(<TableExport visibleColumns={columns} entities={objects} />);
 
     // Open the menu to show `Copy TSV` option
     act(() => {

--- a/src/features/transforms/filtering/__tests__/useFilteredEntities.test.tsx
+++ b/src/features/transforms/filtering/__tests__/useFilteredEntities.test.tsx
@@ -11,7 +11,7 @@ import { VitalityEthnologueFine } from '@entities/language/vitality/VitalityType
 
 import { createMockUsePageParams } from '@tests/MockPageParams.test';
 
-import useFilteredObjects from '../useFilteredObjects';
+import useFilteredEntities from '../useFilteredEntities';
 
 import { getMockLanguages } from './mockLanguagesForFilterTest.test';
 
@@ -32,11 +32,11 @@ function getHookResult(
     useVitality?: boolean;
   } = {},
 ) {
-  const res = renderHook(() => useFilteredObjects(params));
+  const res = renderHook(() => useFilteredEntities(params));
   return res.result.current;
 }
 
-describe('useFilteredObjects', () => {
+describe('useFilteredEntities', () => {
   const setupMockParams = (overrides: PageParamsOptional = {}) => {
     const mockUsePageParams = createMockUsePageParams(overrides);
     (usePageParams as Mock).mockReturnValue(mockUsePageParams);
@@ -48,8 +48,8 @@ describe('useFilteredObjects', () => {
   });
 
   it('returns default items when no filters are active', () => {
-    const { filteredObjects } = getHookResult({});
-    expect(filteredObjects.map((obj) => obj.ID)).toEqual([
+    const { filteredEntities } = getHookResult({});
+    expect(filteredEntities.map((obj) => obj.ID)).toEqual([
       // 'ine', // Indo-European family not included since its filtered out as family by default
       'eng',
       'spa',
@@ -67,37 +67,37 @@ describe('useFilteredObjects', () => {
       languageScopes: [], // allow all languoids including Indo-European family
       searchString: 'i', // I matches ine, ita
     });
-    const { filteredObjects } = getHookResult({});
-    expect(filteredObjects.map((obj) => obj.ID)).toEqual(['ine', 'ita']);
+    const { filteredEntities } = getHookResult({});
+    expect(filteredEntities.map((obj) => obj.ID)).toEqual(['ine', 'ita']);
   });
 
   it('filters by vitality value', () => {
     setupMockParams({ vitalityEthFine: [VitalityEthnologueFine.National] });
-    const { filteredObjects } = getHookResult({});
-    expect(filteredObjects.map((obj) => obj.ID)).toEqual(['eng', 'spa']);
+    const { filteredEntities } = getHookResult({});
+    expect(filteredEntities.map((obj) => obj.ID)).toEqual(['eng', 'spa']);
   });
 
   it('filters by territory', () => {
     setupMockParams({ territoryFilter: 'US' });
-    const { filteredObjects } = getHookResult({});
-    expect(filteredObjects.map((obj) => obj.ID)).toEqual(['eng', 'spa', 'fra', 'rus', 'nav']);
+    const { filteredEntities } = getHookResult({});
+    expect(filteredEntities.map((obj) => obj.ID)).toEqual(['eng', 'spa', 'fra', 'rus', 'nav']);
   });
 
   it('allows composite filters (territory + vitality)', () => {
     setupMockParams({ territoryFilter: 'US', vitalityEthFine: [VitalityEthnologueFine.National] });
-    const { filteredObjects } = getHookResult({});
-    expect(filteredObjects.map((obj) => obj.ID)).toEqual(['eng', 'spa']);
+    const { filteredEntities } = getHookResult({});
+    expect(filteredEntities.map((obj) => obj.ID)).toEqual(['eng', 'spa']);
   });
 
   it('can change the language scope filter', () => {
     setupMockParams({ languageScopes: [LanguageScope.Macrolanguage] });
-    const { filteredObjects } = getHookResult({});
-    expect(filteredObjects.map((obj) => obj.ID)).toEqual(['zho']);
+    const { filteredEntities } = getHookResult({});
+    expect(filteredEntities.map((obj) => obj.ID)).toEqual(['zho']);
   });
 
   it("if we don't want to filter by scope, it will allow the language family (ine) even though the page param wouldn't normally allow it", () => {
-    const { filteredObjects } = getHookResult({ useScope: false });
-    expect(filteredObjects.map((obj) => obj.ID)).toEqual([
+    const { filteredEntities } = getHookResult({ useScope: false });
+    expect(filteredEntities.map((obj) => obj.ID)).toEqual([
       'ine', // usually filtered out as family
       'gem',
       'eng',
@@ -113,8 +113,8 @@ describe('useFilteredObjects', () => {
 
   it('treats empty languageScopes as "any languoid" allowing languoid items through', () => {
     setupMockParams({ languageScopes: [] });
-    const { filteredObjects } = getHookResult({});
-    expect(filteredObjects.map((obj) => obj.ID)).toEqual([
+    const { filteredEntities } = getHookResult({});
+    expect(filteredEntities.map((obj) => obj.ID)).toEqual([
       'ine',
       'gem',
       'eng',
@@ -130,8 +130,8 @@ describe('useFilteredObjects', () => {
 
   it('returns sorted items', () => {
     setupMockParams({ sortBy: Field.Name, sortBehavior: SortBehavior.Reverse });
-    const { filteredObjects } = getHookResult({});
-    expect(filteredObjects.map((obj) => obj.ID)).toEqual([
+    const { filteredEntities } = getHookResult({});
+    expect(filteredEntities.map((obj) => obj.ID)).toEqual([
       'spa', // Spanish
       'rus', // Russian
       'nav', // Navajo

--- a/src/features/transforms/filtering/useFilteredEntities.tsx
+++ b/src/features/transforms/filtering/useFilteredEntities.tsx
@@ -11,7 +11,7 @@ import { getFilterByVitality, getScopeFilter } from './filter';
 import { getFilterByConnections } from './filterByConnections';
 import useFilters from './useFilters';
 
-type UseFilteredObjectsParams<T extends ObjectData> = {
+type UseFilteredEntitiesParams<T extends ObjectData> = {
   // TODO use Fields to specify which filters should be used, not these generalized booleans
   useScope?: boolean;
   useSubstring?: boolean;
@@ -28,7 +28,7 @@ const useFilteredEntities = <T extends ObjectData>({
   useVitality = true,
   usePopulation = true,
   inputEntities,
-}: UseFilteredObjectsParams<T>): { filteredEntities: T[]; allEntities: T[] } => {
+}: UseFilteredEntitiesParams<T>): { filteredEntities: T[]; allEntities: T[] } => {
   // Implementation of filtering logic goes here
   const pageEntities = useEntities() as T[]; // Get all objects of the relevant type from context
   // TODO use useFilters for all of these

--- a/src/features/transforms/filtering/useFilteredEntities.tsx
+++ b/src/features/transforms/filtering/useFilteredEntities.tsx
@@ -18,19 +18,19 @@ type UseFilteredObjectsParams<T extends ObjectData> = {
   useConnections?: boolean;
   useVitality?: boolean;
   usePopulation?: boolean;
-  inputObjects?: T[];
+  inputEntities?: T[];
 };
 
-const useFilteredObjects = <T extends ObjectData>({
+const useFilteredEntities = <T extends ObjectData>({
   useScope = true,
   useSubstring = true,
   useConnections = true,
   useVitality = true,
   usePopulation = true,
-  inputObjects,
-}: UseFilteredObjectsParams<T>): { filteredObjects: T[]; allObjectsInType: T[] } => {
+  inputEntities,
+}: UseFilteredObjectsParams<T>): { filteredEntities: T[]; allEntities: T[] } => {
   // Implementation of filtering logic goes here
-  const pageObjects = useEntities() as T[]; // Get all objects of the relevant type from context
+  const pageEntities = useEntities() as T[]; // Get all objects of the relevant type from context
   // TODO use useFilters for all of these
   const filters = useFilters();
   const filterByScope = useScope ? getScopeFilter() : () => true;
@@ -39,10 +39,10 @@ const useFilteredObjects = <T extends ObjectData>({
   const filterByVitality = useVitality ? getFilterByVitality() : () => true;
   const filterByPopulation = usePopulation ? filters.Population : () => true;
   const sortFunction = getSortFunction();
-  const allObjectsInType = inputObjects ?? pageObjects;
+  const allEntities = inputEntities ?? pageEntities;
 
-  const filteredObjects = useMemo(() => {
-    return allObjectsInType
+  const filteredEntities = useMemo(() => {
+    return allEntities
       .filter(
         (obj) =>
           filterByScope(obj) &&
@@ -53,7 +53,7 @@ const useFilteredObjects = <T extends ObjectData>({
       )
       .sort(sortFunction);
   }, [
-    allObjectsInType,
+    allEntities,
     filterByScope,
     filterBySubstring,
     filterByConnections,
@@ -62,7 +62,7 @@ const useFilteredObjects = <T extends ObjectData>({
     sortFunction,
   ]);
 
-  return { filteredObjects, allObjectsInType };
+  return { filteredEntities, allEntities };
 };
 
-export default useFilteredObjects;
+export default useFilteredEntities;

--- a/src/pages/LuckySearchPageBody.tsx
+++ b/src/pages/LuckySearchPageBody.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { useDataContext } from '@features/data/context/useDataContext';
 import usePageParams from '@features/params/usePageParams';
-import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
+import useFilteredEntities from '@features/transforms/filtering/useFilteredEntities';
 import SearchBar from '@features/transforms/search/SearchBar';
 
 const SearchContainer: React.FC<{ children: React.ReactNode; style?: React.CSSProperties }> = ({
@@ -30,7 +30,7 @@ const LuckySearchPageBody: React.FC = () => {
   const navigate = useNavigate();
   const { searchString } = usePageParams();
   const { getLanguage, languagesInSelectedSource } = useDataContext();
-  const { filteredObjects } = useFilteredObjects({});
+  const { filteredEntities } = useFilteredEntities({});
   const [isSearching, setIsSearching] = useState(true);
 
   useEffect(() => {
@@ -46,16 +46,16 @@ const LuckySearchPageBody: React.FC = () => {
       return;
     }
 
-    if (filteredObjects.length > 0) {
+    if (filteredEntities.length > 0) {
       // Navigate to data page with the first filtered result
       navigate(
-        `/data?searchString=${encodeURIComponent(searchString)}&objectID=${filteredObjects[0].ID}`,
+        `/data?searchString=${encodeURIComponent(searchString)}&objectID=${filteredEntities[0].ID}`,
       );
       return;
     }
 
     setIsSearching(false);
-  }, [searchString, getLanguage, languagesInSelectedSource, filteredObjects, navigate]);
+  }, [searchString, getLanguage, languagesInSelectedSource, filteredEntities, navigate]);
 
   if (isSearching) {
     return (

--- a/src/pages/dataviews/ViewMap.tsx
+++ b/src/pages/dataviews/ViewMap.tsx
@@ -1,8 +1,8 @@
 import { ReactNode } from 'react';
 
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
+import ObjectMap from '@features/map/EntityMap';
 import MapContainer from '@features/map/MapContainer';
-import ObjectMap from '@features/map/ObjectMap';
 import usePagination from '@features/pagination/usePagination';
 import VisibleItemsMeter from '@features/pagination/VisibleItemsMeter';
 import { ObjectType } from '@features/params/PageParamTypes';
@@ -14,7 +14,7 @@ import usePageParams from '@features/params/usePageParams';
 import ColorBySelector from '@features/transforms/coloring/ColorBySelector';
 import ColorGradientSelector from '@features/transforms/coloring/ColorGradientSelector';
 import Field from '@features/transforms/fields/Field';
-import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
+import useFilteredEntities from '@features/transforms/filtering/useFilteredEntities';
 
 import { getObjectTypeLabelPlural } from '@entities/lib/getObjectName';
 import { ObjectData } from '@entities/types/DataTypes';
@@ -24,8 +24,8 @@ import CommaSeparated from '@shared/ui/CommaSeparated';
 
 function ViewMap() {
   const { colorBy, objectType } = usePageParams();
-  const { filteredObjects, allObjectsInType } = useFilteredObjects({});
-  const { getCurrentObjects } = usePagination<ObjectData>();
+  const { filteredEntities, allEntities } = useFilteredEntities({});
+  const { getCurrentEntities } = usePagination<ObjectData>();
 
   const isDrawingTerritories = objectType !== ObjectType.Language;
 
@@ -38,11 +38,11 @@ function ViewMap() {
     );
   }
 
-  const objectsWithoutCoordinates =
+  const entsWithoutCoordinates =
     objectType == ObjectType.Language
-      ? getCurrentObjects(filteredObjects).filter(
-          (obj) =>
-            obj.type === ObjectType.Language && (obj.latitude == null || obj.longitude == null),
+      ? getCurrentEntities(filteredEntities).filter(
+          (ent) =>
+            ent.type === ObjectType.Language && (ent.latitude == null || ent.longitude == null),
         )
       : [];
 
@@ -50,8 +50,8 @@ function ViewMap() {
     <MapContainer>
       <h2 style={{ margin: 0 }}>{toTitleCase(objectType)} Map</h2>
       <div>{getMapDescription(objectType)}</div>
-      {!isDrawingTerritories && <VisibleItemsMeter objects={allObjectsInType} />}
-      <ObjectMap objects={filteredObjects} />
+      {!isDrawingTerritories && <VisibleItemsMeter objects={allEntities} />}
+      <ObjectMap entities={filteredEntities} />
       <SelectorDisplayProvider display={SelectorDisplay.InlineDropdown}>
         <div style={{ display: 'flex', gap: '0.5em', alignItems: 'center' }}>
           <div>
@@ -62,12 +62,12 @@ function ViewMap() {
           <ColorGradientSelector />
         </div>
       </SelectorDisplayProvider>
-      {objectsWithoutCoordinates.length > 0 && (
+      {entsWithoutCoordinates.length > 0 && (
         <div>
           The following {getObjectTypeLabelPlural(objectType)} do not have defined coordinates:{' '}
           <CommaSeparated limit={10}>
-            {objectsWithoutCoordinates.map((obj) => (
-              <HoverableObjectName key={obj.ID} object={obj} />
+            {entsWithoutCoordinates.map((ent) => (
+              <HoverableObjectName key={ent.ID} object={ent} />
             ))}
           </CommaSeparated>
         </div>

--- a/src/widgets/PageNavBar.tsx
+++ b/src/widgets/PageNavBar.tsx
@@ -3,7 +3,7 @@ import { NavLink } from 'react-router-dom';
 
 import { LangNavPageName } from '@app/PageRoutes';
 
-import Settings from '@widgets/settings/Settings';
+import Settings from '@widgets/controls/Settings';
 
 import { FeedbackForm } from '@features/feedback/FeedbackForm';
 import InternalLink from '@features/params/InternalLink';

--- a/src/widgets/cardlists/CardList.tsx
+++ b/src/widgets/cardlists/CardList.tsx
@@ -4,7 +4,7 @@ import usePagination from '@features/pagination/usePagination';
 import VisibleItemsMeter from '@features/pagination/VisibleItemsMeter';
 import useColors from '@features/transforms/coloring/useColors';
 import FilterBreakdown from '@features/transforms/filtering/FilterBreakdown';
-import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
+import useFilteredEntities from '@features/transforms/filtering/useFilteredEntities';
 
 import { ObjectData } from '@entities/types/DataTypes';
 import ObjectCard from '@entities/ui/ObjectCard';
@@ -15,34 +15,34 @@ import CardInCardList from './CardInCardList';
 import ResponsiveGrid from './ResponsiveGrid';
 
 const CardList: React.FC = () => {
-  const { filteredObjects, allObjectsInType } = useFilteredObjects({});
-  const { getCurrentObjects } = usePagination<ObjectData>();
-  const currentObjects = useMemo(
-    () => getCurrentObjects(filteredObjects),
-    [filteredObjects, getCurrentObjects],
+  const { filteredEntities, allEntities } = useFilteredEntities({});
+  const { getCurrentEntities } = usePagination<ObjectData>();
+  const currentEntities = useMemo(
+    () => getCurrentEntities(filteredEntities),
+    [filteredEntities, getCurrentEntities],
   );
-  const { getColor } = useColors({ objects: filteredObjects });
+  const { getColor } = useColors({ objects: filteredEntities });
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '1em' }}>
-      <VisibleItemsMeter objects={allObjectsInType} />
-      {currentObjects.length === 0 && <Deemphasized>No objects found.</Deemphasized>}
+      <VisibleItemsMeter objects={allEntities} />
+      {currentEntities.length === 0 && <Deemphasized>No objects found.</Deemphasized>}
 
       {/* Main grid */}
-      {currentObjects.length >= 1 && (
+      {currentEntities.length >= 1 && (
         <ResponsiveGrid>
-          {currentObjects.map((object) => (
-            <CardInCardList key={object.ID} getBackgroundColor={getColor} object={object}>
-              <ObjectCard object={object} />
+          {currentEntities.map((ent) => (
+            <CardInCardList key={ent.ID} getBackgroundColor={getColor} object={ent}>
+              <ObjectCard object={ent} />
             </CardInCardList>
           ))}
         </ResponsiveGrid>
       )}
 
       {/* Display another visible item meter at the bottom for convenience. */}
-      {currentObjects.length > 3 && <VisibleItemsMeter objects={allObjectsInType} />}
-      {currentObjects.length === 0 && (
-        <FilterBreakdown objects={allObjectsInType} shouldFilterUsingSearchBar={true} />
+      {currentEntities.length > 3 && <VisibleItemsMeter objects={allEntities} />}
+      {currentEntities.length === 0 && (
+        <FilterBreakdown objects={allEntities} shouldFilterUsingSearchBar={true} />
       )}
     </div>
   );

--- a/src/widgets/cardlists/__tests__/CardList.test.tsx
+++ b/src/widgets/cardlists/__tests__/CardList.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { getFullyInstantiatedMockedObjects } from '@features/__tests__/MockObjects';
 import { ObjectType, PageParamsOptional } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
-import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
+import useFilteredEntities from '@features/transforms/filtering/useFilteredEntities';
 import { sortByPopulation } from '@features/transforms/sorting/sort';
 
 import { TerritoryScope } from '@entities/territory/TerritoryTypes';
@@ -17,7 +17,7 @@ vi.mock('@features/params/usePageParams', () => ({ default: vi.fn() }));
 vi.mock('@features/layers/hovercard/useHoverCard', () => ({
   default: vi.fn().mockReturnValue({}),
 }));
-vi.mock('@features/transforms/filtering/useFilteredObjects', () => ({ default: vi.fn() }));
+vi.mock('@features/transforms/filtering/useFilteredEntities', () => ({ default: vi.fn() }));
 vi.mock('@features/transforms/coloring/useColors', () => ({
   default: vi.fn().mockReturnValue({ getColor: () => 'inherit' }),
 }));
@@ -34,8 +34,8 @@ describe('CardList', () => {
   }
 
   function setupMockFilteredObjects(countryOnly: boolean = false) {
-    (useFilteredObjects as Mock).mockReturnValue({
-      filteredObjects: territories.filter(
+    (useFilteredEntities as Mock).mockReturnValue({
+      filteredEntities: territories.filter(
         (obj) => !countryOnly || obj.scope === TerritoryScope.Country,
       ),
       allObjectsInType: territories,

--- a/src/widgets/cardlists/__tests__/CardList.test.tsx
+++ b/src/widgets/cardlists/__tests__/CardList.test.tsx
@@ -23,8 +23,8 @@ vi.mock('@features/transforms/coloring/useColors', () => ({
 }));
 
 describe('CardList', () => {
-  const mockedObjects = getFullyInstantiatedMockedObjects();
-  const territories = Object.values(mockedObjects)
+  const mockedEntities = getFullyInstantiatedMockedObjects();
+  const territories = Object.values(mockedEntities)
     .filter((obj) => obj.type === ObjectType.Territory)
     .sort(sortByPopulation);
 
@@ -33,18 +33,18 @@ describe('CardList', () => {
     (usePageParams as Mock).mockReturnValue(createMockUsePageParams(overrides));
   }
 
-  function setupMockFilteredObjects(countryOnly: boolean = false) {
+  function setupMockFilteredEntities(countryOnly: boolean = false) {
     (useFilteredEntities as Mock).mockReturnValue({
       filteredEntities: territories.filter(
         (obj) => !countryOnly || obj.scope === TerritoryScope.Country,
       ),
-      allObjectsInType: territories,
+      allEntities: territories,
     });
   }
 
   beforeEach(() => {
     setupMockParams();
-    setupMockFilteredObjects();
+    setupMockFilteredEntities();
   });
 
   afterEach(() => {
@@ -76,7 +76,7 @@ describe('CardList', () => {
   });
 
   it('when the objects are filtered, the visible item meter shows correct counts', () => {
-    setupMockFilteredObjects(true); // countryOnly = true
+    setupMockFilteredEntities(true); // countryOnly = true
 
     const { container, getAllByText } = render(<CardList />);
 

--- a/src/widgets/controls/Settings.tsx
+++ b/src/widgets/controls/Settings.tsx
@@ -16,9 +16,9 @@ import SecondarySortBySelector from '@features/transforms/sorting/SecondarySortB
 import SortBySelector from '@features/transforms/sorting/SortBySelector';
 import SortDirectionSelector from '@features/transforms/sorting/SortDirectionSelector';
 
-import LocaleSeparatorSelector from '../controls/selectors/LocaleSeparatorSelector';
-import PageBrightnessSelector from '../controls/selectors/PageBrightnessSelector';
-import ProfileSelector from '../controls/selectors/ProfileSelector';
+import LocaleSeparatorSelector from './selectors/LocaleSeparatorSelector';
+import PageBrightnessSelector from './selectors/PageBrightnessSelector';
+import ProfileSelector from './selectors/ProfileSelector';
 
 const Settings = (): React.ReactNode => {
   const [isOpen, setIsOpen] = useState(false);
@@ -89,7 +89,7 @@ const Settings = (): React.ReactNode => {
 
           {/* Body */}
           <div style={{ padding: '16px', overflow: 'auto', fontSize: '0.9em' }}>
-            <OptionsPanel title="View options" optionsName="view options">
+            <ViewSettingsPanel title="View options" optionsName="view options">
               {isDataPage && (
                 <>
                   <LimitInput />
@@ -106,7 +106,7 @@ const Settings = (): React.ReactNode => {
               )}
               <SearchBySelector />
               <PageBrightnessSelector />
-            </OptionsPanel>
+            </ViewSettingsPanel>
           </div>
         </div>
       )}
@@ -114,7 +114,7 @@ const Settings = (): React.ReactNode => {
   );
 };
 
-const OptionsPanel: React.FC<
+const ViewSettingsPanel: React.FC<
   React.PropsWithChildren<{
     title: string;
     optionsName: string;

--- a/src/widgets/details/sections/LanguageLocation.tsx
+++ b/src/widgets/details/sections/LanguageLocation.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
 import HoverableButton from '@features/layers/hovercard/HoverableButton';
-import ObjectMap from '@features/map/ObjectMap';
+import ObjectMap from '@features/map/EntityMap';
 import LocalParamsProvider from '@features/params/LocalParamsProvider';
 import { ObjectType, PageParamsOptional, View } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 import Field from '@features/transforms/fields/Field';
-import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
+import useFilteredEntities from '@features/transforms/filtering/useFilteredEntities';
 
 import { LanguageData } from '@entities/language/LanguageTypes';
 
@@ -57,7 +57,7 @@ type MapsProps = {
   updatePageParams: (newParams: PageParamsOptional) => void;
 };
 function Maps({ lang, updatePageParams }: MapsProps) {
-  const descendants = useFilteredObjects({}).filteredObjects.filter(
+  const descendants = useFilteredEntities({}).filteredEntities.filter(
     (l) => l.type == ObjectType.Language && l.latitude && l.longitude,
   );
   return (
@@ -68,7 +68,7 @@ function Maps({ lang, updatePageParams }: MapsProps) {
           Glottolog. This could be the centroid of the area where the language is spoken, or a
           significant location such as a major city where the language has a presence. It does not
           represent all the locations where the language is spoken.
-          <ObjectMap objects={[lang]} maxWidth={400} />
+          <ObjectMap entities={[lang]} maxWidth={400} />
         </>
       ) : null}
       {descendants.length > 0 && (
@@ -93,7 +93,7 @@ function Maps({ lang, updatePageParams }: MapsProps) {
               See the full map in explore panel
             </HoverableButton>
           </div>
-          <ObjectMap objects={descendants} maxWidth={1000} />
+          <ObjectMap entities={descendants} maxWidth={1000} />
         </>
       )}
     </>

--- a/src/widgets/details/sections/TerritoryLocation.tsx
+++ b/src/widgets/details/sections/TerritoryLocation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
+import ObjectMap from '@features/map/EntityMap';
 import MapContainer from '@features/map/MapContainer';
-import ObjectMap from '@features/map/ObjectMap';
 import LocalParamsProvider from '@features/params/LocalParamsProvider';
 import { ObjectType } from '@features/params/PageParamTypes';
 
@@ -31,7 +31,7 @@ const TerritoryLocation: React.FC<{ territory: TerritoryData }> = ({ territory }
       <LocalParamsProvider overrides={{ limit: -1, objectType: ObjectType.Territory }}>
         <MapContainer>
           <ObjectMap
-            objects={[
+            entities={[
               territory,
               ...getTerritoryDescendants(territory, territory.scope === TerritoryScope.Country),
             ]}

--- a/src/widgets/reports/ReportCensusCountries.tsx
+++ b/src/widgets/reports/ReportCensusCountries.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useDataContext } from '@features/data/context/useDataContext';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import { CodeColumn, NameColumn } from '@features/table/CommonColumns';
-import InteractiveObjectTable from '@features/table/InteractiveObjectTable';
+import InteractiveEntityTable from '@features/table/InteractiveEntityTable';
 import TableID from '@features/table/TableID';
 import Field from '@features/transforms/fields/Field';
 
@@ -16,9 +16,9 @@ const ReportCensusCountries: React.FC = () => {
   const { territories } = useDataContext();
 
   return (
-    <InteractiveObjectTable<TerritoryData>
+    <InteractiveEntityTable<TerritoryData>
       tableID={TableID.CountriesWithCensuses}
-      objects={territories}
+      entities={territories}
       columns={[
         CodeColumn,
         NameColumn,

--- a/src/widgets/reports/ReportEntitiesMissingFields.tsx
+++ b/src/widgets/reports/ReportEntitiesMissingFields.tsx
@@ -9,7 +9,7 @@ import usePageParams from '@features/params/usePageParams';
 import Field from '@features/transforms/fields/Field';
 import { getApplicableFields } from '@features/transforms/fields/FieldApplicability';
 import getField from '@features/transforms/fields/getField';
-import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
+import useFilteredEntities from '@features/transforms/filtering/useFilteredEntities';
 
 import { getObjectTypeLabelPlural } from '@entities/lib/getObjectName';
 import { ObjectData } from '@entities/types/DataTypes';
@@ -20,17 +20,17 @@ import DecimalNumber from '@shared/ui/DecimalNumber';
 
 const ReportEntitiesMissingFields: React.FC = () => {
   const { objectType } = usePageParams();
-  const { filteredObjects } = useFilteredObjects({});
+  const { filteredEntities } = useFilteredEntities({});
 
   const fields = getApplicableFields(undefined, objectType).filter((f) => f !== Field.None);
 
-  const countTotal = filteredObjects.length;
+  const countTotal = filteredEntities.length;
   const resultsByField = useMemo(
     () =>
       fields.reduce(
         (acc, field) => {
-          const knownCount = filteredObjects.filter((obj) => getField(obj, field) != null).length;
-          const examples = filteredObjects
+          const knownCount = filteredEntities.filter((obj) => getField(obj, field) != null).length;
+          const examples = filteredEntities
             .filter((obj) => getField(obj, field) == null)
             .slice(0, 4);
           acc[field] = { knownCount, missingCount: countTotal - knownCount, examples };
@@ -38,7 +38,7 @@ const ReportEntitiesMissingFields: React.FC = () => {
         },
         {} as Record<Field, { knownCount: number; missingCount: number; examples: ObjectData[] }>,
       ),
-    [fields, filteredObjects, countTotal],
+    [fields, filteredEntities, countTotal],
   );
 
   return (

--- a/src/widgets/reports/ReportLanguageDescendants.tsx
+++ b/src/widgets/reports/ReportLanguageDescendants.tsx
@@ -4,7 +4,7 @@ import { useDataContext } from '@features/data/context/useDataContext';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import Selector from '@features/params/ui/Selector';
 import { CodeColumn, NameColumn } from '@features/table/CommonColumns';
-import InteractiveObjectTable from '@features/table/InteractiveObjectTable';
+import InteractiveEntityTable from '@features/table/InteractiveEntityTable';
 import TableID from '@features/table/TableID';
 import TableValueType from '@features/table/TableValueType';
 import Field from '@features/transforms/fields/Field';
@@ -56,7 +56,7 @@ const ReportLanguageDescendants: React.FC = () => {
           onChange={(value: number) => setMaximumPercentThreshold(value)}
         />
       </div>
-      <InteractiveObjectTable<LanguageData>
+      <InteractiveEntityTable<LanguageData>
         tableID={TableID.LanguagesLargestDescendant}
         columns={[
           CodeColumn,
@@ -94,7 +94,7 @@ const ReportLanguageDescendants: React.FC = () => {
             field: Field.PopulationPercentInBiggestDescendantLanguage,
           },
         ]}
-        objects={filteredLanguages}
+        entities={filteredLanguages}
       />
     </>
   );

--- a/src/widgets/reports/ReportLanguagesDubious.tsx
+++ b/src/widgets/reports/ReportLanguagesDubious.tsx
@@ -24,7 +24,7 @@ const ReportLanguagesDubious: React.FC = () => {
   const filterBySubstring = getFilterBySubstring();
   const filterByConnections = getFilterByConnections();
   const sortFunction = getSortFunction();
-  const { getCurrentObjects } = usePagination<LanguageData>();
+  const { getCurrentEntities } = usePagination<LanguageData>();
   const languagesFiltered = useMemo(
     () =>
       languagesInSelectedSource
@@ -63,16 +63,16 @@ const ReportLanguagesDubious: React.FC = () => {
       </div>
       <div style={{ marginTop: '1em', marginBottom: '1em' }}>
         <ResponsiveGrid>
-          {getCurrentObjects(languagesFiltered.sort(sortFunction)).map((lang) => {
+          {getCurrentEntities(languagesFiltered.sort(sortFunction)).map((lang) => {
             const codePieces = lang.codeDisplay.split(/-|_/);
-            const relatedObjects = codePieces
+            const relatedEntities = codePieces
               .map(
                 (partialCode) =>
                   getLanguage(partialCode) ??
                   getTerritory(partialCode) ??
                   getWritingSystem(partialCode),
               )
-              .filter((object) => object != null);
+              .filter((entity) => entity != null);
             // TODO if its a language + territory, check if the locale exists
             // TODO check if there is an IANA variant.
             return (
@@ -92,10 +92,10 @@ const ReportLanguagesDubious: React.FC = () => {
                 <div>
                   <label>Potentially related objects:</label>
                   <ul style={{ margin: 0 }}>
-                    {relatedObjects.length > 0 ? (
-                      relatedObjects.map((obj) => (
-                        <li key={obj.ID}>
-                          <HoverableObjectName object={obj} labelSource="code" />
+                    {relatedEntities.length > 0 ? (
+                      relatedEntities.map((entity) => (
+                        <li key={entity.ID}>
+                          <HoverableObjectName object={entity} labelSource="code" />
                         </li>
                       ))
                     ) : (

--- a/src/widgets/reports/ReportLanguagesWithAmbiguousNames.tsx
+++ b/src/widgets/reports/ReportLanguagesWithAmbiguousNames.tsx
@@ -25,7 +25,7 @@ const ReportLanguagesWithAmbiguousNames: React.FC = () => {
   const filterBySubstring = getFilterBySubstring();
   const filterByConnections = getFilterByConnections();
   const sortFunction = getSortFunction();
-  const { getCurrentObjects } = usePagination<[string, LanguageData[]]>();
+  const { getCurrentEntities } = usePagination<[string, LanguageData[]]>();
   const languagesByName = useMemo(() => {
     return languagesInSelectedSource
       .filter(filterBySubstring)
@@ -75,7 +75,7 @@ const ReportLanguagesWithAmbiguousNames: React.FC = () => {
         <LimitInput />
         <PaginationControls itemCount={Object.keys(langsWithDupNames).length} />
       </div>
-      {getCurrentObjects(
+      {getCurrentEntities(
         Object.entries(langsWithDupNames).sort((a, b) => {
           const aData = a[1][0];
           const bData = b[1][0];

--- a/src/widgets/reports/ReportLocaleCitationCompleteness.tsx
+++ b/src/widgets/reports/ReportLocaleCitationCompleteness.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { ObjectType } from '@features/params/PageParamTypes';
-import useFilteredObjects from '@features/transforms/filtering/useFilteredObjects';
+import useFilteredEntities from '@features/transforms/filtering/useFilteredEntities';
 
 import { CensusCollectorType } from '@entities/census/CensusTypes';
 import { LanguageScope } from '@entities/language/LanguageTypes';
@@ -11,7 +11,7 @@ import { getLanguageScopeLabel } from '@strings/LanguageScopeStrings';
 import { getTerritoryScopeLabel } from '@strings/TerritoryScopeStrings';
 
 const ReportLocaleCitationCompleteness: React.FC = () => {
-  const { filteredObjects: filteredLocales } = useFilteredObjects({});
+  const { filteredEntities: filteredLocales } = useFilteredEntities({});
 
   // Count locales with populationCensus
   const locales = filteredLocales.filter((obj) => obj.type === ObjectType.Locale);

--- a/src/widgets/reports/ReportLocalesPotential.tsx
+++ b/src/widgets/reports/ReportLocalesPotential.tsx
@@ -6,7 +6,7 @@ import Selector from '@features/params/ui/Selector';
 import { SelectorDisplay } from '@features/params/ui/SelectorDisplayContext';
 import SelectorLabel from '@features/params/ui/SelectorLabel';
 import usePageParams from '@features/params/usePageParams';
-import InteractiveObjectTable from '@features/table/InteractiveObjectTable';
+import InteractiveEntityTable from '@features/table/InteractiveEntityTable';
 import TableID from '@features/table/TableID';
 import Field from '@features/transforms/fields/Field';
 import { getScopeFilter } from '@features/transforms/filtering/filter';
@@ -147,9 +147,9 @@ const PotentialLocalesTable: React.FC<{
   showRelatedLocales?: boolean;
 }> = ({ locales }) => {
   return (
-    <InteractiveObjectTable<LocaleData>
+    <InteractiveEntityTable<LocaleData>
       tableID={TableID.PotentialLocales}
-      objects={locales}
+      entities={locales}
       columns={[
         {
           key: 'Potential Locale',

--- a/src/widgets/reports/ReportWritingSystemsLanguagesWithout.tsx
+++ b/src/widgets/reports/ReportWritingSystemsLanguagesWithout.tsx
@@ -29,7 +29,7 @@ const ReportWritingSystemsLanguagesWithout: React.FC = () => {
   const filterByScope = getScopeFilter();
   const filterByVitality = getFilterByVitality();
   const sortFunction = getSortFunction();
-  const { getCurrentObjects } = usePagination<LanguageData>();
+  const { getCurrentEntities } = usePagination<LanguageData>();
 
   const languagesFiltered = useMemo(
     () =>
@@ -57,7 +57,7 @@ const ReportWritingSystemsLanguagesWithout: React.FC = () => {
       </div>
       <div style={{ marginTop: '1em', marginBottom: '1em' }}>
         <ResponsiveGrid>
-          {getCurrentObjects(languagesFiltered.sort(sortFunction)).map((lang) => {
+          {getCurrentEntities(languagesFiltered.sort(sortFunction)).map((lang) => {
             const family = getLanguageRootLanguageFamily(lang);
             return (
               <CardInCardList key={lang.ID} object={lang}>

--- a/src/widgets/tables/KeyboardTable.tsx
+++ b/src/widgets/tables/KeyboardTable.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { useDataContext } from '@features/data/context/useDataContext';
-import InteractiveObjectTable from '@features/table/InteractiveObjectTable';
+import InteractiveEntityTable from '@features/table/InteractiveEntityTable';
 import TableID from '@features/table/TableID';
 
 import { KeyboardData } from '@entities/keyboard/KeyboardTypes';
@@ -13,9 +13,9 @@ const KeyboardTable: React.FC = () => {
   const columns = useMemo(() => getKeyboardColumns(), []);
 
   return (
-    <InteractiveObjectTable<KeyboardData>
+    <InteractiveEntityTable<KeyboardData>
       tableID={TableID.Keyboards}
-      objects={keyboards}
+      entities={keyboards}
       columns={columns}
     />
   );

--- a/src/widgets/tables/LanguageTable.tsx
+++ b/src/widgets/tables/LanguageTable.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { useDataContext } from '@features/data/context/useDataContext';
-import InteractiveObjectTable from '@features/table/InteractiveObjectTable';
+import InteractiveEntityTable from '@features/table/InteractiveEntityTable';
 import TableID from '@features/table/TableID';
 
 import { LanguageData } from '@entities/language/LanguageTypes';
@@ -13,9 +13,9 @@ const LanguageTable: React.FC = () => {
   const columns = useMemo(() => getLanguageColumns(), []);
 
   return (
-    <InteractiveObjectTable<LanguageData>
+    <InteractiveEntityTable<LanguageData>
       tableID={TableID.Languages}
-      objects={languagesInSelectedSource}
+      entities={languagesInSelectedSource}
       columns={columns}
     />
   );

--- a/src/widgets/tables/LocaleTable.tsx
+++ b/src/widgets/tables/LocaleTable.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { useDataContext } from '@features/data/context/useDataContext';
 import usePageParams from '@features/params/usePageParams';
-import InteractiveObjectTable from '@features/table/InteractiveObjectTable';
+import InteractiveEntityTable from '@features/table/InteractiveEntityTable';
 import TableID from '@features/table/TableID';
 
 import { LocaleData } from '@entities/locale/LocaleTypes';
@@ -15,9 +15,9 @@ const LocaleTable: React.FC = () => {
   const columns = getLocaleColumns();
 
   return (
-    <InteractiveObjectTable<LocaleData>
+    <InteractiveEntityTable<LocaleData>
       tableID={TableID.Locales}
-      objects={locales.filter((locale) => locale.language?.[languageSource].code != null)}
+      entities={locales.filter((locale) => locale.language?.[languageSource].code != null)}
       columns={columns}
     />
   );

--- a/src/widgets/tables/OrganizationTable.tsx
+++ b/src/widgets/tables/OrganizationTable.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 
 import { useDataContext } from '@features/data/context/useDataContext';
-import InteractiveObjectTable from '@features/table/InteractiveObjectTable';
+import InteractiveEntityTable from '@features/table/InteractiveEntityTable';
 import TableID from '@features/table/TableID';
 
 import { OrganizationData } from '@entities/org/OrganizationTypes';
@@ -13,9 +13,9 @@ const OrganizationTable: React.FC = () => {
   const columns = useMemo(() => getOrganizationColumns(), []);
 
   return (
-    <InteractiveObjectTable<OrganizationData>
+    <InteractiveEntityTable<OrganizationData>
       tableID={TableID.Organizations}
-      objects={organizations}
+      entities={organizations}
       columns={columns}
     />
   );

--- a/src/widgets/tables/TableOfAllCensuses.tsx
+++ b/src/widgets/tables/TableOfAllCensuses.tsx
@@ -1,10 +1,9 @@
 import React, { useMemo } from 'react';
 
 import { useDataContext } from '@features/data/context/useDataContext';
-import InteractiveObjectTable from '@features/table/InteractiveObjectTable';
+import InteractiveEntityTable from '@features/table/InteractiveEntityTable';
 import TableID from '@features/table/TableID';
 
-import { CensusData } from '@entities/census/CensusTypes';
 import { OrganizationData } from '@entities/org/OrganizationTypes';
 
 import getCensusColumns from './columns/CensusColumns';
@@ -22,11 +21,7 @@ const TableOfAllCensuses: React.FC<Props> = ({ organization }) => {
   }, [organization, allCensuses]);
 
   return (
-    <InteractiveObjectTable<CensusData>
-      tableID={TableID.Censuses}
-      objects={censuses}
-      columns={columns}
-    />
+    <InteractiveEntityTable tableID={TableID.Censuses} entities={censuses} columns={columns} />
   );
 };
 

--- a/src/widgets/tables/TableOfLanguagesInCensus.tsx
+++ b/src/widgets/tables/TableOfLanguagesInCensus.tsx
@@ -7,7 +7,7 @@ import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName'
 import { ObjectType, SearchableField } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 import { CodeColumn } from '@features/table/CommonColumns';
-import InteractiveObjectTable from '@features/table/InteractiveObjectTable';
+import InteractiveEntityTable from '@features/table/InteractiveEntityTable';
 import TableID from '@features/table/TableID';
 import TableValueType from '@features/table/TableValueType';
 import Field from '@features/transforms/fields/Field';
@@ -97,9 +97,9 @@ const TableOfLanguagesInCensus: React.FC<Props> = ({ census }) => {
           {langsNotFound.join(', ')}
         </div>
       )}
-      <InteractiveObjectTable<LocaleData>
+      <InteractiveEntityTable
         tableID={TableID.LanguagesInCensus}
-        objects={languagesInCensus}
+        entities={languagesInCensus}
         shouldFilterUsingSearchBar={false}
         columns={[
           CodeColumn,

--- a/src/widgets/tables/TableOfLanguagesInTerritory.tsx
+++ b/src/widgets/tables/TableOfLanguagesInTerritory.tsx
@@ -3,14 +3,13 @@ import React from 'react';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import LocalParamsProvider from '@features/params/LocalParamsProvider';
 import { CodeColumn, EndonymColumn } from '@features/table/CommonColumns';
-import InteractiveObjectTable from '@features/table/InteractiveObjectTable';
+import InteractiveEntityTable from '@features/table/InteractiveEntityTable';
 import TableID from '@features/table/TableID';
 import TableValueType from '@features/table/TableValueType';
 import Field from '@features/transforms/fields/Field';
 
 import LocaleCensusCitation from '@entities/locale/LocaleCensusCitation';
 import { getOfficialLabel } from '@entities/locale/LocaleStrings';
-import { LocaleData } from '@entities/locale/LocaleTypes';
 import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import Deemphasized from '@shared/ui/Deemphasized';
@@ -36,9 +35,9 @@ const TableOfLanguagesInTerritory: React.FC<Props> = ({ territory }) => {
 
   return (
     <LocalParamsProvider overrides={{ territoryScopes: [territory.scope], page: 1, limit: 10 }}>
-      <InteractiveObjectTable<LocaleData>
+      <InteractiveEntityTable
         tableID={TableID.LanguagesInTerritory}
-        objects={locales}
+        entities={locales}
         shouldFilterUsingSearchBar={false}
         columns={[
           CodeColumn,

--- a/src/widgets/tables/TerritoryTable.tsx
+++ b/src/widgets/tables/TerritoryTable.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 
 import { useDataContext } from '@features/data/context/useDataContext';
-import InteractiveObjectTable from '@features/table/InteractiveObjectTable';
+import InteractiveEntityTable from '@features/table/InteractiveEntityTable';
 import TableID from '@features/table/TableID';
-
-import { TerritoryData } from '@entities/territory/TerritoryTypes';
 
 import getTerritoryColumns from './columns/TerritoryColumns';
 
@@ -13,9 +11,9 @@ const TerritoryTable: React.FC = () => {
   const columns = getTerritoryColumns();
 
   return (
-    <InteractiveObjectTable<TerritoryData>
+    <InteractiveEntityTable
       tableID={TableID.Territories}
-      objects={territories}
+      entities={territories}
       columns={columns}
     />
   );

--- a/src/widgets/tables/VariantTable.tsx
+++ b/src/widgets/tables/VariantTable.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 
 import { useDataContext } from '@features/data/context/useDataContext';
-import InteractiveObjectTable from '@features/table/InteractiveObjectTable';
+import InteractiveEntityTable from '@features/table/InteractiveEntityTable';
 import TableID from '@features/table/TableID';
-
-import { VariantData } from '@entities/variant/VariantTypes';
 
 import getVariantColumns from './columns/VariantColumns';
 
@@ -13,11 +11,7 @@ const VariantTable: React.FC = () => {
   const columns = getVariantColumns();
 
   return (
-    <InteractiveObjectTable<VariantData>
-      tableID={TableID.Variants}
-      objects={variants}
-      columns={columns}
-    />
+    <InteractiveEntityTable tableID={TableID.Variants} entities={variants} columns={columns} />
   );
 };
 

--- a/src/widgets/tables/WritingSystemTable.tsx
+++ b/src/widgets/tables/WritingSystemTable.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 
 import { useDataContext } from '@features/data/context/useDataContext';
-import InteractiveObjectTable from '@features/table/InteractiveObjectTable';
+import InteractiveEntityTable from '@features/table/InteractiveEntityTable';
 import TableID from '@features/table/TableID';
-
-import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 import getWritingSystemColumns from './columns/WritingSystemColumns';
 
@@ -13,9 +11,9 @@ const WritingSystemTable: React.FC = () => {
   const columns = getWritingSystemColumns();
 
   return (
-    <InteractiveObjectTable<WritingSystemData>
+    <InteractiveEntityTable
       tableID={TableID.WritingSystems}
-      objects={writingSystems}
+      entities={writingSystems}
       columns={columns}
     />
   );


### PR DESCRIPTION
This renames "objects" to "entities" in many files, particularly around useFilteredObjects and InteractiveObjectTable