### PR TITLE
Refactor: Create central PopupCard component

### DIFF
--- a/src/app/component_styles.css
+++ b/src/app/component_styles.css
@@ -64,7 +64,8 @@ button:hover,
 }
 
 button:focus,
-.option:focus {
+.option:focus,
+.ButtonFocused {
   border-color: var(--color-button-hover);
   background: var(--color-button-hover);
 }
@@ -135,7 +136,7 @@ div h3:first-child {
   margin-top: 0px;
 }
 
-.collapsible-report > summary {
+.collapsible-report>summary {
   width: 100%;
   background-color: var(--color-button-secondary);
   padding: 0.5em;

--- a/src/app/component_styles.css
+++ b/src/app/component_styles.css
@@ -66,6 +66,7 @@ button:hover,
 button:focus,
 .option:focus,
 .ButtonFocused {
+  color: var(--color-text-on-color);
   border-color: var(--color-button-hover);
   background: var(--color-button-hover);
 }

--- a/src/app/component_styles.css
+++ b/src/app/component_styles.css
@@ -137,7 +137,7 @@ div h3:first-child {
   margin-top: 0px;
 }
 
-.collapsible-report>summary {
+.collapsible-report > summary {
   width: 100%;
   background-color: var(--color-button-secondary);
   padding: 0.5em;

--- a/src/features/feedback/FeedbackForm.tsx
+++ b/src/features/feedback/FeedbackForm.tsx
@@ -1,18 +1,14 @@
-import { MailIcon, XIcon } from 'lucide-react';
+import { MailIcon } from 'lucide-react';
 import { useState } from 'react';
 
 import HoverableButton from '@features/layers/hovercard/HoverableButton';
-import ZIndex from '@features/layers/ZIndex';
+import PopupCard from '@features/layers/popupcard/PopupCard';
 
 import { getFeedbackEmailBody } from './getFeedbackEmailBody';
 
 const FEEDBACK_EMAIL = 'langnav-outreach@translationcommons.org';
 
-interface Props {
-  onClose: () => void;
-}
-
-export function FeedbackForm({ onClose }: Props) {
+export function FeedbackForm() {
   const [type, setType] = useState('General feedback');
   const [message, setMessage] = useState('');
 
@@ -29,101 +25,68 @@ export function FeedbackForm({ onClose }: Props) {
   };
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        top: '0.75em',
-        right: '0.75em',
-        zIndex: ZIndex.FeedbackForm,
-        width: '20em', // 320px
-        backgroundColor: 'var(--color-background)',
-        borderRadius: '0.5em',
-        boxShadow: '0 4px 12px var(--color-shadow)',
-        color: 'var(--color-text)',
-      }}
-    >
-      {/* Header */}
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          padding: '0.5em 1em',
-          borderBottom: '1px solid var(--color-shadow)',
-        }}
-      >
-        <span style={{ fontWeight: 600 }}>Send feedback</span>
-        <HoverableButton onClick={onClose} style={{ padding: '0.5em' }}>
-          <XIcon size="1em" display="block" />
-        </HoverableButton>
-      </div>
+    <PopupCard
+      buttonLabel="Feedback"
+      buttonClassName="primary"
+      description="Submit feedback to the LangNav team"
+      title="Send feedback"
+      body={
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '1em', width: '300px' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25em' }}>
+            <label style={{ fontWeight: 500, color: 'var(--color-text-secondary)' }}>Type</label>
+            <select
+              value={type}
+              onChange={(e) => setType(e.target.value)}
+              style={{
+                padding: '0.5em',
+                border: '1px solid var(--color-shadow)',
+                borderRadius: '0.5em',
+                color: 'var(--color-text)',
+                backgroundColor: 'var(--color-background)',
+              }}
+            >
+              <option>Bug</option>
+              <option>Data issue</option>
+              <option>Feature request</option>
+              <option>General feedback</option>
+            </select>
+          </div>
 
-      {/* Body */}
-      <div style={{ padding: '16px', display: 'flex', flexDirection: 'column', gap: 12 }}>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-          <label style={{ fontWeight: 500, color: 'var(--color-text-secondary)' }}>Type</label>
-          <select
-            value={type}
-            onChange={(e) => setType(e.target.value)}
-            style={{
-              padding: '0.5em',
-              border: '1px solid var(--color-shadow)',
-              borderRadius: '0.5em',
-              color: 'var(--color-text)',
-              backgroundColor: 'var(--color-background)',
-            }}
-          >
-            <option>Bug</option>
-            <option>Data issue</option>
-            <option>Feature request</option>
-            <option>General feedback</option>
-          </select>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25em' }}>
+            <label style={{ fontWeight: 500, color: 'var(--color-text-secondary)' }}>Message</label>
+            <textarea
+              rows={5}
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              placeholder="What did you notice or suggest?"
+              style={{
+                padding: '0.5em',
+                color: 'var(--color-text)',
+                backgroundColor: 'var(--color-background)',
+                border: '1px solid var(--color-shadow)',
+                borderRadius: '0.5em',
+                resize: 'vertical',
+              }}
+            />
+          </div>
         </div>
-
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-          <label style={{ fontWeight: 500, color: 'var(--color-text-secondary)' }}>Message</label>
-          <textarea
-            rows={5}
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
-            placeholder="What did you notice or suggest?"
-            style={{
-              padding: '0.5em',
-              color: 'var(--color-text)',
-              backgroundColor: 'var(--color-background)',
-              border: '1px solid var(--color-shadow)',
-              borderRadius: '0.5em',
-              resize: 'vertical',
-            }}
-          />
-        </div>
-      </div>
-
-      {/* Footer */}
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'flex-end',
-          gap: '0.5em',
-          padding: '.5em 1em',
-          borderTop: '1px solid var(--color-shadow)',
-        }}
-      >
+      }
+      ctas={[
         <HoverableButton
-          onClick={onClose}
-          style={{ backgroundColor: 'var(--color-button-secondary)' }}
-        >
-          Cancel
-        </HoverableButton>
-        <HoverableButton
-          onClick={handleSubmit}
-          disabled={!message.trim()}
+          key="submit"
+          role="submit"
+          className={message.trim() ? 'primary' : ''}
+          onClick={() => message.trim() && handleSubmit()}
+          hoverContent={
+            message.trim()
+              ? 'Open your email client to send this feedback'
+              : 'Please enter a message'
+          }
           style={{
             backgroundColor: message.trim()
               ? 'var(--color-button-primary)'
               : 'var(--color-button-secondary)',
             color: message.trim() ? 'var(--color-text-on-color)' : 'var(--color-text-secondary)',
-            cursor: !message.trim() ? 'not-allowed' : undefined,
             display: 'flex',
             alignItems: 'center',
             gap: '0.5em',
@@ -131,8 +94,8 @@ export function FeedbackForm({ onClose }: Props) {
         >
           Open email
           <MailIcon display="block" size="1em" />
-        </HoverableButton>
-      </div>
-    </div>
+        </HoverableButton>,
+      ]}
+    />
   );
 }

--- a/src/features/feedback/FeedbackForm.tsx
+++ b/src/features/feedback/FeedbackForm.tsx
@@ -75,7 +75,7 @@ export function FeedbackForm() {
       ctas={[
         <HoverableButton
           key="submit"
-          role="submit"
+          buttonType="submit"
           className={message.trim() ? 'primary' : ''}
           onClick={() => message.trim() && handleSubmit()}
           hoverContent={

--- a/src/features/feedback/FeedbackForm.tsx
+++ b/src/features/feedback/FeedbackForm.tsx
@@ -28,6 +28,7 @@ export function FeedbackForm() {
     <PopupCard
       buttonLabel="Feedback"
       buttonClassName="primary"
+      buttonStyle={{ padding: '0.5em' }}
       description="Submit feedback to the LangNav team"
       title="Send feedback"
       body={

--- a/src/features/layers/ZIndex.ts
+++ b/src/features/layers/ZIndex.ts
@@ -6,7 +6,6 @@ const ZIndex = {
   Sidepanel: 40,
   Modal: 50, // in CSS
   PopupCard: 60,
-  FeedbackForm: 100,
   HoverCard: 101,
   Dropdown: 110,
   HoverCardInDropdown: 111,

--- a/src/features/layers/ZIndex.ts
+++ b/src/features/layers/ZIndex.ts
@@ -4,8 +4,8 @@ const ZIndex = {
   MapZoomControls: 5,
 
   Sidepanel: 40,
+  PopupCard: 45,
   Modal: 50, // in CSS
-  PopupCard: 60,
   HoverCard: 101,
   Dropdown: 110,
   HoverCardInDropdown: 111,

--- a/src/features/layers/ZIndex.ts
+++ b/src/features/layers/ZIndex.ts
@@ -5,6 +5,7 @@ const ZIndex = {
 
   Sidepanel: 40,
   Modal: 50, // in CSS
+  PopupCard: 60,
   FeedbackForm: 100,
   HoverCard: 101,
   Dropdown: 110,

--- a/src/features/layers/hovercard/HoverCardContext.tsx
+++ b/src/features/layers/hovercard/HoverCardContext.tsx
@@ -1,7 +1,7 @@
 import { createContext } from 'react';
 
 type HoverCardContextType = {
-  showHoverCard: (content: React.ReactNode, x: number, y: number) => void;
+  showHoverCard: (content: React.ReactNode | (() => React.ReactNode), x: number, y: number) => void;
   hideHoverCard: () => void;
   onMouseLeaveTriggeringElement: () => void; // Callback when the mouse leaves the triggering element
 };

--- a/src/features/layers/hovercard/HoverCardProvider.tsx
+++ b/src/features/layers/hovercard/HoverCardProvider.tsx
@@ -6,7 +6,7 @@ import EmptyHoverCardProvider from './EmptyHoverCardProvider';
 import HoverCardContext from './HoverCardContext';
 
 type HoverCardData = {
-  content: React.ReactNode;
+  content: React.ReactNode | (() => React.ReactNode);
   x: number;
   y: number;
   visible: boolean;
@@ -24,10 +24,13 @@ const HoverCardProvider: React.FC<{ children: React.ReactNode; zIndex?: number }
   });
   const [leftTriggeringElement, setLeftTriggeringElement] = useState<boolean>(false);
 
-  const showHoverCard = useCallback((content: React.ReactNode, x: number, y: number) => {
-    setLeftTriggeringElement(false);
-    setHoverCard({ content, x, y, visible: true });
-  }, []);
+  const showHoverCard = useCallback(
+    (content: React.ReactNode | (() => React.ReactNode), x: number, y: number) => {
+      setLeftTriggeringElement(false);
+      setHoverCard({ content, x, y, visible: true });
+    },
+    [],
+  );
 
   const hideHoverCard = useCallback(() => {
     setHoverCard((prev) => ({ ...prev, visible: false }));
@@ -117,7 +120,7 @@ const HoverCardProvider: React.FC<{ children: React.ReactNode; zIndex?: number }
             left: hoverCard.x + 5,
           }}
         >
-          {hoverCard.content}
+          {typeof hoverCard.content === 'function' ? hoverCard.content() : hoverCard.content}
         </div>
       </EmptyHoverCardProvider>
     </HoverCardContext.Provider>

--- a/src/features/layers/hovercard/HoverableButton.tsx
+++ b/src/features/layers/hovercard/HoverableButton.tsx
@@ -64,6 +64,7 @@ const HoverableButton: React.FC<HoverableProps> = ({
           onClick();
         }
       }}
+      role={role}
       style={{
         cursor: onClick ? 'pointer' : 'auto',
         ...style,

--- a/src/features/layers/modal/Modal.tsx
+++ b/src/features/layers/modal/Modal.tsx
@@ -1,0 +1,44 @@
+import React, { ReactNode, useCallback, useState } from 'react';
+
+import HoverableButton from '@features/layers/hovercard/HoverableButton';
+import ModalCard from '@features/layers/modal/ModalCard';
+
+type Props = {
+  buttonLabel: ReactNode;
+  description: ReactNode;
+  buttonClassName?: string;
+  title: ReactNode;
+  body: ReactNode | (() => ReactNode);
+};
+
+const Modal: React.FC<Props> = ({ body, buttonLabel, description, buttonClassName, title }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+
+  return (
+    <>
+      <HoverableButton
+        className={buttonClassName}
+        onClick={open}
+        hoverContent={description}
+        style={{ padding: '0.25em 0.5em' }}
+      >
+        {buttonLabel}
+      </HoverableButton>
+
+      {isOpen && (
+        <ModalCard
+          isOpen={isOpen}
+          onClose={close}
+          title={title}
+          bodyStyle={{ width: '90vw', maxWidth: '85em', padding: '1em' }}
+        >
+          {typeof body === 'function' ? body() : body}
+        </ModalCard>
+      )}
+    </>
+  );
+};
+
+export default Modal;

--- a/src/features/layers/modal/ModalButton.tsx
+++ b/src/features/layers/modal/ModalButton.tsx
@@ -5,13 +5,19 @@ import ModalCard from '@features/layers/modal/ModalCard';
 
 type Props = {
   buttonLabel: ReactNode;
-  description: ReactNode;
+  description?: ReactNode;
   buttonClassName?: string;
   title: ReactNode;
   body: ReactNode | (() => ReactNode);
 };
 
-const Modal: React.FC<Props> = ({ body, buttonLabel, description, buttonClassName, title }) => {
+const ModalButton: React.FC<Props> = ({
+  body,
+  buttonLabel,
+  description,
+  buttonClassName,
+  title,
+}) => {
   const [isOpen, setIsOpen] = useState(false);
   const open = useCallback(() => setIsOpen(true), []);
   const close = useCallback(() => setIsOpen(false), []);
@@ -29,7 +35,6 @@ const Modal: React.FC<Props> = ({ body, buttonLabel, description, buttonClassNam
 
       {isOpen && (
         <ModalCard
-          isOpen={isOpen}
           onClose={close}
           title={title}
           bodyStyle={{ width: '90vw', maxWidth: '85em', padding: '1em' }}
@@ -41,4 +46,4 @@ const Modal: React.FC<Props> = ({ body, buttonLabel, description, buttonClassNam
   );
 };
 
-export default Modal;
+export default ModalButton;

--- a/src/features/layers/modal/ModalCard.tsx
+++ b/src/features/layers/modal/ModalCard.tsx
@@ -6,7 +6,6 @@ import HoverableButton from '../hovercard/HoverableButton';
 import './modal.css';
 
 interface ModalProps {
-  isOpen: boolean;
   onClose: () => void;
   title: React.ReactNode;
   children: React.ReactNode;

--- a/src/features/layers/modal/ModalCard.tsx
+++ b/src/features/layers/modal/ModalCard.tsx
@@ -13,12 +13,11 @@ interface ModalProps {
   bodyStyle?: React.CSSProperties;
 }
 
-const ViewModal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, bodyStyle }) => {
+const ModalCard: React.FC<ModalProps> = ({ onClose, title, children, bodyStyle }) => {
   // Turning off because of conflicts with hovercards that technically are outside of the modal
   // const modalRef = useClickOutside(onClose);
 
   useEffect(() => {
-    if (!isOpen) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         onClose();
@@ -26,9 +25,7 @@ const ViewModal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, bod
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, onClose]);
-
-  if (!isOpen) return <></>;
+  }, [onClose]);
 
   return (
     <div className="ModalOverlay">
@@ -47,4 +44,4 @@ const ViewModal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, bod
   );
 };
 
-export default ViewModal;
+export default ModalCard;

--- a/src/features/layers/modal/__tests__/ModalButton.test.tsx
+++ b/src/features/layers/modal/__tests__/ModalButton.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import ModalButton from '../ModalButton';
+
+vi.mock('@features/layers/hovercard/useHoverCard', () => ({
+  default: vi.fn().mockReturnValue({ showHoverCard: vi.fn(), hideHoverCard: vi.fn() }),
+}));
+
+describe('ModalButton', () => {
+  it('renders a button but not the modal if it has not been opened', () => {
+    render(
+      <ModalButton buttonLabel="Open Modal" title="Modal title" body={<p>Modal content</p>} />,
+    );
+
+    expect(screen.getByText('Open Modal')).toBeInTheDocument();
+    expect(screen.queryByText('Modal title')).not.toBeInTheDocument();
+    expect(screen.queryByText('Modal content')).not.toBeInTheDocument();
+  });
+
+  it('opens the modal when the button is clicked', () => {
+    render(
+      <ModalButton buttonLabel="Open Modal" title="Modal title" body={<p>Modal content</p>} />,
+    );
+
+    expect(screen.getByText('Open Modal')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Open Modal'));
+    expect(screen.getByText('Modal title')).toBeInTheDocument();
+    expect(screen.getByText('Modal content')).toBeInTheDocument();
+  });
+});

--- a/src/features/layers/modal/__tests__/ModalCard.test.tsx
+++ b/src/features/layers/modal/__tests__/ModalCard.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import ViewModal from '../ModalCard';
+import ModalCard from '../ModalCard';
 
 vi.mock('@features/layers/hovercard/useHoverCard', () => ({
   default: vi.fn().mockReturnValue({ showHoverCard: vi.fn(), hideHoverCard: vi.fn() }),
@@ -12,23 +12,12 @@ beforeEach(() => {
   cleanup();
 });
 
-describe('ViewModal', () => {
-  it('renders nothing when isOpen is false', () => {
+describe('ModalCard', () => {
+  it('renders title and children', () => {
     render(
-      <ViewModal isOpen={false} onClose={vi.fn()} title="Test Modal">
+      <ModalCard onClose={vi.fn()} title="Test Modal">
         <p>Modal content</p>
-      </ViewModal>,
-    );
-
-    expect(screen.queryByText('Test Modal')).toBeNull();
-    expect(screen.queryByText('Modal content')).toBeNull();
-  });
-
-  it('renders title and children when isOpen is true', () => {
-    render(
-      <ViewModal isOpen={true} onClose={vi.fn()} title="Test Modal">
-        <p>Modal content</p>
-      </ViewModal>,
+      </ModalCard>,
     );
 
     expect(screen.getByText('Test Modal')).toBeTruthy();
@@ -37,9 +26,9 @@ describe('ViewModal', () => {
 
   it('renders with aria-modal and dialog role', () => {
     render(
-      <ViewModal isOpen={true} onClose={vi.fn()} title="Test Modal">
+      <ModalCard onClose={vi.fn()} title="Test Modal">
         <p>Content</p>
-      </ViewModal>,
+      </ModalCard>,
     );
 
     const dialog = screen.getByRole('dialog');
@@ -50,9 +39,9 @@ describe('ViewModal', () => {
   it('calls onClose when the close button is clicked', () => {
     const onClose = vi.fn();
     render(
-      <ViewModal isOpen={true} onClose={onClose} title="Test Modal">
+      <ModalCard onClose={onClose} title="Test Modal">
         <p>Content</p>
-      </ViewModal>,
+      </ModalCard>,
     );
 
     const closeButton = screen.getByRole('button');
@@ -63,9 +52,9 @@ describe('ViewModal', () => {
   it('calls onClose when Escape key is pressed', () => {
     const onClose = vi.fn();
     render(
-      <ViewModal isOpen={true} onClose={onClose} title="Test Modal">
+      <ModalCard onClose={onClose} title="Test Modal">
         <p>Content</p>
-      </ViewModal>,
+      </ModalCard>,
     );
 
     fireEvent.keyDown(document, { key: 'Escape' });
@@ -76,9 +65,9 @@ describe('ViewModal', () => {
   // it('calls onClose when clicking outside the modal', () => {
   //   const onClose = vi.fn();
   //   render(
-  //     <ViewModal isOpen={true} onClose={onClose} title="Test Modal">
+  //     <ModalCard onClose={onClose} title="Test Modal">
   //       <p>Content</p>
-  //     </ViewModal>,
+  //     </ModalCard>,
   //   );
 
   //   // mousedown on the overlay (outside the modal)
@@ -89,14 +78,13 @@ describe('ViewModal', () => {
 
   it('applies bodyStyle to the modal body', () => {
     render(
-      <ViewModal
-        isOpen={true}
+      <ModalCard
         onClose={vi.fn()}
         title="Test Modal"
         bodyStyle={{ maxWidth: 'none', padding: '2em' }}
       >
         <p>Content</p>
-      </ViewModal>,
+      </ModalCard>,
     );
 
     const body = screen.getByText('Content').closest('.ModalBody') as HTMLElement;

--- a/src/features/layers/modal/__tests__/ViewModal.test.tsx
+++ b/src/features/layers/modal/__tests__/ViewModal.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import ViewModal from '../ViewModal';
+import ViewModal from '../ModalCard';
 
 vi.mock('@features/layers/hovercard/useHoverCard', () => ({
   default: vi.fn().mockReturnValue({ showHoverCard: vi.fn(), hideHoverCard: vi.fn() }),

--- a/src/features/layers/popupcard/PopupCard.tsx
+++ b/src/features/layers/popupcard/PopupCard.tsx
@@ -7,9 +7,13 @@ import ZIndex from '../ZIndex';
 import './popupcard.css';
 
 type Props = {
+  // CTA
   buttonLabel: ReactNode;
-  description: ReactNode;
   buttonClassName?: string;
+  buttonStyle?: React.CSSProperties;
+  description?: ReactNode;
+
+  // Card content
   title: ReactNode;
   body: ReactNode | (() => ReactNode);
   ctas?: ReactNode[];
@@ -23,6 +27,7 @@ type Props = {
 const PopupCard: React.FC<Props> = ({
   buttonLabel,
   buttonClassName,
+  buttonStyle,
   description,
   title,
   body,
@@ -60,6 +65,7 @@ const PopupCard: React.FC<Props> = ({
         }
         hoverContent={description}
         onClick={() => setIsOpen((prev) => !prev)}
+        style={buttonStyle}
       >
         {buttonLabel}
       </HoverableButton>
@@ -68,21 +74,11 @@ const PopupCard: React.FC<Props> = ({
           <div className="popupCardHeader">
             <div className="popupCardTitle">{title}</div>
             <HoverableButton onClick={closeCard} style={{ padding: '0.5em' }}>
-              <XIcon size="1em" display="block" />
+              <XIcon size="1em" display="block" aria-label="Close" />
             </HoverableButton>
           </div>
           <div className="popupCardBody">{typeof body === 'function' ? body() : body}</div>
-          {ctas.length > 0 && (
-            <div className="popupCardFooter">
-              {ctas}
-              {/* {[
-                ...ctas,
-                <HoverableButton key="close" onClick={closeCard}>
-                    Close
-                </HoverableButton>,
-                ]} */}
-            </div>
-          )}
+          {ctas.length > 0 && <div className="popupCardFooter">{ctas}</div>}
         </div>
       )}
     </div>

--- a/src/features/layers/popupcard/PopupCard.tsx
+++ b/src/features/layers/popupcard/PopupCard.tsx
@@ -1,0 +1,92 @@
+import { XIcon } from 'lucide-react';
+import React, { ReactNode, useCallback, useEffect, useState } from 'react';
+
+import HoverableButton from '../hovercard/HoverableButton';
+import ZIndex from '../ZIndex';
+
+import './popupcard.css';
+
+type Props = {
+  buttonLabel: ReactNode;
+  description: ReactNode;
+  buttonClassName?: string;
+  title: ReactNode;
+  body: ReactNode | (() => ReactNode);
+  ctas?: ReactNode[];
+};
+
+/**
+ * Opens a card that displays on the page and does not close when the user moves their mouse.
+ * Used for displaying more complex information that the user may want to interact with, such
+ * as a list of view options.
+ */
+const PopupCard: React.FC<Props> = ({
+  buttonLabel,
+  buttonClassName,
+  description,
+  title,
+  body,
+  ctas = [],
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const closeCard = useCallback(() => setIsOpen(false), []);
+
+  // Close the dropdown when the route changes
+  useEffect(() => {
+    setIsOpen(false);
+  }, [location.pathname]);
+
+  // Close the dropdown when the user presses the Escape key
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closeCard();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, closeCard]);
+
+  // Not done: Close the dropdown when the user clicks outside of it.
+  // This is tricky because clicking on a nested card in the dropdown (particularly
+  // a hovercard) should not close the dropdown.)
+
+  return (
+    <div className="popupContainer">
+      <HoverableButton
+        className={
+          'popupToggle' +
+          (isOpen ? ' ButtonFocused' : '') +
+          (buttonClassName ? ` ${buttonClassName}` : '')
+        }
+        hoverContent={description}
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        {buttonLabel}
+      </HoverableButton>
+      {isOpen && (
+        <div className="popupCard" role="dialog" style={{ zIndex: ZIndex.PopupCard }}>
+          <div className="popupCardHeader">
+            <div className="popupCardTitle">{title}</div>
+            <HoverableButton onClick={closeCard} style={{ padding: '0.5em' }}>
+              <XIcon size="1em" display="block" />
+            </HoverableButton>
+          </div>
+          <div className="popupCardBody">{typeof body === 'function' ? body() : body}</div>
+          {ctas.length > 0 && (
+            <div className="popupCardFooter">
+              {ctas}
+              {/* {[
+                ...ctas,
+                <HoverableButton key="close" onClick={closeCard}>
+                    Close
+                </HoverableButton>,
+                ]} */}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PopupCard;

--- a/src/features/layers/popupcard/__tests__/PopupCard.test.tsx
+++ b/src/features/layers/popupcard/__tests__/PopupCard.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import PopupCard from '../PopupCard';
+
+vi.mock('@features/layers/hovercard/useHoverCard', () => ({
+  default: vi.fn().mockReturnValue({ showHoverCard: vi.fn(), hideHoverCard: vi.fn() }),
+}));
+
+describe('PopupCard', () => {
+  it('renders the button label', () => {
+    render(<PopupCard buttonLabel="Open Popup" title="Popup Title" body={<p>Popup content</p>} />);
+    expect(screen.getByText('Open Popup')).toBeInTheDocument();
+  });
+
+  it('opens the popup when the button is clicked', () => {
+    render(<PopupCard buttonLabel="Open Popup" title="Popup Title" body={<p>Popup content</p>} />);
+    fireEvent.click(screen.getByText('Open Popup'));
+    expect(screen.getByText('Popup Title')).toBeInTheDocument();
+    expect(screen.getByText('Popup content')).toBeInTheDocument();
+  });
+
+  it('closes the popup when the Escape key is pressed', () => {
+    render(<PopupCard buttonLabel="Open Popup" title="Popup Title" body={<p>Popup content</p>} />);
+    fireEvent.click(screen.getByText('Open Popup'));
+    expect(screen.getByText('Popup Title')).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByText('Popup Title')).not.toBeInTheDocument();
+  });
+
+  it('closes the popup when the close button is clicked', () => {
+    render(<PopupCard buttonLabel="Open Popup" title="Popup Title" body={<p>Popup content</p>} />);
+    fireEvent.click(screen.getByText('Open Popup'));
+    expect(screen.getByText('Popup Title')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Close'));
+    expect(screen.queryByText('Popup Title')).not.toBeInTheDocument();
+  });
+
+  it('closes the popup when the opening button is clicked again', () => {
+    render(<PopupCard buttonLabel="Open Popup" title="Popup Title" body={<p>Popup content</p>} />);
+    fireEvent.click(screen.getByText('Open Popup'));
+    expect(screen.getByText('Popup Title')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Open Popup'));
+    expect(screen.queryByText('Popup Title')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/layers/popupcard/popupcard.css
+++ b/src/features/layers/popupcard/popupcard.css
@@ -1,0 +1,42 @@
+.popupContainer {
+    position: relative;
+}
+
+.popupToggle {
+    /* Optional: Add styles for the button that opens the popup */
+}
+
+.popupCard {
+    position: absolute;
+    right: 0;
+
+    color: var(--color-text);
+    background-color: var(--color-background);
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    box-shadow: 0px 4px 8px var(--color-shadow);
+}
+
+.popupCardHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5em 1em;
+    border-bottom: 1px solid var(--color-shadow);
+}
+
+.popupCardTitle {
+    font-weight: 600;
+}
+
+.popupCardBody {
+    padding: 1em;
+    font-size: 0.9em;
+}
+
+.popupCardFooter {
+    display: flex;
+    gap: 0.5em;
+    padding: 0.5em;
+    border-top: 1px solid var(--color-shadow);
+}

--- a/src/features/layers/popupcard/popupcard.css
+++ b/src/features/layers/popupcard/popupcard.css
@@ -1,5 +1,6 @@
 .popupContainer {
     position: relative;
+    width: fit-content;
 }
 
 .popupToggle {

--- a/src/features/layers/popupcard/popupcard.css
+++ b/src/features/layers/popupcard/popupcard.css
@@ -1,43 +1,43 @@
 .popupContainer {
-    position: relative;
-    width: fit-content;
+  position: relative;
+  width: fit-content;
 }
 
 .popupToggle {
-    /* Optional: Add styles for the button that opens the popup */
+  /* Optional: Add styles for the button that opens the popup */
 }
 
 .popupCard {
-    position: absolute;
-    right: 0;
+  position: absolute;
+  right: 0;
 
-    color: var(--color-text);
-    background-color: var(--color-background);
-    border: 1px solid var(--color-border);
-    border-radius: 4px;
-    box-shadow: 0px 4px 8px var(--color-shadow);
+  color: var(--color-text);
+  background-color: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  box-shadow: 0px 4px 8px var(--color-shadow);
 }
 
 .popupCardHeader {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 0.5em 1em;
-    border-bottom: 1px solid var(--color-shadow);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5em 1em;
+  border-bottom: 1px solid var(--color-shadow);
 }
 
 .popupCardTitle {
-    font-weight: 600;
+  font-weight: 600;
 }
 
 .popupCardBody {
-    padding: 1em;
-    font-size: 0.9em;
+  padding: 1em;
+  font-size: 0.9em;
 }
 
 .popupCardFooter {
-    display: flex;
-    gap: 0.5em;
-    padding: 0.5em;
-    border-top: 1px solid var(--color-shadow);
+  display: flex;
+  gap: 0.5em;
+  padding: 0.5em;
+  border-top: 1px solid var(--color-shadow);
 }

--- a/src/features/table/TableColumnSelector.tsx
+++ b/src/features/table/TableColumnSelector.tsx
@@ -3,7 +3,7 @@ import React, { useCallback } from 'react';
 
 import Hoverable from '@features/layers/hovercard/Hoverable';
 import HoverableButton from '@features/layers/hovercard/HoverableButton';
-import Modal from '@features/layers/modal/Modal';
+import Modal from '@features/layers/modal/ModalButton';
 
 import { ObjectData } from '@entities/types/DataTypes';
 

--- a/src/features/table/TableColumnSelector.tsx
+++ b/src/features/table/TableColumnSelector.tsx
@@ -1,9 +1,9 @@
 import { SquareCheckIcon, SquareIcon, SquareMinusIcon } from 'lucide-react';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 
 import Hoverable from '@features/layers/hovercard/Hoverable';
 import HoverableButton from '@features/layers/hovercard/HoverableButton';
-import ViewModal from '@features/layers/modal/ViewModal';
+import Modal from '@features/layers/modal/Modal';
 
 import { ObjectData } from '@entities/types/DataTypes';
 
@@ -23,47 +23,37 @@ function TableColumnSelector<T extends ObjectData>({
   const { columnVisibility } = visibilityModule;
   const columnsByGroup = groupBy(columns, (column) => column.columnGroup || column.key);
   const nVisible = columns.filter((col) => columnVisibility[col.key]).length;
-  const [isOpen, setIsOpen] = useState(false);
-  const onClose = useCallback(() => setIsOpen(false), []);
 
   return (
-    <>
-      <HoverableButton
-        onClick={() => setIsOpen(true)}
-        hoverContent="Select which columns to show or hide"
-        style={{ padding: '0.25em 0.5em' }}
-      >
-        {nVisible}/{columns.length} columns visible. Click to configure.
-      </HoverableButton>
-
-      <ViewModal
-        isOpen={isOpen}
-        onClose={onClose}
-        title="Select Columns"
-        bodyStyle={{ width: '90vw', maxWidth: '85em', padding: '1em' }}
-      >
-        Click to toggle the visibility of columns in the table. You can also hover over column names
-        for more info and sorting/filtering options.
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(12em, 1fr))',
-            gap: '1em',
-            padding: '0.5em',
-          }}
-        >
-          {Object.entries(columnsByGroup).map(([group, columns]) => (
-            <ColumnGroup
-              columns={columns}
-              group={group}
-              key={group}
-              visibilityModule={visibilityModule}
-            />
-          ))}
-        </div>
-        <GlobalControls visibilityModule={visibilityModule} columns={columns} />
-      </ViewModal>
-    </>
+    <Modal
+      buttonLabel={`${nVisible}/${columns.length} columns visible. Click to configure.`}
+      description="Select which columns to show or hide"
+      title="Select Columns"
+      body={
+        <>
+          Click to toggle the visibility of columns in the table. You can also hover over column
+          names for more info and sorting/filtering options.
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(12em, 1fr))',
+              gap: '1em',
+              padding: '0.5em',
+            }}
+          >
+            {Object.entries(columnsByGroup).map(([group, columns]) => (
+              <ColumnGroup
+                columns={columns}
+                group={group}
+                key={group}
+                visibilityModule={visibilityModule}
+              />
+            ))}
+          </div>
+          <GlobalControls columns={columns} visibilityModule={visibilityModule} />
+        </>
+      }
+    />
   );
 }
 

--- a/src/pages/docs/CodeStylePage.tsx
+++ b/src/pages/docs/CodeStylePage.tsx
@@ -1,92 +1,16 @@
 import React from 'react';
 
 import ColorStyles from '@widgets/docs/ColorStyles';
-import DocsCard from '@widgets/docs/DocsCard';
 import DocsPageContainer from '@widgets/docs/DocsPageContainer';
-import DocsSection from '@widgets/docs/DocsSection';
-
-import Hoverable from '@features/layers/hovercard/Hoverable';
-import HoverableButton from '@features/layers/hovercard/HoverableButton';
-import InternalLink from '@features/params/InternalLink';
-
-import ExternalLink from '@shared/ui/ExternalLink';
-import LinkButton from '@shared/ui/LinkButton';
+import LayerComponents from '@widgets/docs/LayerComponents';
+import LinkComponents from '@widgets/docs/LinkComponents';
 
 const CodeStylePage: React.FC = () => {
   return (
     <DocsPageContainer title="Code Style">
       <div>This page outlines the code style guidelines for the Language Navigator project.</div>
-      <DocsSection title="Links">
-        <div>
-          Links should be clear but not overly styled. Thereby, they should only have underlines on
-          hover. They should follow the regular text color but stand out using font-weight.
-        </div>
-        <DocsCard title="External Links">
-          External links should always open in a new tab. They should include{' '}
-          <code>rel=&quot;noopener noreferrer&quot;</code> for security and performance reasons.
-          They should be accompanied by an appropriate visual indicator to inform users that the
-          link will open in a new tab. Buttons are slightly preferred to give clear visual
-          indicators of an interaction.
-        </DocsCard>
-        <DocsCard title="Internal Links">
-          Internal links should use the <code>&lt;InternalLink&gt;</code> component that uses{' '}
-          <code>&lt;Link&gt;</code> from react-router-dom. This enables client-side navigation
-          without full page reloads.
-        </DocsCard>
-        <DocsCard title="Hoverables">
-          Components that show a card or other additional context on hover should use the{' '}
-          <code>&lt;Hoverable&gt;</code> or <code>&lt;HoverableButton&gt;</code> component. These
-          components provide a consistent hover experience and can be easily styled to fit the
-          design of the site. They have <code>onClick</code> handlers for interactive behavior.
-          Unlike most links, inline hoverables are colored by default.
-        </DocsCard>
-        <DocsCard title="Page Parameter Updates">
-          When updating page parameters, you can use the <code>updatePageParams</code> function in{' '}
-          <code>onClick</code> events. Sometimes though it may be good to use{' '}
-          <code>&lt;InternalLink&gt;</code> components to allow users to open in new tabs or copy
-          links.
-        </DocsCard>
-        <DocsCard title="Component examples">
-          <table style={{ tableLayout: 'fixed' }}>
-            <tbody>
-              <tr>
-                <td style={{ fontFamily: 'monospace' }}>&lt;ExternalLink&gt;</td>
-                <td>
-                  <ExternalLink href="https://example.com">I&apos;m a link</ExternalLink>
-                </td>
-              </tr>
-              <tr>
-                <td style={{ fontFamily: 'monospace' }}>&lt;InternalLink&gt;</td>
-                <td>
-                  <InternalLink>I&apos;m a link</InternalLink>
-                </td>
-              </tr>
-              <tr>
-                <td style={{ fontFamily: 'monospace' }}>&lt;Hoverable&gt;</td>
-                <td>
-                  <Hoverable hoverContent="I show on hover" onClick={() => alert('Clicked!')}>
-                    I&apos;m hoverable and clickable
-                  </Hoverable>
-                </td>
-              </tr>
-              <tr>
-                <td style={{ fontFamily: 'monospace' }}>&lt;LinkButton&gt;</td>
-                <td>
-                  <LinkButton href="https://example.com">I&apos;m a link</LinkButton>
-                </td>
-              </tr>
-              <tr>
-                <td style={{ fontFamily: 'monospace' }}>&lt;HoverableButton&gt;</td>
-                <td>
-                  <HoverableButton hoverContent="I show on hover" onClick={() => alert('Clicked!')}>
-                    I&apos;m hoverable and clickable
-                  </HoverableButton>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </DocsCard>
-      </DocsSection>
+      <LinkComponents />
+      <LayerComponents />
       <ColorStyles />
     </DocsPageContainer>
   );

--- a/src/widgets/PageNavBar.tsx
+++ b/src/widgets/PageNavBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { NavLink } from 'react-router-dom';
 
 import { LangNavPageName } from '@app/PageRoutes';
@@ -12,7 +12,6 @@ import SettingsButton from './controls/SettingsButton';
 
 const PageNavBar: React.FC = () => {
   const { pageBrightness } = usePageParams().brightness;
-  const [feedbackOpen, setFeedbackOpen] = useState(false);
 
   return (
     <NavBarContainer>
@@ -32,16 +31,8 @@ const PageNavBar: React.FC = () => {
       <div style={{ display: 'flex', flexGrow: 1 }}>
         <SearchBar />
       </div>
-      <div style={{ display: 'flex', marginLeft: 'auto', alignItems: 'center' }}>
-        <button
-          className="primary"
-          type="button"
-          style={{ padding: '0.5em', whiteSpace: 'nowrap' }}
-          onClick={() => setFeedbackOpen(true)}
-        >
-          Feedback
-        </button>
-        {feedbackOpen && <FeedbackForm onClose={() => setFeedbackOpen(false)} />}
+      <div style={{ display: 'flex', marginLeft: 'auto', alignItems: 'center', gap: '0.5em' }}>
+        <FeedbackForm />
         <SettingsButton />
       </div>
     </NavBarContainer>

--- a/src/widgets/PageNavBar.tsx
+++ b/src/widgets/PageNavBar.tsx
@@ -3,12 +3,12 @@ import { NavLink } from 'react-router-dom';
 
 import { LangNavPageName } from '@app/PageRoutes';
 
-import Settings from '@widgets/controls/Settings';
-
 import { FeedbackForm } from '@features/feedback/FeedbackForm';
 import InternalLink from '@features/params/InternalLink';
 import usePageParams from '@features/params/usePageParams';
 import SearchBar from '@features/transforms/search/SearchBar';
+
+import SettingsButton from './controls/SettingsButton';
 
 const PageNavBar: React.FC = () => {
   const { pageBrightness } = usePageParams().brightness;
@@ -42,7 +42,7 @@ const PageNavBar: React.FC = () => {
           Feedback
         </button>
         {feedbackOpen && <FeedbackForm onClose={() => setFeedbackOpen(false)} />}
-        <Settings />
+        <SettingsButton />
       </div>
     </NavBarContainer>
   );

--- a/src/widgets/controls/Settings.tsx
+++ b/src/widgets/controls/Settings.tsx
@@ -1,11 +1,8 @@
-import { SettingsIcon, XIcon } from 'lucide-react';
-import React, { useCallback, useEffect, useState } from 'react';
+import React from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { LangNavPageName } from '@app/PageRoutes.tsx';
 
-import HoverableButton from '@features/layers/hovercard/HoverableButton.tsx';
-import ZIndex from '@features/layers/ZIndex';
 import LimitInput from '@features/pagination/LimitInput';
 import ColorBySelector from '@features/transforms/coloring/ColorBySelector';
 import ColorGradientSelector from '@features/transforms/coloring/ColorGradientSelector';
@@ -21,128 +18,43 @@ import PageBrightnessSelector from './selectors/PageBrightnessSelector';
 import ProfileSelector from './selectors/ProfileSelector';
 
 const Settings = (): React.ReactNode => {
-  const [isOpen, setIsOpen] = useState(false);
-  const onClose = useCallback(() => setIsOpen(false), []);
-
   const location = useLocation();
-
-  // Close the dropdown when the route changes
-  useEffect(() => {
-    setIsOpen(false);
-  }, [location.pathname]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        onClose();
-      }
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, onClose]);
-
   const isDataPage = location.pathname === '/' + LangNavPageName.Data;
 
   return (
-    <>
-      <HoverableButton
-        className="primary"
-        onClick={() => setIsOpen(true)}
-        style={{ padding: '0.5em' }}
-      >
-        <SettingsIcon size="1.5em" display="block" />
-      </HoverableButton>
-      {isOpen && (
-        <div
-          aria-modal="true"
-          className="view-settings"
-          role="dialog"
-          style={{
-            position: 'fixed',
-            top: '0.75em',
-            right: '0.75em',
-            zIndex: ZIndex.FeedbackForm,
-            backgroundColor: 'var(--color-background)',
-            borderRadius: '0.5em',
-            boxShadow: '0 4px 12px var(--color-shadow)',
-            color: 'var(--color-text)',
-            display: 'flex',
-            flexDirection: 'column',
-          }}
-        >
-          {/* Header */}
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              padding: '0.5em 1em',
-              borderBottom: '1px solid var(--color-shadow)',
-            }}
-          >
-            <span style={{ fontWeight: 600 }}>View settings</span>
-            <HoverableButton onClick={onClose} style={{ padding: '0.5em' }}>
-              <XIcon size="1em" display="block" />
-            </HoverableButton>
-          </div>
-
-          {/* Body */}
-          <div style={{ padding: '16px', overflow: 'auto', fontSize: '0.9em' }}>
-            <ViewSettingsPanel title="View options" optionsName="view options">
-              {isDataPage && (
-                <>
-                  <LimitInput />
-                  <SortBySelector />
-                  <SecondarySortBySelector />
-                  <SortDirectionSelector />
-                  <ColorBySelector />
-                  <ColorGradientSelector />
-                  <ScaleBySelector />
-                  <FieldFocusSelector />
-                  <LocaleSeparatorSelector />
-                  <ProfileSelector />
-                </>
-              )}
-              <SearchBySelector />
-              <PageBrightnessSelector />
-            </ViewSettingsPanel>
-          </div>
-        </div>
+    <ViewSettingsPanel>
+      {isDataPage && (
+        <>
+          <LimitInput />
+          <SortBySelector />
+          <SecondarySortBySelector />
+          <SortDirectionSelector />
+          <ColorBySelector />
+          <ColorGradientSelector />
+          <ScaleBySelector />
+          <FieldFocusSelector />
+          <LocaleSeparatorSelector />
+          <ProfileSelector />
+        </>
       )}
-    </>
+      <SearchBySelector />
+      <PageBrightnessSelector />
+    </ViewSettingsPanel>
   );
 };
 
-const ViewSettingsPanel: React.FC<
-  React.PropsWithChildren<{
-    title: string;
-    optionsName: string;
-    fullView?: boolean;
-  }>
-> = ({ children }) => {
-  const childArray = React.Children.toArray(children);
-
+const ViewSettingsPanel: React.FC<React.PropsWithChildren> = ({ children }) => {
   return (
     <div
       style={{
-        borderTop: 'none',
-        width: '95%',
-        marginBottom: '0.5em',
+        display: 'flex',
+        gap: '0.5em',
+        flexDirection: 'column',
+        alignItems: 'flex-end',
+        width: 'max-content',
       }}
     >
-      <div
-        style={{
-          display: 'flex',
-          padding: '0.25em 0.5em',
-          gap: '0.5em',
-          flexDirection: 'column',
-          alignItems: 'flex-end',
-          width: 'max-content',
-        }}
-      >
-        {childArray}
-      </div>
+      {children}
     </div>
   );
 };

--- a/src/widgets/controls/SettingsButton.tsx
+++ b/src/widgets/controls/SettingsButton.tsx
@@ -10,6 +10,7 @@ const SettingsButton = (): React.ReactNode => {
     <PopupCard
       buttonLabel={<SettingsIcon size="1.5em" display="block" />}
       buttonClassName="primary"
+      buttonStyle={{ padding: '0.5em' }}
       description="View settings"
       title="View settings"
       body={() => <Settings />}

--- a/src/widgets/controls/SettingsButton.tsx
+++ b/src/widgets/controls/SettingsButton.tsx
@@ -8,7 +8,7 @@ import Settings from './Settings';
 const SettingsButton = (): React.ReactNode => {
   return (
     <PopupCard
-      buttonLabel={<SettingsIcon size="1.5em" display="block" />}
+      buttonLabel={<SettingsIcon size="1.5em" display="block" aria-label="View settings" />}
       buttonClassName="primary"
       buttonStyle={{ padding: '0.5em' }}
       description="View settings"

--- a/src/widgets/controls/SettingsButton.tsx
+++ b/src/widgets/controls/SettingsButton.tsx
@@ -1,0 +1,20 @@
+import { SettingsIcon } from 'lucide-react';
+import React from 'react';
+
+import PopupCard from '@features/layers/popupcard/PopupCard';
+
+import Settings from './Settings';
+
+const SettingsButton = (): React.ReactNode => {
+  return (
+    <PopupCard
+      buttonLabel={<SettingsIcon size="1.5em" display="block" />}
+      buttonClassName="primary"
+      description="View settings"
+      title="View settings"
+      body={() => <Settings />}
+    />
+  );
+};
+
+export default SettingsButton;

--- a/src/widgets/docs/LayerComponents.tsx
+++ b/src/widgets/docs/LayerComponents.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { LangNavPageName } from '@app/PageRoutes';
 
 import HoverableButton from '@features/layers/hovercard/HoverableButton';
-import Modal from '@features/layers/modal/Modal';
+import Modal from '@features/layers/modal/ModalButton';
 import PopupCard from '@features/layers/popupcard/PopupCard';
 import { getNewURL } from '@features/params/getNewURL';
 import Selector from '@features/params/ui/Selector';

--- a/src/widgets/docs/LayerComponents.tsx
+++ b/src/widgets/docs/LayerComponents.tsx
@@ -1,0 +1,124 @@
+import React, { useState } from 'react';
+
+import { LangNavPageName } from '@app/PageRoutes';
+
+import HoverableButton from '@features/layers/hovercard/HoverableButton';
+import Modal from '@features/layers/modal/Modal';
+import PopupCard from '@features/layers/popupcard/PopupCard';
+import { getNewURL } from '@features/params/getNewURL';
+import Selector from '@features/params/ui/Selector';
+import { SelectorDisplay } from '@features/params/ui/SelectorDisplayContext';
+
+import { toSentenceCase } from '@shared/lib/stringUtils';
+import LinkButton from '@shared/ui/LinkButton';
+
+import DocsCard from './DocsCard';
+import DocsCardGrid from './DocsCardGrid';
+import DocsSection from './DocsSection';
+
+/**
+ * Documentation explaining different layer components
+ */
+const LayerComponents: React.FC = () => {
+  return (
+    <DocsSection title="Layers">
+      <div>
+        To make the website interactive but maintain a clean structure, we use various layer
+        components. These are reusable components that can be used as to maintain a consistent style
+        and user experience.
+      </div>
+      <DocsCard title="Hovercards">
+        <div>
+          Hovercards are used to show additional information when the user hovers over an element.
+          They should be used for simple information that can be quickly consumed, such as a preview
+          of a linked page or a definition of a term. At the moment they main contain their own
+          interactive elements, but there may be difficulties using the interactive elements without
+          accidentally dismissing the hovercard.
+        </div>
+        <div>
+          Usually there is 1 hovercard per page that is reused, but you can add a{' '}
+          <code>HoverCardProvider</code> to add a new hovercard. Nested hovercards are discouraged
+          (it is easy to provide a poor UX with competing hover areas) but can also be done with an
+          internal hovercard provider.
+        </div>
+        <div>
+          <HoverableButton hoverContent="I show on hover">Hoverable button</HoverableButton>
+        </div>
+      </DocsCard>
+      <DocsCard title="Popup Cards">
+        Popup cards are used to show more complex information that the user may want to interact
+        with, such as a list of view options. They include their own close button and persist on the
+        page until the original button is clicked again, the close button is clicked, or the escape
+        key is pressed.
+        <PopupCard
+          buttonLabel="Open popup card"
+          description="Description of the popup card goes here."
+          title="Popup Card Example"
+          body="I am the content of the popup card. I can include interactive elements like buttons."
+        />
+      </DocsCard>
+      <DocsCard title="Selector">
+        Selectors are used for selecting from a list of options. There are various display styles:
+        <DocsCardGrid>
+          <DocsCard title="Dropdown">
+            Standard compact selector
+            <DropdownExample display={SelectorDisplay.Dropdown} />
+          </DocsCard>
+          <DocsCard title="Inline Dropdown">
+            More compact, works in short text segments (does not support line wrapping well though).
+            <DropdownExample display={SelectorDisplay.InlineDropdown} />
+          </DocsCard>
+          <DocsCard title="Button Group">
+            When you want to show all options. Best with short options.
+            <DropdownExample display={SelectorDisplay.ButtonGroup} />
+          </DocsCard>
+          <DocsCard title="Button List">
+            When you want to show all options but enable wrapping.
+            <DropdownExample display={SelectorDisplay.ButtonList} />
+          </DocsCard>
+        </DocsCardGrid>
+      </DocsCard>
+      <DocsCard title="Modals">
+        Modals are used for important interactions that require focused attention, such as
+        confirming a destructive action or filling out a form. They should be used sparingly and
+        should include clear options for closing the modal without taking the primary action.
+        <div>
+          <Modal
+            buttonLabel="Open modal"
+            description="I am a modal"
+            title="Modal Example"
+            body="I am the content of the modal. I can include interactive elements like buttons."
+          />
+        </div>
+      </DocsCard>
+      <DocsCard title="Panels">
+        Panels are used to display content in a side or bottom drawer. They can be used for
+        navigation, settings, or additional information. Panels should be used when the content is
+        secondary to the main content and can be temporarily hidden. Right now the only available
+        panel is the entity details.
+        <div>
+          <LinkButton href={LangNavPageName.Data + getNewURL({ objectID: '1' })}>
+            Open data page with a right-hand panel open
+          </LinkButton>
+        </div>
+      </DocsCard>
+    </DocsSection>
+  );
+};
+
+const DropdownExample: React.FC<{ display: SelectorDisplay }> = ({ display }) => {
+  const [selected, setSelected] = useState('Option 2');
+  return (
+    <Selector
+      display={display}
+      selectorLabel={'Example ' + toSentenceCase(display)}
+      selectorDescription="Selector description goes here."
+      options={['Option 1', 'Option 2', 'Option 3', 'Option 4']}
+      onChange={setSelected}
+      selected={selected}
+      getOptionDescription={(v) => v + ' description'}
+    />
+  );
+};
+
+export default LayerComponents;

--- a/src/widgets/docs/LayerComponents.tsx
+++ b/src/widgets/docs/LayerComponents.tsx
@@ -24,14 +24,14 @@ const LayerComponents: React.FC = () => {
     <DocsSection title="Layers">
       <div>
         To make the website interactive but maintain a clean structure, we use various layer
-        components. These are reusable components that can be used as to maintain a consistent style
-        and user experience.
+        components. These are reusable components to maintain a consistent style and user
+        experience.
       </div>
       <DocsCard title="Hovercards">
         <div>
           Hovercards are used to show additional information when the user hovers over an element.
           They should be used for simple information that can be quickly consumed, such as a preview
-          of a linked page or a definition of a term. At the moment they main contain their own
+          of a linked page or a definition of a term. At the moment they may contain their own
           interactive elements, but there may be difficulties using the interactive elements without
           accidentally dismissing the hovercard.
         </div>

--- a/src/widgets/docs/LinkComponents.tsx
+++ b/src/widgets/docs/LinkComponents.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+
+import DocsCard from '@widgets/docs/DocsCard';
+import DocsSection from '@widgets/docs/DocsSection';
+
+import Hoverable from '@features/layers/hovercard/Hoverable';
+import HoverableButton from '@features/layers/hovercard/HoverableButton';
+import InternalLink from '@features/params/InternalLink';
+
+import ExternalLink from '@shared/ui/ExternalLink';
+import LinkButton from '@shared/ui/LinkButton';
+
+const LinkComponents: React.FC = () => {
+  return (
+    <DocsSection title="Links">
+      <div>
+        Links should be clear but not overly styled. Thereby, they should only have underlines on
+        hover. They should follow the regular text color but stand out using font-weight.
+      </div>
+      <DocsCard title="External Links">
+        External links should always open in a new tab. They should include{' '}
+        <code>rel=&quot;noopener noreferrer&quot;</code> for security and performance reasons. They
+        should be accompanied by an appropriate visual indicator to inform users that the link will
+        open in a new tab. Buttons are slightly preferred to give clear visual indicators of an
+        interaction.
+      </DocsCard>
+      <DocsCard title="Internal Links">
+        Internal links should use the <code>&lt;InternalLink&gt;</code> component that uses{' '}
+        <code>&lt;Link&gt;</code> from react-router-dom. This enables client-side navigation without
+        full page reloads.
+      </DocsCard>
+      <DocsCard title="Hoverables">
+        Components that show a card or other additional context on hover should use the{' '}
+        <code>&lt;Hoverable&gt;</code> or <code>&lt;HoverableButton&gt;</code> component. These
+        components provide a consistent hover experience and can be easily styled to fit the design
+        of the site. They have <code>onClick</code> handlers for interactive behavior. Unlike most
+        links, inline hoverables are colored by default.
+      </DocsCard>
+      <DocsCard title="Page Parameter Updates">
+        When updating page parameters, you can use the <code>updatePageParams</code> function in{' '}
+        <code>onClick</code> events. Sometimes though it may be good to use{' '}
+        <code>&lt;InternalLink&gt;</code> components to allow users to open in new tabs or copy
+        links.
+      </DocsCard>
+      <DocsCard title="Component examples">
+        <table style={{ tableLayout: 'fixed' }}>
+          <tbody>
+            <tr>
+              <td style={{ fontFamily: 'monospace' }}>&lt;ExternalLink&gt;</td>
+              <td>
+                <ExternalLink href="https://example.com">I&apos;m a link</ExternalLink>
+              </td>
+            </tr>
+            <tr>
+              <td style={{ fontFamily: 'monospace' }}>&lt;InternalLink&gt;</td>
+              <td>
+                <InternalLink>I&apos;m a link</InternalLink>
+              </td>
+            </tr>
+            <tr>
+              <td style={{ fontFamily: 'monospace' }}>&lt;Hoverable&gt;</td>
+              <td>
+                <Hoverable hoverContent="I show on hover" onClick={() => alert('Clicked!')}>
+                  I&apos;m hoverable and clickable
+                </Hoverable>
+              </td>
+            </tr>
+            <tr>
+              <td style={{ fontFamily: 'monospace' }}>&lt;LinkButton&gt;</td>
+              <td>
+                <LinkButton href="https://example.com">I&apos;m a link</LinkButton>
+              </td>
+            </tr>
+            <tr>
+              <td style={{ fontFamily: 'monospace' }}>&lt;HoverableButton&gt;</td>
+              <td>
+                <HoverableButton hoverContent="I show on hover" onClick={() => alert('Clicked!')}>
+                  I&apos;m hoverable and clickable
+                </HoverableButton>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </DocsCard>
+    </DocsSection>
+  );
+};
+
+export default LinkComponents;


### PR DESCRIPTION
Fixes #664

Summary: As we've added more interactions there are 3 places so far that include popup card components: Submit Feedback, View Settings, and Map Cards. This PR organizes the existing functionality to 1 component for the first two use cases and improves the general framework for the various "Layer" components.

### Changes

- User experience
  - Code style page now explains information about panels, selectors/dropdowns, hovercards, popupcards, and modals
- Logical changes
  - any logical changes are in refactors
- Data
  - n/a
- Refactors
  - FeedbackForm & Settings now use a common Popup component
  - Abstracted the Modal better to have a separate modal button
  - Some more common parameters -- isOpen state not required for as many components

Out of scope/Future work: Use the new popup card in more places.

### Test Plan and Screenshots

How to test the changes in this PR: Here are some screenshots of the updated components and the new layer components overview.

| Page/View with link | Description of Changes | Screenshot Before | Screenshot After |
| ------------------- | ---------------------- | ----------------- | ---------------- |
|[Layer Components overview](https://translation-commons.github.io/lang-nav/code-style)|See an overview of the various layer components used in the website|not available|<img width="795" height="1237" alt="Screenshot 2026-06-14 at 19 53 30" src="https://github.com/user-attachments/assets/27ddbeb7-b6a5-464a-9288-7962fb22d9c4" />|
|Feedback Form|offset changed, cancel CTA is now at top, submit CTA moved (but can be moved again)|<img width="342" height="346" alt="Screenshot 2026-06-14 at 19 54 51" src="https://github.com/user-attachments/assets/60207c3b-975b-4927-ad4b-2446127e1a0a" />|<img width="340" height="368" alt="Screenshot 2026-06-14 at 19 53 17" src="https://github.com/user-attachments/assets/5eecd01c-a9cd-4827-9210-334e4c4ad360" />|
|View Settings|offset changed slightly but otherwise still the same|<img width="308" height="421" alt="Screenshot 2026-06-14 at 19 54 56" src="https://github.com/user-attachments/assets/5f8109b5-481a-4f25-802b-c1d1f2edee00" />|<img width="280" height="433" alt="Screenshot 2026-06-14 at 19 53 44" src="https://github.com/user-attachments/assets/f34e57be-8ecf-4a44-b416-3ac64e93a793" />|





