### PR TITLE
Sort: Replace sort selector with popup card containing sort options

### DIFF
--- a/src/features/transforms/sorting/SortBySelector.tsx
+++ b/src/features/transforms/sorting/SortBySelector.tsx
@@ -1,4 +1,3 @@
-import { ArrowDownUpIcon } from 'lucide-react';
 import React from 'react';
 
 import Selector from '@features/params/ui/Selector';
@@ -8,14 +7,14 @@ import { getApplicableFields } from '@features/transforms/fields/FieldApplicabil
 
 import TransformEnum from '../TransformEnum';
 
-const SortBySelector: React.FC<{ showLabel?: boolean }> = ({ showLabel = true }) => {
+const SortBySelector: React.FC = () => {
   const { sortBy, updatePageParams, objectType } = usePageParams();
   const applicableSortBys = getApplicableFields(TransformEnum.Sort, objectType);
 
   return (
     <Selector
-      selectorLabel={showLabel ? 'Sort By' : <ArrowDownUpIcon size="1.2em" />}
-      selectorDescription={showLabel ? 'Choose the order of items in the view.' : undefined}
+      selectorLabel="Sort By"
+      selectorDescription="Choose the order of items in the view."
       options={applicableSortBys}
       onChange={(sortBy) => updatePageParams({ sortBy })}
       selected={sortBy}

--- a/src/features/transforms/sorting/SortPopupCard.tsx
+++ b/src/features/transforms/sorting/SortPopupCard.tsx
@@ -1,0 +1,39 @@
+import { ArrowDownUpIcon } from 'lucide-react';
+import React from 'react';
+
+import PopupCard from '@features/layers/popupcard/PopupCard';
+import { SelectorDisplay } from '@features/params/ui/SelectorDisplayContext';
+import { getOptionStyle } from '@features/params/ui/SelectorOption';
+import usePageParams from '@features/params/usePageParams';
+
+import { PositionInGroup } from '@shared/lib/PositionInGroup';
+
+import SecondarySortBySelector from './SecondarySortBySelector';
+import SortBySelector from './SortBySelector';
+import SortDirectionSelector from './SortDirectionSelector';
+
+const SortPopupCard: React.FC = () => {
+  const { sortBy } = usePageParams();
+
+  return (
+    <div className="selector" style={{ gap: '0.25em' }}>
+      <ArrowDownUpIcon size="1.2em" />
+      <PopupCard
+        buttonLabel={<>{sortBy} ▶</>}
+        buttonClassName="selected"
+        buttonStyle={getOptionStyle(SelectorDisplay.Dropdown, true, PositionInGroup.Standalone)}
+        description="Change how items are sorted."
+        title="Sort"
+        body={() => (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5em' }}>
+            <SortBySelector />
+            <SecondarySortBySelector />
+            <SortDirectionSelector />
+          </div>
+        )}
+      />
+    </div>
+  );
+};
+
+export default SortPopupCard;

--- a/src/pages/DataPageBody.tsx
+++ b/src/pages/DataPageBody.tsx
@@ -6,7 +6,7 @@ import { PathContainer } from '@widgets/pathnav/PathNav';
 
 import ResultCount from '@features/pagination/ResultCount';
 import FilterPath from '@features/transforms/filtering/FilterPath';
-import SortBySelector from '@features/transforms/sorting/SortBySelector';
+import SortPopupCard from '@features/transforms/sorting/SortPopupCard';
 
 import ContainErrorsAndSuspense from '@shared/containers/ContainErrorsAndSuspense';
 
@@ -42,7 +42,7 @@ const DataPageBody: React.FC = () => {
             gap: '0.5rem',
           }}
         >
-          <SortBySelector showLabel={false} />
+          <SortPopupCard />
           <ViewSelector />
         </div>
       </div>

--- a/src/widgets/controls/Settings.tsx
+++ b/src/widgets/controls/Settings.tsx
@@ -9,9 +9,6 @@ import ColorGradientSelector from '@features/transforms/coloring/ColorGradientSe
 import FieldFocusSelector from '@features/transforms/fields/FieldFocusSelector';
 import ScaleBySelector from '@features/transforms/scales/ScaleBySelector';
 import SearchBySelector from '@features/transforms/search/SearchBySelector';
-import SecondarySortBySelector from '@features/transforms/sorting/SecondarySortBySelector';
-import SortBySelector from '@features/transforms/sorting/SortBySelector';
-import SortDirectionSelector from '@features/transforms/sorting/SortDirectionSelector';
 
 import LocaleSeparatorSelector from './selectors/LocaleSeparatorSelector';
 import PageBrightnessSelector from './selectors/PageBrightnessSelector';
@@ -26,9 +23,6 @@ const Settings = (): React.ReactNode => {
       {isDataPage && (
         <>
           <LimitInput />
-          <SortBySelector />
-          <SecondarySortBySelector />
-          <SortDirectionSelector />
           <ColorBySelector />
           <ColorGradientSelector />
           <ScaleBySelector />


### PR DESCRIPTION
Fixes #579

<img width="300" height="250" alt="截屏2026-06-15 上午11 44 55" src="https://github.com/user-attachments/assets/d1e002af-476b-4990-887b-a1d1eedffa50" />

## Summary
- Replace the toolbar sort dropdown with a `SortPopupCard` that contains Sort By, Secondary Sort By, and Sort Direction.
- Remove the corresponding sort controls from View Settings.
- Remove the unused `showLabel` prop from `SortBySelector`.