### PR TITLE
feat(map): complete pinned floating card restore from URL

### DIFF
--- a/src/features/map/EntityMap.tsx
+++ b/src/features/map/EntityMap.tsx
@@ -44,7 +44,7 @@ const ObjectMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
     onZoom: setZoomFactor,
   });
 
-  const { colorBy, objectType } = usePageParams();
+  const { colorBy, objectType, pinned, updatePageParams } = usePageParams();
   const [floatingCards, setFloatingCards] = useState<FloatingCard[]>([]);
   const [mapScale, setMapScale] = useState(1);
 
@@ -79,6 +79,7 @@ const ObjectMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
 
   const openCard = useCallback(
     (entity: DrawableData, clientX: number, clientY: number) => {
+      updatePageParams({ pinned: [...pinned, entity.ID] });
       const rect = contentRef.current?.getBoundingClientRect();
       if (!rect) return;
 
@@ -93,12 +94,16 @@ const ObjectMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
         { id: entity.ID, entity, x, y },
       ]);
     },
-    [contentRef, mapHeight],
+    [contentRef, mapHeight, pinned],
   );
 
-  const closeCard = useCallback((id: string) => {
-    setFloatingCards((prev) => prev.filter((card) => card.id !== id));
-  }, []);
+  const closeCard = useCallback(
+    (id: string) => {
+      updatePageParams({ pinned: pinned.filter((pin) => pin != id) });
+      setFloatingCards((prev) => prev.filter((card) => card.id !== id));
+    },
+    [pinned],
+  );
 
   const handleZoomIn = useCallback(() => {
     zoomIn();

--- a/src/features/map/EntityMap.tsx
+++ b/src/features/map/EntityMap.tsx
@@ -108,7 +108,7 @@ const ObjectMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
       if (pinned.includes(entity.ID)) return;
       updatePageParams({ pinned: [...pinned, entity.ID] });
     },
-    [pinned, updateMapScale,updatePageParams],
+    [pinned, updateMapScale, updatePageParams],
   );
 
   const closeCard = useCallback(

--- a/src/features/map/EntityMap.tsx
+++ b/src/features/map/EntityMap.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { ObjectType } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
@@ -14,9 +14,15 @@ import { ObjectData } from '@entities/types/DataTypes';
 import { uniqueBy } from '@shared/lib/setUtils';
 
 import DrawableData from './DrawableData';
+import { getRobinsonCoordinatesShifted } from './getRobinsonCoordinates';
 import MapCard from './MapCard';
 import MapCentroids from './MapCentroids';
-import { MAP_ASPECT_RATIO, MAP_INTERNAL_WIDTH } from './MapConsts';
+import {
+  MAP_ASPECT_RATIO,
+  MAP_INTERNAL_WIDTH,
+  MAP_ROBINSON_X_SCALE,
+  MAP_ROBINSON_Y_SCALE,
+} from './MapConsts';
 import MapTerritories from './MapTerritories';
 import useMapZoom from './UseMapZoom';
 import ZoomControls from './ZoomControls';
@@ -45,8 +51,8 @@ const ObjectMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
   });
 
   const { colorBy, objectType, pinned, updatePageParams } = usePageParams();
-  const [floatingCards, setFloatingCards] = useState<FloatingCard[]>([]);
   const [mapScale, setMapScale] = useState(1);
+  const prevObjectTypeRef = useRef(objectType);
 
   const updateMapScale = useCallback(() => {
     const rect = contentRef.current?.getBoundingClientRect();
@@ -77,32 +83,39 @@ const ObjectMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
 
   const coloringFunctions = useColors({ objects: drawableEntities });
 
+  // Floating cards are derived from the pinned page param so they can be fully restored from the
+  // URL after a refresh. Each card is positioned at its entity's Robinson centroid.
+  const floatingCards = useMemo<FloatingCard[]>(() => {
+    const drawableById = new Map(drawableEntities.map((entity) => [entity.ID, entity]));
+    return pinned
+      .map((id) => {
+        const entity = drawableById.get(id);
+        if (entity == null || entity.latitude == null || entity.longitude == null) return undefined;
+
+        const { x: robinsonX, y: robinsonY } = getRobinsonCoordinatesShifted(entity);
+        return {
+          id,
+          entity,
+          x: MAP_INTERNAL_WIDTH / 2 + robinsonX * MAP_ROBINSON_X_SCALE,
+          y: mapHeight / 2 - robinsonY * MAP_ROBINSON_Y_SCALE,
+        };
+      })
+      .filter((card): card is FloatingCard => card != null);
+  }, [pinned, drawableEntities, mapHeight]);
+
   const openCard = useCallback(
-    (entity: DrawableData, clientX: number, clientY: number) => {
+    (entity: DrawableData) => {
+      if (pinned.includes(entity.ID)) return;
       updatePageParams({ pinned: [...pinned, entity.ID] });
-      const rect = contentRef.current?.getBoundingClientRect();
-      if (!rect) return;
-
-      const scale = rect.width / MAP_INTERNAL_WIDTH;
-      setMapScale(scale);
-
-      const x = ((clientX - rect.left) / rect.width) * MAP_INTERNAL_WIDTH;
-      const y = ((clientY - rect.top) / rect.height) * mapHeight;
-
-      setFloatingCards((prev) => [
-        ...prev.filter((card) => card.id !== entity.ID),
-        { id: entity.ID, entity, x, y },
-      ]);
     },
-    [contentRef, mapHeight, pinned],
+    [pinned, updatePageParams],
   );
 
   const closeCard = useCallback(
     (id: string) => {
-      updatePageParams({ pinned: pinned.filter((pin) => pin != id) });
-      setFloatingCards((prev) => prev.filter((card) => card.id !== id));
+      updatePageParams({ pinned: pinned.filter((pin) => pin !== id) });
     },
-    [pinned],
+    [pinned, updatePageParams],
   );
 
   const handleZoomIn = useCallback(() => {
@@ -120,9 +133,19 @@ const ObjectMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
     requestAnimationFrame(updateMapScale);
   }, [resetTransform, updateMapScale]);
 
+  // Restore the map scale on mount so URL-restored cards are sized correctly before any zoom.
   useEffect(() => {
-    setFloatingCards([]);
-  }, [objectType]);
+    requestAnimationFrame(updateMapScale);
+  }, [updateMapScale]);
+
+  // Clear pinned cards when the object type changes, but not on the initial mount so that pinned
+  // cards can still be restored from the URL after a refresh.
+  useEffect(() => {
+    if (prevObjectTypeRef.current !== objectType) {
+      prevObjectTypeRef.current = objectType;
+      updatePageParams({ pinned: [] });
+    }
+  }, [objectType, updatePageParams]);
 
   return (
     <div style={{ maxWidth, width: '100%', position: 'relative' }}>
@@ -142,7 +165,7 @@ const ObjectMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
           cursor: 'grab',
           position: 'relative',
         }}
-        onClick={() => setFloatingCards([])}
+        onClick={() => updatePageParams({ pinned: [] })}
       >
         <div
           ref={contentRef}

--- a/src/features/map/EntityMap.tsx
+++ b/src/features/map/EntityMap.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { ObjectType } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
@@ -52,7 +52,6 @@ const ObjectMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
 
   const { colorBy, objectType, pinned, updatePageParams } = usePageParams();
   const [mapScale, setMapScale] = useState(1);
-  const prevObjectTypeRef = useRef(objectType);
 
   const updateMapScale = useCallback(() => {
     const rect = contentRef.current?.getBoundingClientRect();
@@ -105,10 +104,11 @@ const ObjectMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
 
   const openCard = useCallback(
     (entity: DrawableData) => {
+      updateMapScale();
       if (pinned.includes(entity.ID)) return;
       updatePageParams({ pinned: [...pinned, entity.ID] });
     },
-    [pinned, updatePageParams],
+    [pinned, updateMapScale,updatePageParams],
   );
 
   const closeCard = useCallback(
@@ -137,15 +137,6 @@ const ObjectMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
   useEffect(() => {
     requestAnimationFrame(updateMapScale);
   }, [updateMapScale]);
-
-  // Clear pinned cards when the object type changes, but not on the initial mount so that pinned
-  // cards can still be restored from the URL after a refresh.
-  useEffect(() => {
-    if (prevObjectTypeRef.current !== objectType) {
-      prevObjectTypeRef.current = objectType;
-      updatePageParams({ pinned: [] });
-    }
-  }, [objectType, updatePageParams]);
 
   return (
     <div style={{ maxWidth, width: '100%', position: 'relative' }}>

--- a/src/features/map/MapCentroids.tsx
+++ b/src/features/map/MapCentroids.tsx
@@ -10,7 +10,7 @@ import { getFieldString } from '@features/transforms/fields/getFieldString';
 import useScale from '@features/transforms/scales/useScale';
 
 import DrawableData from './DrawableData';
-import { getRobinsonCoordinates } from './getRobinsonCoordinates';
+import { getRobinsonCoordinatesShifted } from './getRobinsonCoordinates';
 import { MAP_ASPECT_RATIO } from './MapConsts';
 
 import './map.css';
@@ -112,10 +112,7 @@ const ObjectNode: React.FC<NodeProps> = ({
   if (object.type !== ObjectType.Language && object.type !== ObjectType.Territory) return null;
   if (object.latitude == null || object.longitude == null) return null;
 
-  const { x, y } = getRobinsonCoordinates(
-    object.latitude,
-    (object.longitude < -169 ? object.longitude + 360 : object.longitude) - 11,
-  );
+  const { x, y } = getRobinsonCoordinatesShifted(object);
 
   const showCircle = !(object.type === ObjectType.Territory && (object?.landArea || 0) >= 20000);
 

--- a/src/features/map/MapCentroids.tsx
+++ b/src/features/map/MapCentroids.tsx
@@ -11,7 +11,7 @@ import useScale from '@features/transforms/scales/useScale';
 
 import DrawableData from './DrawableData';
 import { getRobinsonCoordinatesShifted } from './getRobinsonCoordinates';
-import { MAP_ASPECT_RATIO } from './MapConsts';
+import { MAP_ASPECT_RATIO, MAP_ROBINSON_X_SCALE, MAP_ROBINSON_Y_SCALE } from './MapConsts';
 
 import './map.css';
 
@@ -117,7 +117,9 @@ const ObjectNode: React.FC<NodeProps> = ({
   const showCircle = !(object.type === ObjectType.Territory && (object?.landArea || 0) >= 20000);
 
   return (
-    <g transform={`translate(${x * 178.5}, ${y * -90}) scale(${1 / zoomFactor})`}>
+    <g
+      transform={`translate(${x * MAP_ROBINSON_X_SCALE}, ${y * -MAP_ROBINSON_Y_SCALE}) scale(${1 / zoomFactor})`}
+    >
       {showCircle && (
         <Circle
           color={color}

--- a/src/features/map/MapConsts.ts
+++ b/src/features/map/MapConsts.ts
@@ -1,2 +1,7 @@
 export const MAP_ASPECT_RATIO = 1.979;
 export const MAP_INTERNAL_WIDTH = 360;
+
+// Robinson coordinates are normalized to roughly -1..1. These scalars map them onto the
+// SVG viewBox (-180..180 horizontally, -90..90 vertically) used to draw the map overlay.
+export const MAP_ROBINSON_X_SCALE = 178.5;
+export const MAP_ROBINSON_Y_SCALE = 90;

--- a/src/features/map/getRobinsonCoordinates.ts
+++ b/src/features/map/getRobinsonCoordinates.ts
@@ -53,4 +53,3 @@ export function getRobinsonCoordinatesShifted(object: DrawableData) {
     (object.longitude < -169 ? object.longitude + 360 : object.longitude) - 11,
   );
 }
-

--- a/src/features/map/getRobinsonCoordinates.ts
+++ b/src/features/map/getRobinsonCoordinates.ts
@@ -1,4 +1,7 @@
 // Official Robinson table from Snyder (1987), for every 5° of latitude.
+
+import DrawableData from './DrawableData';
+
 // Each row: [latitude_deg, x_coeff (A), y_coeff (B)]
 const ROBINSON = [
   [0, 1.0, 0.0],
@@ -40,3 +43,14 @@ export function getRobinsonCoordinates(lat: number, lon: number) {
 
   return { x, y };
 }
+
+// The coordinates are shifted 11 degrees east to center the map.
+export function getRobinsonCoordinatesShifted(object: DrawableData) {
+  if (object == null) return { x: 0, y: 0 };
+  if (object.latitude == null || object.longitude == null) return { x: 0, y: 0 };
+  return getRobinsonCoordinates(
+    object.latitude,
+    (object.longitude < -169 ? object.longitude + 360 : object.longitude) - 11,
+  );
+}
+

--- a/src/features/params/PageParamTypes.tsx
+++ b/src/features/params/PageParamTypes.tsx
@@ -70,6 +70,7 @@ export enum PageParamKey {
   objectID = 'objectID',
   objectType = 'objectType',
   page = 'page',
+  pinned = 'pinned',
   populationMax = 'populationMax',
   populationMin = 'populationMin',
   profile = 'profile',
@@ -105,6 +106,7 @@ export type PageParams = {
   objectID?: string;
   objectType: ObjectType;
   page: number; // 1 indexed
+  pinned: string[];
   populationMax: number;
   populationMin: number;
   profile: ProfileType;
@@ -138,6 +140,7 @@ export type PageParamsOptional = {
   objectID?: string;
   objectType?: ObjectType;
   page?: number;
+  pinned?: string[];
   populationMax?: number;
   populationMin?: number;
   profile?: ProfileType;

--- a/src/features/params/Profiles.tsx
+++ b/src/features/params/Profiles.tsx
@@ -53,6 +53,7 @@ const GLOBAL_DEFAULTS: PageParams = {
   objectID: undefined,
   objectType: ObjectType.Language,
   page: 1,
+  pinned: [],
   profile: ProfileType.LanguageEthusiast,
   populationMax: 10_000_000_000, // higher than the world population
   populationMin: -1, // allow undefined population as well as definite 0s

--- a/src/features/params/getNewURLSearchParams.ts
+++ b/src/features/params/getNewURLSearchParams.ts
@@ -122,6 +122,7 @@ function clearContextDependentParams(
 
   if (newParams.objectType !== undefined && newParams.objectType !== prevOrDefault.objectType) {
     next.delete('reportID');
+    next.delete('pinned');
     if (newParams.page == null) next.delete('page');
     const oldSearchString = prev?.get('searchString');
     if (oldSearchString) {

--- a/src/features/params/getParamsFromURL.ts
+++ b/src/features/params/getParamsFromURL.ts
@@ -145,6 +145,11 @@ export function getParamsFromURL(urlParams: URLSearchParams): PageParamsOptional
         params.fieldFocus = value as Field;
         break;
 
+      //These are string arrays
+      case PageParamKey.pinned:
+        params.pinned = value.split(',');
+        break;
+
       // Freeform strings
       case PageParamKey.objectID:
       case PageParamKey.searchString:


### PR DESCRIPTION
Fixes #658 

Summary: This finishes work started in the prior commit (feat(params): add pinned URL param for map floating cards). That earlier commit added a pinned URL parameter and synced it when opening/closing cards, but floating cards still lived in local React state. After a refresh, the URL could contain pinned IDs, but the cards would not reappear.

This PR makes pinned the single source of truth for which floating cards are open. Floating cards are now derived from the pinned page parameter, so pinned cards can be restored from the URL after refresh.

### Changes
- User experience
  - Restores pinned floating cards after a page refresh when the URL contains pinned entity IDs.
  - Allows shared URLs with pinned values to reopen the same floating cards.
  - Clears pinned cards from the URL when clicking the map background.
- Logical changes
  - Removed local React state as the source for floating cards.
  - Derived floatingCards from the pinned page parameter using useMemo.
  - Updated openCard/closeCard to only add/remove entity IDs to pinned.
  - Added object type change handling that clears pinned only when the object type actually changes.
- Refactors
  - Moved Robinson map scale values into shared constants.


### Screenshots
<img width="1291" height="802" alt="image" src="https://github.com/user-attachments/assets/814889f5-605b-40b1-89a8-86385e762cf1" />
<img width="1240" height="839" alt="image" src="https://github.com/user-attachments/assets/5f59f480-9ebc-401e-be7a-aa357392933e" />
