### PR TITLE
Pinned url param

### DIFF
--- a/src/features/map/EntityMap.tsx
+++ b/src/features/map/EntityMap.tsx
@@ -44,7 +44,7 @@ const ObjectMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
     onZoom: setZoomFactor,
   });
 
-  const { colorBy, objectType } = usePageParams();
+  const { colorBy, objectType, pinned, updatePageParams } = usePageParams();
   const [floatingCards, setFloatingCards] = useState<FloatingCard[]>([]);
   const [mapScale, setMapScale] = useState(1);
 
@@ -79,6 +79,7 @@ const ObjectMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
 
   const openCard = useCallback(
     (entity: DrawableData, clientX: number, clientY: number) => {
+      updatePageParams({ pinned: [...pinned, entity.ID] });
       const rect = contentRef.current?.getBoundingClientRect();
       if (!rect) return;
 
@@ -93,12 +94,16 @@ const ObjectMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
         { id: entity.ID, entity, x, y },
       ]);
     },
-    [contentRef, mapHeight],
+    [contentRef, mapHeight, pinned],
   );
 
-  const closeCard = useCallback((id: string) => {
-    setFloatingCards((prev) => prev.filter((card) => card.id !== id));
-  }, []);
+  const closeCard = useCallback(
+    (id: string) => {
+      updatePageParams({ pinned: pinned.filter((pin) => pin != id) });
+      setFloatingCards((prev) => prev.filter((card) => card.id !== id));
+    },
+    [pinned],
+  );
 
   const handleZoomIn = useCallback(() => {
     zoomIn();

--- a/src/features/map/MapCentroids.tsx
+++ b/src/features/map/MapCentroids.tsx
@@ -10,7 +10,7 @@ import { getFieldString } from '@features/transforms/fields/getFieldString';
 import useScale from '@features/transforms/scales/useScale';
 
 import DrawableData from './DrawableData';
-import { getRobinsonCoordinates } from './getRobinsonCoordinates';
+import { getRobinsonCoordinatesShifted } from './getRobinsonCoordinates';
 import { MAP_ASPECT_RATIO } from './MapConsts';
 
 import './map.css';
@@ -112,10 +112,7 @@ const ObjectNode: React.FC<NodeProps> = ({
   if (object.type !== ObjectType.Language && object.type !== ObjectType.Territory) return null;
   if (object.latitude == null || object.longitude == null) return null;
 
-  const { x, y } = getRobinsonCoordinates(
-    object.latitude,
-    (object.longitude < -169 ? object.longitude + 360 : object.longitude) - 11,
-  );
+  const { x, y } = getRobinsonCoordinatesShifted(object);
 
   const showCircle = !(object.type === ObjectType.Territory && (object?.landArea || 0) >= 20000);
 

--- a/src/features/map/getRobinsonCoordinates.ts
+++ b/src/features/map/getRobinsonCoordinates.ts
@@ -53,4 +53,3 @@ export function getRobinsonCoordinatesShifted(object: DrawableData) {
     (object.longitude < -169 ? object.longitude + 360 : object.longitude) - 11,
   );
 }
-

--- a/src/features/map/getRobinsonCoordinates.ts
+++ b/src/features/map/getRobinsonCoordinates.ts
@@ -1,4 +1,7 @@
 // Official Robinson table from Snyder (1987), for every 5° of latitude.
+
+import DrawableData from './DrawableData';
+
 // Each row: [latitude_deg, x_coeff (A), y_coeff (B)]
 const ROBINSON = [
   [0, 1.0, 0.0],
@@ -40,3 +43,14 @@ export function getRobinsonCoordinates(lat: number, lon: number) {
 
   return { x, y };
 }
+
+// The coordinates are shifted 11 degrees east to center the map.
+export function getRobinsonCoordinatesShifted(object: DrawableData) {
+  if (object == null) return { x: 0, y: 0 };
+  if (object.latitude == null || object.longitude == null) return { x: 0, y: 0 };
+  return getRobinsonCoordinates(
+    object.latitude,
+    (object.longitude < -169 ? object.longitude + 360 : object.longitude) - 11,
+  );
+}
+

--- a/src/features/params/PageParamTypes.tsx
+++ b/src/features/params/PageParamTypes.tsx
@@ -70,6 +70,7 @@ export enum PageParamKey {
   objectID = 'objectID',
   objectType = 'objectType',
   page = 'page',
+  pinned = 'pinned',
   populationMax = 'populationMax',
   populationMin = 'populationMin',
   profile = 'profile',
@@ -105,6 +106,7 @@ export type PageParams = {
   objectID?: string;
   objectType: ObjectType;
   page: number; // 1 indexed
+  pinned: string[];
   populationMax: number;
   populationMin: number;
   profile: ProfileType;
@@ -138,6 +140,7 @@ export type PageParamsOptional = {
   objectID?: string;
   objectType?: ObjectType;
   page?: number;
+  pinned?: string[];
   populationMax?: number;
   populationMin?: number;
   profile?: ProfileType;

--- a/src/features/params/Profiles.tsx
+++ b/src/features/params/Profiles.tsx
@@ -53,6 +53,7 @@ const GLOBAL_DEFAULTS: PageParams = {
   objectID: undefined,
   objectType: ObjectType.Language,
   page: 1,
+  pinned: [],
   profile: ProfileType.LanguageEthusiast,
   populationMax: 10_000_000_000, // higher than the world population
   populationMin: -1, // allow undefined population as well as definite 0s

--- a/src/features/params/getParamsFromURL.ts
+++ b/src/features/params/getParamsFromURL.ts
@@ -145,6 +145,11 @@ export function getParamsFromURL(urlParams: URLSearchParams): PageParamsOptional
         params.fieldFocus = value as Field;
         break;
 
+      //These are string arrays
+      case PageParamKey.pinned:
+        params.pinned = value.split(',');
+        break;
+
       // Freeform strings
       case PageParamKey.objectID:
       case PageParamKey.searchString:


### PR DESCRIPTION
Refs #658

Summary: 
- Added a new `pinned` page parameter to store selected/pinned entity IDs in the URL.
- Updated page param types, defaults, and URL parsing for `pinned`.
- Updated map floating card behavior so opening a card adds its ID to `pinned`, and closing it removes the ID.
- Refactored shifted Robinson coordinate logic into a reusable helper for map centroids.

### Changes

- User experience
    - Opening a map floating card now updates the URL with the selected entity ID in the pinned parameter.
    - Closing a map floating card removes that entity ID from the pinned parameter.
- Logical changes
  - Added pinned to page parameter types as a string array.
  - Added default value for pinned.
  - Added URL parsing support for comma-separated pinned values.
- Refactors
  - Extracted shifted Robinson coordinate logic into getRobinsonCoordinatesShifted.

Out of scope/Future work: Build **floatingCards** directly from the **pinned page param** using **useMemo** so pinned cards can be fully restored from the URL after refresh.

### Screenshots
<img width="1606" height="991" alt="Screenshot 2026-06-13 at 11 23 13 AM" src="https://github.com/user-attachments/assets/fb79004e-1d6a-4e6b-9a8d-06deac48d50d" />

<img width="1553" height="936" alt="Screenshot 2026-06-13 at 11 23 24 AM" src="https://github.com/user-attachments/assets/9d7267c6-8670-4c66-8d19-03d93f16b18b" />
