### PR TITLE
Variants: Add more information, finish field definitions

### DIFF
--- a/public/data/tc/variant_annotations.tsv
+++ b/public/data/tc/variant_annotations.tsv
@@ -1,4 +1,4 @@
-ID	VariantType	Languoid
+ID	VariantType	EquivalentLanguageCode
 spanglis	d	mis
 unifon	o	
 basiceng	d	mis

--- a/src/entities/language/LanguageTypes.ts
+++ b/src/entities/language/LanguageTypes.ts
@@ -132,6 +132,7 @@ export interface LanguageData extends ObjectBase {
   childLanguages: LanguageData[];
   largestDescendant?: LanguageData; // eg. Indo-European -> English, North Germanic -> Swedish
   variants?: VariantData[]; // links to IANA variants
+  equivalentVariant?: VariantData; // eg. variant "newfound" === languoid "newf1239"
   keyboards?: KeyboardData[];
 
   // Fields that change based on the language source

--- a/src/entities/lib/getObjectMiscFields.ts
+++ b/src/entities/lib/getObjectMiscFields.ts
@@ -1,6 +1,7 @@
 import { getObjectChildren } from '@widgets/pathnav/getParentsAndDescendants';
 
 import { ObjectType } from '@features/params/PageParamTypes';
+import { getVariantsForEntity } from '@features/transforms/fields/getEntityConnection';
 import { sortByPopulation } from '@features/transforms/sorting/sort';
 
 import { LanguageData } from '@entities/language/LanguageTypes';
@@ -228,7 +229,7 @@ export function getCountOfVariants(object: ObjectData): number | undefined {
   const { type } = object;
   switch (type) {
     case ObjectType.Language:
-      return object.variants?.length ?? 0;
+      return getVariantsForEntity(object)?.length ?? 0;
     case ObjectType.Locale:
       return object.variants?.length ?? 0;
     case ObjectType.Keyboard:

--- a/src/entities/lib/getObjectMiscFields.ts
+++ b/src/entities/lib/getObjectMiscFields.ts
@@ -23,7 +23,7 @@ export function getObjectMostImportantLanguageName(object: ObjectData): string |
     case ObjectType.Language:
       return object.nameDisplay;
     case ObjectType.Variant:
-      return object.languages?.[0]?.nameDisplay;
+      return (object.equivalentLanguage ?? object.languages?.[0])?.nameDisplay;
     case ObjectType.WritingSystem:
       return object.languages
         ? Object.values(object.languages).sort(sortByPopulation)[0].nameDisplay

--- a/src/entities/lib/getObjectMiscFields.ts
+++ b/src/entities/lib/getObjectMiscFields.ts
@@ -224,6 +224,27 @@ export function getCountOfCensuses(object: ObjectData): number | undefined {
   }
 }
 
+export function getCountOfVariants(object: ObjectData): number | undefined {
+  const { type } = object;
+  switch (type) {
+    case ObjectType.Language:
+      return object.variants?.length ?? 0;
+    case ObjectType.Locale:
+      return object.variants?.length ?? 0;
+    case ObjectType.Keyboard:
+      return object.variant ? 1 : 0;
+    case ObjectType.Variant:
+      return 1;
+    case ObjectType.Territory:
+    case ObjectType.Census:
+    case ObjectType.WritingSystem:
+    case ObjectType.Org:
+      return undefined;
+    default:
+      enforceExhaustiveSwitch(type);
+  }
+}
+
 // Field.Depth
 export function getDepth(object: ObjectData): number | undefined {
   const { type } = object;

--- a/src/entities/variant/VariantAnnotationTable.tsx
+++ b/src/entities/variant/VariantAnnotationTable.tsx
@@ -64,7 +64,7 @@ const VariantAnnotationTable: React.FC<Props> = ({ variants, addToChangedVariant
           ),
         },
         {
-          key: 'Languoid (Predicted)',
+          key: 'Equivalent Language (Predicted)',
           render: (variant) =>
             variant.variantType !== VariantType.Orthographic && (
               <VariantLanguoidToggle

--- a/src/entities/variant/VariantCard.tsx
+++ b/src/entities/variant/VariantCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import Field from '@features/transforms/fields/Field';
+import { getLanguagesRelevantToObject } from '@features/transforms/filtering/filterByConnections';
 
 import ObjectTitle from '@entities/ui/ObjectTitle';
 
@@ -18,9 +19,10 @@ interface Props {
 }
 
 const VariantCard: React.FC<Props> = ({ data }) => {
-  const { description, languages } = data;
+  const { description } = data;
   const shortDescription =
     description && description.length > 100 ? description.slice(0, 100) + '...' : description;
+  const languages = getLanguagesRelevantToObject(data);
 
   return (
     <div>
@@ -52,9 +54,9 @@ const VariantCard: React.FC<Props> = ({ data }) => {
         field={Field.Language}
         description="Languages that use this variant."
       >
-        {languages && Object.values(languages).length > 0 ? (
+        {languages.length > 0 ? (
           <CommaSeparated>
-            {Object.values(languages).map((lang) => (
+            {languages.map((lang) => (
               <HoverableObjectName key={lang.ID} object={lang} />
             ))}
           </CommaSeparated>

--- a/src/entities/variant/VariantLanguoidToggle.tsx
+++ b/src/entities/variant/VariantLanguoidToggle.tsx
@@ -27,7 +27,7 @@ const VariantLanguoidToggle: React.FC<{
   languageUncoded: LanguageData;
 }> = ({ variant, getPredictedLanguoid, addToChangedVariants, languageUncoded }) => {
   // getPredictedLanguoid is expensive to compute so we want to call it as little as possible and cache the result
-  const saved = variant.languoid;
+  const saved = variant.equivalentLanguage;
   const [predicted, setPredicted] = React.useState<LanguageData | undefined>(languageUncoded);
   const [languageSelectorMode, setLanguageSelectorMode] = React.useState<LanguageSelectorMode>(
     LanguageSelectorMode.Unset,
@@ -46,25 +46,32 @@ const VariantLanguoidToggle: React.FC<{
     switch (languageSelectorMode) {
       case LanguageSelectorMode.Current:
         setLanguageSelectorMode(LanguageSelectorMode.Manual);
-        variant.languoid = undefined;
+        variant.equivalentLanguage = undefined;
         break;
       case LanguageSelectorMode.Manual:
         setLanguageSelectorMode(LanguageSelectorMode.Uncoded);
-        variant.languoid = languageUncoded;
-        variant.languoidCode = languageUncoded.ID;
+        variant.equivalentLanguage = languageUncoded;
+        variant.equivalentLanguageCode = languageUncoded.ID;
         break;
       case LanguageSelectorMode.Uncoded:
         setLanguageSelectorMode(LanguageSelectorMode.Unset);
-        variant.languoid = undefined;
-        variant.languoidCode = undefined;
+        variant.equivalentLanguage = undefined;
+        variant.equivalentLanguageCode = undefined;
         break;
       case LanguageSelectorMode.Unset:
         setLanguageSelectorMode(LanguageSelectorMode.Current);
-        variant.languoid = predicted;
+        variant.equivalentLanguage = predicted;
         break;
     }
     addToChangedVariants(variant);
-  }, [variant.languoid, predicted, languageUncoded, addToChangedVariants, languageSelectorMode]);
+  }, [
+    variant.equivalentLanguage,
+    variant.equivalentLanguageCode,
+    predicted,
+    languageUncoded,
+    addToChangedVariants,
+    languageSelectorMode,
+  ]);
 
   if (variant.variantType === VariantType.Orthographic) return null;
 
@@ -79,7 +86,7 @@ const VariantLanguoidToggle: React.FC<{
           submit={(value) => {
             const id = value.split(/\[|\]/)[1]?.trim(); // In case they paste in something with extra info like "valencia [cat_valencia]"
             if (!id) return;
-            variant.languoidCode = id;
+            variant.equivalentLanguageCode = id;
             addToChangedVariants(variant);
           }}
         />

--- a/src/entities/variant/VariantTypes.ts
+++ b/src/entities/variant/VariantTypes.ts
@@ -27,10 +27,10 @@ export interface VariantData extends ObjectBase {
 
   // Additional data from Translation Commons
   variantType?: VariantType;
-  languoidCode?: LanguageCode; // When this variant has a direct match to a languoid, this is the code of that languoid. For example "valencia" can be expressed as a variant (cat_valencia) OR a languoid from glottolog vale1252
+  equivalentLanguageCode?: LanguageCode; // When this variant has a direct match to a languoid, this is the code of that languoid. For example "valencia" can be expressed as a variant (cat_valencia) OR a languoid from glottolog vale1252
 
   // References to other objects
   languages: LanguageData[]; // The languages that have this variation
   locales: LocaleData[];
-  languoid?: LanguageData; // The precise languoid that matches this variant
+  equivalentLanguage?: LanguageData; // The precise languoid that matches this variant
 }

--- a/src/features/data/load/supplemental/loadVariantAnnotations.ts
+++ b/src/features/data/load/supplemental/loadVariantAnnotations.ts
@@ -22,11 +22,13 @@ export async function loadVariantAnnotations(
         if (!variant || parts.length < 2) return;
         variant.variantType = getVariantTypeFromString(parts[1]);
         if (parts.length >= 3 && parts[2].trim()) {
-          variant.languoidCode = parts[2].trim();
-          variant.languoid = getLanguage(variant.languoidCode);
-          if (variant.languoid && variant.languoidCode !== 'mis') {
-            variant.languoid.variants?.push(variant);
-            variant.languoid.equivalentVariant = variant; // Link back from language to variant for easy access when we only have the language
+          variant.equivalentLanguageCode = parts[2].trim();
+          const equivalentLanguage = getLanguage(variant.equivalentLanguageCode);
+          if (equivalentLanguage && equivalentLanguage.ID !== 'mis') {
+            variant.equivalentLanguage = equivalentLanguage;
+            if (variant.equivalentLanguage) {
+              equivalentLanguage.equivalentVariant = variant; // Link back from language to variant for easy access when we only have the language
+            }
           }
         }
       }),

--- a/src/features/data/load/supplemental/loadVariantAnnotations.ts
+++ b/src/features/data/load/supplemental/loadVariantAnnotations.ts
@@ -26,6 +26,7 @@ export async function loadVariantAnnotations(
           variant.languoid = getLanguage(variant.languoidCode);
           if (variant.languoid && variant.languoidCode !== 'mis') {
             variant.languoid.variants?.push(variant);
+            variant.languoid.equivalentVariant = variant; // Link back from language to variant for easy access when we only have the language
           }
         }
       }),

--- a/src/features/layers/hovercard/HoverableObjectName.tsx
+++ b/src/features/layers/hovercard/HoverableObjectName.tsx
@@ -9,7 +9,13 @@ import HoverableObject from './HoverableObject';
 
 type Props = {
   object?: ObjectData;
-  labelSource?: 'name' | 'code' | 'territory' | 'language' | 'locale without territory';
+  labelSource?:
+    | 'name'
+    | 'code'
+    | 'territory'
+    | 'language'
+    | 'locale without territory'
+    | 'name and code';
   format?: 'text' | 'button';
   style?: React.CSSProperties;
 };
@@ -23,6 +29,9 @@ const HoverableObjectName: React.FC<Props> = ({
   if (!object) return null;
 
   let label = labelSource == 'code' ? object.codeDisplay : object.nameDisplay;
+  if (labelSource == 'name and code') {
+    label = `${object.nameDisplay} [${object.codeDisplay}]`;
+  }
   if (object.type === ObjectType.Locale) {
     if (labelSource == 'language') {
       label = object.language?.nameDisplay ?? object.languageCode;

--- a/src/features/transforms/fields/FieldApplicability.ts
+++ b/src/features/transforms/fields/FieldApplicability.ts
@@ -32,7 +32,7 @@ export const FIELDS_IN_DEVELOPMENT: Field[] = [
  * the number of child language nodes.
  */
 export const UNINTERESTING_FIELD_COMBINATIONS: Record<ObjectType, Field[]> = {
-  [ObjectType.Language]: [Field.Language],
+  [ObjectType.Language]: [Field.Language, Field.VariantType],
   [ObjectType.Territory]: [Field.PopulationDirectlySourced],
   [ObjectType.WritingSystem]: [
     Field.WritingSystem,
@@ -96,6 +96,7 @@ function getSpecificFieldsForObjectType(objectType: ObjectType): Field[] {
         Field.CountOfCountries,
         Field.CountOfChildTerritories,
         Field.CountOfCensuses,
+        Field.CountOfVariants,
 
         Field.Depth,
       ];
@@ -224,6 +225,7 @@ function getSpecificFieldsForObjectType(objectType: ObjectType): Field[] {
         Field.CountOfWritingSystems, // May be poorly defined
         Field.CountOfChildTerritories,
         Field.CountOfCountries, // 0 or 1
+        Field.CountOfVariants,
 
         Field.Date,
         Field.Description,
@@ -248,6 +250,7 @@ function getSpecificFieldsForObjectType(objectType: ObjectType): Field[] {
 
         Field.CountOfWritingSystems, // May be poorly defined
         Field.CountOfCountries, // 0 or 1
+        Field.CountOfVariants,
       ];
     case ObjectType.Org:
       return [

--- a/src/features/transforms/fields/FieldApplicability.ts
+++ b/src/features/transforms/fields/FieldApplicability.ts
@@ -39,7 +39,7 @@ export const UNINTERESTING_FIELD_COMBINATIONS: Record<ObjectType, Field[]> = {
     Field.CountOfWritingSystems,
     Field.PopulationOfDescendants,
   ],
-  [ObjectType.Variant]: [Field.Variant],
+  [ObjectType.Variant]: [Field.Variant, Field.CountOfVariants],
   [ObjectType.Locale]: [],
   [ObjectType.Keyboard]: [],
   [ObjectType.Census]: [

--- a/src/features/transforms/fields/FieldApplicability.ts
+++ b/src/features/transforms/fields/FieldApplicability.ts
@@ -14,7 +14,6 @@ const COMMON_FIELDS: Field[] = [Field.None, Field.Code, Field.Name, Field.Popula
 export const FIELDS_IN_DEVELOPMENT: Field[] = [
   Field.VitalityEthnologueCoarse,
   Field.VitalityEthnologueFine,
-  Field.CountOfVariants,
   Field.SourceType,
   Field.Indigeneity,
   Field.CLDRCoverage,
@@ -88,7 +87,7 @@ function getSpecificFieldsForObjectType(objectType: ObjectType): Field[] {
         Field.WritingSystem,
         Field.Territory,
         Field.Region,
-        // Field.Variant, // Data not available yet
+        Field.Variant,
         Field.SourceForPopulation,
         Field.SourceForLanguage,
 
@@ -149,6 +148,7 @@ function getSpecificFieldsForObjectType(objectType: ObjectType): Field[] {
         Field.LanguageFamily,
         Field.WritingSystem,
         Field.Territory,
+        Field.Variant,
         Field.SourceForPopulation,
         Field.SourceForLanguage,
         // Field.Region, // TODO
@@ -157,7 +157,7 @@ function getSpecificFieldsForObjectType(objectType: ObjectType): Field[] {
         Field.CountOfKeyboards,
         Field.CountOfWritingSystems,
         Field.CountOfCountries,
-        // Field.CountOfVariants, // TODO
+        Field.CountOfVariants,
 
         Field.Depth,
         Field.Literacy,
@@ -341,6 +341,7 @@ function getFieldsForTransform(transform: Transform): Field[] {
         Field.CountOfCountries,
         Field.CountOfChildTerritories,
         Field.CountOfCensuses,
+        Field.CountOfVariants,
 
         Field.PopulationDirectlySourced,
         Field.PercentOfOverallLanguageSpeakers,

--- a/src/features/transforms/fields/getEntityConnection.ts
+++ b/src/features/transforms/fields/getEntityConnection.ts
@@ -5,6 +5,7 @@ import { KeyboardData } from '@entities/keyboard/KeyboardTypes';
 import { LanguageData } from '@entities/language/LanguageTypes';
 import { TerritoryData } from '@entities/territory/TerritoryTypes';
 import { ObjectData } from '@entities/types/DataTypes';
+import { VariantData } from '@entities/variant/VariantTypes';
 import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
 export function getLanguageForEntity(object: ObjectData | undefined): LanguageData | undefined {
@@ -43,5 +44,15 @@ export function getCensusForEntity(object: ObjectData | undefined): CensusData |
 export function getKeyboardForEntity(object: ObjectData | undefined): KeyboardData | undefined {
   if (!object) return undefined;
   if (object.type === ObjectType.Keyboard) return object;
+  return undefined;
+}
+
+export function getVariantForEntity(object: ObjectData | undefined): VariantData | undefined {
+  if (!object) return undefined;
+  if (object.type === ObjectType.Variant) return object;
+  if (object.type === ObjectType.Keyboard) return object.variant;
+
+  if (object.type === ObjectType.Locale && object.variants) return object.variants[0]; // Locales can have multiple variants, but for simplicity we just return the first one here
+  if (object.type === ObjectType.Language) return object.equivalentVariant;
   return undefined;
 }

--- a/src/features/transforms/fields/getEntityConnection.ts
+++ b/src/features/transforms/fields/getEntityConnection.ts
@@ -8,6 +8,8 @@ import { ObjectData } from '@entities/types/DataTypes';
 import { VariantData } from '@entities/variant/VariantTypes';
 import { WritingSystemData } from '@entities/writingsystem/WritingSystemTypes';
 
+import { uniqueBy } from '@shared/lib/setUtils';
+
 export function getLanguageForEntity(object: ObjectData | undefined): LanguageData | undefined {
   if (!object) return undefined;
   if (object.type === ObjectType.Language) return object;
@@ -47,12 +49,15 @@ export function getKeyboardForEntity(object: ObjectData | undefined): KeyboardDa
   return undefined;
 }
 
-export function getVariantForEntity(object: ObjectData | undefined): VariantData | undefined {
+export function getVariantsForEntity(object: ObjectData | undefined): VariantData[] | undefined {
   if (!object) return undefined;
-  if (object.type === ObjectType.Variant) return object;
-  if (object.type === ObjectType.Keyboard) return object.variant;
-
-  if (object.type === ObjectType.Locale && object.variants) return object.variants[0]; // Locales can have multiple variants, but for simplicity we just return the first one here
-  if (object.type === ObjectType.Language) return object.equivalentVariant;
+  if (object.type === ObjectType.Variant) return [object];
+  if (object.type === ObjectType.Keyboard) return object.variant ? [object.variant] : undefined;
+  if (object.type === ObjectType.Locale && object.variants) return object.variants;
+  if (object.type === ObjectType.Language)
+    return uniqueBy(
+      [object.equivalentVariant, ...(object.variants ?? [])].filter((v) => !!v),
+      (v) => v.ID,
+    );
   return undefined;
 }

--- a/src/features/transforms/fields/getField.ts
+++ b/src/features/transforms/fields/getField.ts
@@ -38,7 +38,7 @@ import {
   getKeyboardForEntity,
   getLanguageForEntity,
   getTerritoryForEntity,
-  getVariantForEntity,
+  getVariantsForEntity,
   getWritingSystemForEntity,
 } from './getEntityConnection';
 
@@ -84,7 +84,7 @@ function getField(object: ObjectData, field: Field): string | number | undefined
     case Field.TerritoryScope:
       return getTerritoryForEntity(object)?.scope;
     case Field.VariantType:
-      return getVariantForEntity(object)?.type;
+      return getVariantsForEntity(object)?.[0]?.type;
     case Field.SourceType:
       return getCensusForEntity(object)?.collectorType;
 
@@ -132,7 +132,7 @@ function getField(object: ObjectData, field: Field): string | number | undefined
     case Field.Platform:
       return getKeyboardForEntity(object)?.platform;
     case Field.Variant:
-      return getVariantForEntity(object)?.nameDisplay;
+      return getVariantsForEntity(object)?.[0]?.nameDisplay;
     case Field.SourceForPopulation:
       return getCensusForEntity(object)?.collectorName;
     case Field.SourceForLanguage:

--- a/src/features/transforms/fields/getField.ts
+++ b/src/features/transforms/fields/getField.ts
@@ -5,6 +5,7 @@ import {
   getCountOfCensuses,
   getCountOfKeyboards,
   getCountOfLanguages,
+  getCountOfVariants,
   getCountOfWritingSystems,
   getDepth,
   getObjectDateAsNumber,
@@ -37,6 +38,7 @@ import {
   getKeyboardForEntity,
   getLanguageForEntity,
   getTerritoryForEntity,
+  getVariantForEntity,
   getWritingSystemForEntity,
 } from './getEntityConnection';
 
@@ -82,7 +84,7 @@ function getField(object: ObjectData, field: Field): string | number | undefined
     case Field.TerritoryScope:
       return getTerritoryForEntity(object)?.scope;
     case Field.VariantType:
-      return object.type === ObjectType.Variant ? object.variantType : undefined;
+      return getVariantForEntity(object)?.type;
     case Field.SourceType:
       return getCensusForEntity(object)?.collectorType;
 
@@ -130,7 +132,7 @@ function getField(object: ObjectData, field: Field): string | number | undefined
     case Field.Platform:
       return getKeyboardForEntity(object)?.platform;
     case Field.Variant:
-      return getKeyboardForEntity(object)?.variantCode;
+      return getVariantForEntity(object)?.nameDisplay;
     case Field.SourceForPopulation:
       return getCensusForEntity(object)?.collectorName;
     case Field.SourceForLanguage:
@@ -150,7 +152,7 @@ function getField(object: ObjectData, field: Field): string | number | undefined
     case Field.CountOfCensuses:
       return getCountOfCensuses(object);
     case Field.CountOfVariants:
-      return undefined; // Not yet defined
+      return getCountOfVariants(object);
 
     // Population
     case Field.Population:

--- a/src/features/transforms/fields/getField.ts
+++ b/src/features/transforms/fields/getField.ts
@@ -84,7 +84,7 @@ function getField(object: ObjectData, field: Field): string | number | undefined
     case Field.TerritoryScope:
       return getTerritoryForEntity(object)?.scope;
     case Field.VariantType:
-      return getVariantsForEntity(object)?.[0]?.type;
+      return getVariantsForEntity(object)?.[0]?.variantType;
     case Field.SourceType:
       return getCensusForEntity(object)?.collectorType;
 

--- a/src/features/transforms/filtering/filterByConnections.tsx
+++ b/src/features/transforms/filtering/filterByConnections.tsx
@@ -179,7 +179,10 @@ export function getLanguagesRelevantToObject(object: ObjectData): LanguageData[]
     case ObjectType.WritingSystem:
       return Object.values(object.languages ?? {});
     case ObjectType.Variant:
-      return object.languages ?? [];
+      return uniqueBy(
+        [object.equivalentLanguage, ...(object.languages ?? [])].filter((lang) => !!lang),
+        (lang) => lang.ID,
+      );
     case ObjectType.Keyboard:
       return object.languages ?? [];
     case ObjectType.Org:

--- a/src/widgets/details/LanguageDetails.tsx
+++ b/src/widgets/details/LanguageDetails.tsx
@@ -1,26 +1,12 @@
 import React from 'react';
 
-import { useDataContext } from '@features/data/context/useDataContext';
-import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
-import usePageParams from '@features/params/usePageParams';
-import { getScopeFilter } from '@features/transforms/filtering/filter';
-import { getSortFunction } from '@features/transforms/sorting/sort';
-import TreeListRoot from '@features/treelist/TreeListRoot';
-
 import { LanguageData } from '@entities/language/LanguageTypes';
 import LanguageDetailsVitalityAndViability from '@entities/language/vitality/LanguageDetailsVitalityAndViability';
 import LanguageVitalitySection from '@entities/language/vitality/LanguageVitalitySection';
 
-import DetailsField from '@shared/containers/DetailsField';
-import DetailsSection from '@shared/containers/DetailsSection';
-import CommaSeparated from '@shared/ui/CommaSeparated';
-import Deemphasized from '@shared/ui/Deemphasized';
-
-import { getLanguageTreeNodes } from '../treelists/LanguageHierarchy';
-import { getLocaleTreeNodes } from '../treelists/LocaleHierarchy';
-
 import LanguageAttributes from './sections/LanguageAttributes';
 import LanguageCodes from './sections/LanguageCodes';
+import LanguageConnections from './sections/LanguageConnections';
 import LanguageLocation from './sections/LanguageLocation';
 import LanguageNames from './sections/LanguageNames';
 import LanguagePopulationDetails from './sections/LanguagePopulationDetails';
@@ -85,86 +71,3 @@ const FlexItem: React.FC<{ children: React.ReactNode; flex?: string }> = ({
   children,
   flex = '1 1 200px',
 }) => <div style={{ flex }}>{children}</div>;
-
-const LanguageConnections: React.FC<{ lang: LanguageData }> = ({ lang }) => {
-  const { languageSource } = usePageParams();
-  const { getCLDRLanguage } = useDataContext();
-  const sortFunction = getSortFunction();
-  const filterByScope = getScopeFilter();
-  const { childLanguages, ISO, Glottolog, variants } = lang;
-  const relatedLanguages = (lang.CLDR.languageMatch ?? [])
-    .map((match) => ({
-      match,
-      relatedLanguage: getCLDRLanguage(match.supported),
-    }))
-    .filter(
-      (entry): entry is { match: (typeof entry)['match']; relatedLanguage: LanguageData } =>
-        entry.relatedLanguage != null,
-    );
-
-  return (
-    <DetailsSection title="Connections">
-      {ISO.parentLanguage && (
-        <DetailsField title="ISO group">
-          <HoverableObjectName object={ISO.parentLanguage} />
-        </DetailsField>
-      )}
-      {Glottolog.parentLanguage && (
-        <DetailsField title="Glottolog group">
-          <HoverableObjectName object={Glottolog.parentLanguage} />
-        </DetailsField>
-      )}
-      {variants && variants.length > 0 && (
-        <DetailsField title="Variants">
-          <CommaSeparated>
-            {variants.map((tag) => (
-              <HoverableObjectName key={tag.ID} object={tag} />
-            ))}
-          </CommaSeparated>
-        </DetailsField>
-      )}
-      {relatedLanguages.length > 0 && (
-        <DetailsField title="Related Languages (CLDR)">
-          <CommaSeparated>
-            {relatedLanguages.map(({ match, relatedLanguage }) => (
-              <span key={match.desired + ':' + match.supported + ':' + match.distance}>
-                <HoverableObjectName object={relatedLanguage} /> ({match.distance} CLDR)
-              </span>
-            ))}
-          </CommaSeparated>
-        </DetailsField>
-      )}
-      <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-        <DetailsField title="Descendant Languages">
-          {childLanguages.length > 0 ? (
-            <TreeListRoot rootNodes={getLanguageTreeNodes([lang], languageSource, sortFunction)} />
-          ) : (
-            <div>
-              <Deemphasized>No languages come from this language.</Deemphasized>
-            </div>
-          )}
-        </DetailsField>
-        <DetailsField title="Locales">
-          {lang.locales.length > 0 ? (
-            <TreeListRoot rootNodes={getLocaleTreeNodes([lang], sortFunction, filterByScope)} />
-          ) : (
-            <div>
-              <Deemphasized>There are no recorded locales for this language.</Deemphasized>
-            </div>
-          )}
-        </DetailsField>
-      </div>
-      {lang.keyboards && lang.keyboards.length > 0 && (
-        <DetailsField title="Keyboards">
-          {lang.keyboards && lang.keyboards.length > 0 && (
-            <CommaSeparated>
-              {lang.keyboards.map((keyboard) => (
-                <HoverableObjectName key={keyboard.ID} object={keyboard} />
-              ))}
-            </CommaSeparated>
-          )}
-        </DetailsField>
-      )}
-    </DetailsSection>
-  );
-};

--- a/src/widgets/details/VariantDetails.tsx
+++ b/src/widgets/details/VariantDetails.tsx
@@ -45,9 +45,14 @@ const VariantAttributesSection: React.FC<{ variant: VariantData }> = ({ variant 
 };
 
 const VariantConnectionsSection: React.FC<{ variant: VariantData }> = ({ variant }) => {
-  const { languages, locales, languoid, prefixes } = variant;
+  const { languages, locales, equivalentLanguage, prefixes } = variant;
 
-  if (languages.length === 0 && locales.length === 0 && !languoid && prefixes.length === 0) {
+  if (
+    languages.length === 0 &&
+    locales.length === 0 &&
+    !equivalentLanguage &&
+    prefixes.length === 0
+  ) {
     return null;
   }
 
@@ -76,9 +81,9 @@ const VariantConnectionsSection: React.FC<{ variant: VariantData }> = ({ variant
           </CommaSeparated>
         </DetailsField>
       )}
-      {languoid && (
-        <DetailsField title="Languoid">
-          <HoverableObjectName object={languoid} />
+      {equivalentLanguage && equivalentLanguage.ID !== 'mis' && (
+        <DetailsField title="Equivalent Language">
+          <HoverableObjectName object={equivalentLanguage} />
         </DetailsField>
       )}
     </DetailsSection>

--- a/src/widgets/details/sections/LanguageConnections.tsx
+++ b/src/widgets/details/sections/LanguageConnections.tsx
@@ -72,30 +72,28 @@ const LanguageConnections: React.FC<{ lang: LanguageData }> = ({ lang }) => {
           </CommaSeparated>
         </DetailsField>
       )}
-      <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-        <DetailsField title="Descendant Languages">
-          <TreeOrList
-            treeNodes={
-              childLanguages.length > 0
-                ? getLanguageTreeNodes([lang], languageSource, sortFunction)
-                : []
-            }
-            listNodes={childLanguages.map((l) => (
-              <HoverableObjectName key={l.ID} object={l} />
-            ))}
-            emptyMessage="No languages come from this language."
-          />
-        </DetailsField>
-        <DetailsField title="Locales">
-          <TreeOrList
-            treeNodes={getLocaleTreeNodes([lang], sortFunction, filterByScope)}
-            listNodes={lang.locales?.map((v) => (
-              <HoverableObjectName key={v.ID} object={v} />
-            ))}
-            emptyMessage="No locales available for this language."
-          />
-        </DetailsField>
-      </div>
+      <DetailsField title="Descendant Languages">
+        <TreeOrList
+          treeNodes={
+            childLanguages.length > 0
+              ? getLanguageTreeNodes([lang], languageSource, sortFunction)
+              : []
+          }
+          listNodes={childLanguages.map((l) => (
+            <HoverableObjectName key={l.ID} object={l} />
+          ))}
+          emptyMessage="No languages come from this language."
+        />
+      </DetailsField>
+      <DetailsField title="Locales">
+        <TreeOrList
+          treeNodes={getLocaleTreeNodes([lang], sortFunction, filterByScope)}
+          listNodes={lang.locales?.map((v) => (
+            <HoverableObjectName key={v.ID} object={v} />
+          ))}
+          emptyMessage="No locales available for this language."
+        />
+      </DetailsField>
       {lang.keyboards && lang.keyboards.length > 0 && (
         <DetailsField title="Keyboards">
           {lang.keyboards && lang.keyboards.length > 0 && (

--- a/src/widgets/details/sections/LanguageConnections.tsx
+++ b/src/widgets/details/sections/LanguageConnections.tsx
@@ -87,8 +87,10 @@ const LanguageConnections: React.FC<{ lang: LanguageData }> = ({ lang }) => {
       </DetailsField>
       <DetailsField title="Locales">
         <TreeOrList
-          treeNodes={getLocaleTreeNodes([lang], sortFunction, filterByScope)}
-          listNodes={lang.locales?.map((v) => (
+          treeNodes={
+            lang.locales.length > 0 ? getLocaleTreeNodes([lang], sortFunction, filterByScope) : []
+          }
+          listNodes={(lang.locales ?? []).map((v) => (
             <HoverableObjectName key={v.ID} object={v} />
           ))}
           emptyMessage="No locales available for this language."

--- a/src/widgets/details/sections/LanguageConnections.tsx
+++ b/src/widgets/details/sections/LanguageConnections.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+
+import { getLanguageTreeNodes } from '@widgets/treelists/LanguageHierarchy';
+import { getLocaleTreeNodes } from '@widgets/treelists/LocaleHierarchy';
+
+import { useDataContext } from '@features/data/context/useDataContext';
+import HoverableButton from '@features/layers/hovercard/HoverableButton';
+import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
+import usePageParams from '@features/params/usePageParams';
+import { getScopeFilter } from '@features/transforms/filtering/filter';
+import { getSortFunction } from '@features/transforms/sorting/sort';
+import { TreeNodeData } from '@features/treelist/TreeListNode';
+import TreeListRoot from '@features/treelist/TreeListRoot';
+
+import { LanguageData } from '@entities/language/LanguageTypes';
+
+import DetailsField from '@shared/containers/DetailsField';
+import DetailsSection from '@shared/containers/DetailsSection';
+import CommaSeparated from '@shared/ui/CommaSeparated';
+import Deemphasized from '@shared/ui/Deemphasized';
+
+const LanguageConnections: React.FC<{ lang: LanguageData }> = ({ lang }) => {
+  const { languageSource } = usePageParams();
+  const { getCLDRLanguage } = useDataContext();
+  const sortFunction = getSortFunction();
+  const filterByScope = getScopeFilter();
+  const { childLanguages, ISO, Glottolog, variants, equivalentVariant } = lang;
+  const relatedLanguages = (lang.CLDR.languageMatch ?? [])
+    .map((match) => ({
+      match,
+      relatedLanguage: getCLDRLanguage(match.supported),
+    }))
+    .filter(
+      (entry): entry is { match: (typeof entry)['match']; relatedLanguage: LanguageData } =>
+        entry.relatedLanguage != null,
+    );
+
+  return (
+    <DetailsSection title="Connections">
+      {ISO.parentLanguage && (
+        <DetailsField title="ISO group">
+          <HoverableObjectName object={ISO.parentLanguage} />
+        </DetailsField>
+      )}
+      {Glottolog.parentLanguage && (
+        <DetailsField title="Glottolog group">
+          <HoverableObjectName object={Glottolog.parentLanguage} />
+        </DetailsField>
+      )}
+      {equivalentVariant && (
+        <DetailsField title="Equivalent Variant">
+          <HoverableObjectName object={equivalentVariant} labelSource="name and code" />
+        </DetailsField>
+      )}
+      {variants && variants.length > 0 && (
+        <DetailsField title="Variants">
+          <CommaSeparated>
+            {variants.map((v) => (
+              <HoverableObjectName key={v.ID} object={v} labelSource="name and code" />
+            ))}
+          </CommaSeparated>
+        </DetailsField>
+      )}
+      {relatedLanguages.length > 0 && (
+        <DetailsField title="Related Languages (CLDR)">
+          <CommaSeparated>
+            {relatedLanguages.map(({ match, relatedLanguage }) => (
+              <span key={match.desired + ':' + match.supported + ':' + match.distance}>
+                <HoverableObjectName object={relatedLanguage} /> ({match.distance} CLDR)
+              </span>
+            ))}
+          </CommaSeparated>
+        </DetailsField>
+      )}
+      <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+        <DetailsField title="Descendant Languages">
+          <TreeOrList
+            treeNodes={
+              childLanguages.length > 0
+                ? getLanguageTreeNodes([lang], languageSource, sortFunction)
+                : []
+            }
+            listNodes={childLanguages.map((l) => (
+              <HoverableObjectName key={l.ID} object={l} />
+            ))}
+            emptyMessage="No languages come from this language."
+          />
+        </DetailsField>
+        <DetailsField title="Locales">
+          <TreeOrList
+            treeNodes={getLocaleTreeNodes([lang], sortFunction, filterByScope)}
+            listNodes={lang.locales?.map((v) => (
+              <HoverableObjectName key={v.ID} object={v} />
+            ))}
+            emptyMessage="No locales available for this language."
+          />
+        </DetailsField>
+      </div>
+      {lang.keyboards && lang.keyboards.length > 0 && (
+        <DetailsField title="Keyboards">
+          {lang.keyboards && lang.keyboards.length > 0 && (
+            <CommaSeparated>
+              {lang.keyboards.map((keyboard) => (
+                <HoverableObjectName key={keyboard.ID} object={keyboard} />
+              ))}
+            </CommaSeparated>
+          )}
+        </DetailsField>
+      )}
+    </DetailsSection>
+  );
+};
+
+type TreeOrListProps = {
+  treeNodes: TreeNodeData[];
+  listNodes: React.ReactNode[];
+  emptyMessage: string;
+};
+const TreeOrList: React.FC<TreeOrListProps> = ({ treeNodes, listNodes, emptyMessage }) => {
+  const [viewAsTree, setViewAsTree] = React.useState(false);
+
+  if ((treeNodes.length ?? 0) === 0 && (listNodes.length ?? 0) === 0) {
+    return <Deemphasized>{emptyMessage}</Deemphasized>;
+  }
+
+  return (
+    <>
+      <HoverableButton
+        onClick={() => setViewAsTree((prev) => !prev)}
+        style={{ padding: '0.25em' }}
+        hoverContent={viewAsTree ? 'Click to view as list' : 'Click to view as tree'}
+      >
+        {viewAsTree ? 'as tree' : 'as list'}
+      </HoverableButton>{' '}
+      {viewAsTree ? (
+        <TreeListRoot rootNodes={treeNodes} />
+      ) : (
+        <CommaSeparated>{listNodes}</CommaSeparated>
+      )}
+    </>
+  );
+};
+
+export default LanguageConnections;

--- a/src/widgets/reports/ReportVariantsAnnotationTool.tsx
+++ b/src/widgets/reports/ReportVariantsAnnotationTool.tsx
@@ -47,13 +47,14 @@ const ReportVariantsAnnotationTool: React.FC = () => {
         ].join('\t'),
       )
       .join('\n');
-    navigator.clipboard.writeText('ID\tVariantType\tLanguoid\n' + clipboardText);
+    navigator.clipboard.writeText('ID\tVariantType\tEquivalentLanguageCode\n' + clipboardText);
   }, [variants]);
 
   return (
     <>
       This is a tool to help add annotations to variants, such as classifying it as orthographic or
-      dialectal. For dialects there is also an option to specify which languoid it corresponds to.
+      dialectal. For dialects there is also an option to specify which equivalent language it
+      corresponds to.
       <Selector<IncludeCriteria>
         selectorLabel="Filter variants"
         selected={includeCriteria}

--- a/src/widgets/reports/ReportVariantsAnnotationTool.tsx
+++ b/src/widgets/reports/ReportVariantsAnnotationTool.tsx
@@ -23,7 +23,7 @@ const ReportVariantsAnnotationTool: React.FC = () => {
       variants.filter((variant) => {
         const missingData =
           variant.variantType == null ||
-          (variant.variantType === VariantType.Dialect && variant.languoid == null);
+          (variant.variantType === VariantType.Dialect && variant.equivalentLanguageCode == null);
         if (includeCriteria === IncludeCriteria.Any) return true;
         if (includeCriteria === IncludeCriteria.HasData) return !missingData;
         if (includeCriteria === IncludeCriteria.MissingData) return missingData;
@@ -40,7 +40,11 @@ const ReportVariantsAnnotationTool: React.FC = () => {
       .filter((variant) => variant.variantType != null)
       .sort(sortByPopulation)
       .map((variant) =>
-        [variant.ID, variant.variantType, variant.languoid?.ID ?? variant.languoidCode].join('\t'),
+        [
+          variant.ID,
+          variant.variantType,
+          variant.equivalentLanguage?.ID ?? variant.equivalentLanguageCode,
+        ].join('\t'),
       )
       .join('\n');
     navigator.clipboard.writeText('ID\tVariantType\tLanguoid\n' + clipboardText);

--- a/src/widgets/tables/columns/LanguageColumns.tsx
+++ b/src/widgets/tables/columns/LanguageColumns.tsx
@@ -8,6 +8,7 @@ import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName'
 import TableColumn from '@features/table/TableColumn';
 import TableValueType from '@features/table/TableValueType';
 import Field from '@features/transforms/fields/Field';
+import { getVariantsForEntity } from '@features/transforms/fields/getEntityConnection';
 import { sortByPopulation } from '@features/transforms/sorting/sort';
 
 import {
@@ -119,6 +120,21 @@ function getLanguageColumns(): TableColumn<LanguageData>[] {
       valueType: TableValueType.Count,
       field: Field.Depth,
       columnGroup: 'Relations',
+    },
+    {
+      key: 'Variants',
+      description:
+        'Variations of the language (dialects or spelling conventions) that have been registered with the IANA and given codes.',
+      render: (lang) => (
+        <CommaSeparated limit={1} limitText="short">
+          {getVariantsForEntity(lang)?.map((variant) => (
+            <HoverableObjectName object={variant} key={variant.ID} />
+          ))}
+        </CommaSeparated>
+      ),
+      field: Field.Variant,
+      columnGroup: 'Relations',
+      isInitiallyVisible: false,
     },
     {
       key: 'Countries',

--- a/src/widgets/tables/columns/LanguageVitalityColumns.tsx
+++ b/src/widgets/tables/columns/LanguageVitalityColumns.tsx
@@ -11,12 +11,13 @@ const LanguageVitalityColumns: TableColumn<LanguageData>[] = [
     labelInColumnGroup: 'Metascore',
     render: (lang) => <LanguageVitalityCell lang={lang} src={VitalitySource.Metascore} />,
     field: Field.VitalityMetascore,
-    isInitiallyVisible: true,
+    isInitiallyVisible: false,
   },
   {
     key: 'ISO Status',
     render: (lang) => <LanguageVitalityCell lang={lang} src={VitalitySource.ISO} />,
     field: Field.ISOStatus,
+    isInitiallyVisible: true,
   },
   // {
   //   key: 'Vitality: Ethnologue (Fine)',

--- a/src/widgets/tables/columns/LocaleColumns.tsx
+++ b/src/widgets/tables/columns/LocaleColumns.tsx
@@ -92,6 +92,7 @@ function getLocaleColumns(): TableColumn<LocaleData>[] {
             ))}
           </CommaSeparated>
         ),
+      field: Field.Variant,
       isInitiallyVisible: false,
       columnGroup: 'Linked Data',
     },

--- a/src/widgets/tables/columns/VariantColumns.tsx
+++ b/src/widgets/tables/columns/VariantColumns.tsx
@@ -45,8 +45,8 @@ function getVariantColumns(): TableColumn<VariantData>[] {
     {
       key: 'Equivalent Languoid',
       render: (object) => {
-        if (!object.languoid || object.languoid.ID === 'mis') return null;
-        return <HoverableObjectName object={object.languoid} />;
+        if (!object.equivalentLanguage || object.equivalentLanguage.ID === 'mis') return null;
+        return <HoverableObjectName object={object.equivalentLanguage} />;
       },
       columnGroup: 'Related Objects',
     },

--- a/src/widgets/tables/columns/VariantColumns.tsx
+++ b/src/widgets/tables/columns/VariantColumns.tsx
@@ -39,15 +39,15 @@ function getVariantColumns(): TableColumn<VariantData>[] {
           ))}
         </CommaSeparated>
       ),
-      field: Field.Language,
       columnGroup: 'Related Objects',
     },
     {
-      key: 'Equivalent Languoid',
+      key: 'Equivalent Language',
       render: (object) => {
         if (!object.equivalentLanguage || object.equivalentLanguage.ID === 'mis') return null;
         return <HoverableObjectName object={object.equivalentLanguage} />;
       },
+      field: Field.Language,
       columnGroup: 'Related Objects',
     },
     {


### PR DESCRIPTION
Fixes #511

Summary: The variant fields were not fully hooked up and the count of variants field was not working -- this updates them.

### Changes

- User experience
  - Variant Card shows the equivalent language if possible, also renamed "languoid" to that because its more precise and easier to understand
  - Language and Locale now sortable by # of variants, many things sortable by variant name now (not just the keyboards)
  - Language Detail connections now defaults to showing dialects in a list rather than the tree view.
  - HoverableObjectName can show codes with the name as well
- Logical changes
  - n/a
- Data
  - n/a
- Refactors
  - LanguageConnections split as its own component from LanguageDetails

### Test Plan and Screenshots

How to test the changes in this PR: See examples:

| Page/View with link | Description of Changes | Screenshot Before | Screenshot After |
| ------------------- | ---------------------- | ----------------- | ---------------- |
|[Variant Cards & Details](http://localhost:5173/lang-nav/data?view=Cards&objectType=Variant&objectID=newfound)|"Languoid" replaced by better name. Equivalent language now visible directly in the card|<img width="1323" height="584" alt="Screenshot 2026-06-12 at 18 59 55" src="https://github.com/user-attachments/assets/90bc68da-745e-4498-a804-6250473f5554" />|<img width="1295" height="510" alt="Screenshot 2026-06-12 at 18 56 26" src="https://github.com/user-attachments/assets/9c427902-0840-49b7-8ad1-717889306711" />|
|Language Details Connections|Language & locale list can be compressed now.|<img width="890" height="639" alt="Screenshot 2026-06-12 at 19 00 12" src="https://github.com/user-attachments/assets/8662e2b5-3079-41b6-9cc7-e8207bb6bceb" />|<img width="887" height="378" alt="Screenshot 2026-06-12 at 18 57 33" src="https://github.com/user-attachments/assets/fab283ff-8200-410f-b193-0247d4e97399" />|
|[Language Table](http://localhost:5173/lang-nav/data?view=Table&reportID=7&sortBy=Variant&columns=1-e13wu1z5&languageScopes=3%2C4)|Now sortable by variants and visible as column|<img width="399" height="538" alt="Screenshot 2026-06-12 at 19 00 30" src="https://github.com/user-attachments/assets/be9e9b18-51cb-4ae4-808f-e321c80c91e3" />|<img width="644" height="576" alt="Screenshot 2026-06-12 at 18 57 42" src="https://github.com/user-attachments/assets/63dd8c5b-2352-4ffd-bcfc-881e0a28fbf2" />|





