### PR TITLE
#671 feat: add FilterList display mode for enum filters

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,19 @@
 Fixes #ISSUE_NUMBER
 
-Summary: Replaced dropdown/button displays for enum filters with a new Filter List display mode that shows options as a compact vertical list, showing the first 4 with an "Expand All" toggle when there are 5 or more.
+Summary: ...
 
 ### Changes
 
 - User experience
-  - Enum filters (Language Authority, Modality, Languoid Type, Territory Type, ISO Language Status) now show as a vertical plain-text list instead of a dropdown or button group
-  - Options are visible at a glance without needing to open a dropdown
-  - "Expand All" / "Collapse" button appears when there are more than 4 options
+  - ...
 - Logical changes
-  - Added FilterList to the SelectorDisplay enum
-  - Selector now slices visible options to the first 4 when in FilterList mode and not expanded
-  - FilterListMoreButton component added to Selector for the expand/collapse toggle
-  - SelectorContainer renders as flex-column with full width for FilterList
-  - useClickOutside guarded to not collapse FilterList state on outside click
+  - ...
 - Data
-  - No data changes
+  - ...
 - Refactors
-  - LanguageModalitySelector, LanguageScopeSelector, TerritoryScopeSelector, VitalitySelector updated to accept and forward a display prop
+  - ...
 
-Out of scope/Future work: The dual meaning of expanded state (dropdown open vs filter list expanded) could be split into two separate state variables for clarity.
+Out of scope/Future work: ...
 
 ### Test Plan and Screenshots
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,25 @@
 Fixes #ISSUE_NUMBER
 
-Summary: ...
+Summary: Replaced dropdown/button displays for enum filters with a new Filter List display mode that shows options as a compact vertical list, showing the first 4 with an "Expand All" toggle when there are 5 or more.
 
 ### Changes
 
 - User experience
-  - ...
+  - Enum filters (Language Authority, Modality, Languoid Type, Territory Type, ISO Language Status) now show as a vertical plain-text list instead of a dropdown or button group
+  - Options are visible at a glance without needing to open a dropdown
+  - "Expand All" / "Collapse" button appears when there are more than 4 options
 - Logical changes
-  - ...
+  - Added FilterList to the SelectorDisplay enum
+  - Selector now slices visible options to the first 4 when in FilterList mode and not expanded
+  - FilterListMoreButton component added to Selector for the expand/collapse toggle
+  - SelectorContainer renders as flex-column with full width for FilterList
+  - useClickOutside guarded to not collapse FilterList state on outside click
 - Data
-  - ...
+  - No data changes
 - Refactors
-  - ...
+  - LanguageModalitySelector, LanguageScopeSelector, TerritoryScopeSelector, VitalitySelector updated to accept and forward a display prop
 
-Out of scope/Future work: ...
+Out of scope/Future work: The dual meaning of expanded state (dropdown open vs filter list expanded) could be split into two separate state variables for clarity.
 
 ### Test Plan and Screenshots
 

--- a/src/features/params/ui/Selector.tsx
+++ b/src/features/params/ui/Selector.tsx
@@ -26,6 +26,8 @@ type Props<T> = {
   selectorStyle?: React.CSSProperties;
 };
 
+const FILTER_LIST_INITIAL_COUNT = 4;
+
 function Selector<T extends React.Key>({
   display,
   getOptionDescription,
@@ -41,14 +43,33 @@ function Selector<T extends React.Key>({
 }: Props<T>) {
   const [expanded, setExpanded] = useState(false);
   const optionsRef = useClickOutside(() => {
-    setTimeout(() => setExpanded(false), 100);
+    // Only auto-collapse for dropdown modes; FilterList is a persistent filter UI
+    if (display !== SelectorDisplay.FilterList) {
+      setTimeout(() => setExpanded(false), 100);
+    }
   });
+
+  // For FilterList: collapse to first N items unless expanded
+  const isFilterList = display === SelectorDisplay.FilterList;
+  const filterListCollapsed =
+    isFilterList && !expanded && options.length > FILTER_LIST_INITIAL_COUNT;
+  const visibleOptions = filterListCollapsed
+    ? options.slice(0, FILTER_LIST_INITIAL_COUNT)
+    : options;
 
   return (
     <SelectorContainer manualStyle={selectorStyle} manualDisplay={display}>
       {selectorLabel && <SelectorLabel label={selectorLabel} description={selectorDescription} />}
 
-      <div style={{ position: 'relative', display: 'flex', alignItems: 'center' }}>
+      <div
+        style={{
+          position: isFilterList ? undefined : 'relative',
+          display: 'flex',
+          width: isFilterList ? '100%' : undefined,
+          alignItems: isFilterList ? 'flex-start' : 'center',
+          flexDirection: isFilterList ? 'column' : 'row',
+        }}
+      >
         {/* The dropdown menu or the button list */}
         <OptionsContainer
           isExpanded={expanded}
@@ -59,14 +80,21 @@ function Selector<T extends React.Key>({
             getOptionDescription={getOptionDescription}
             getOptionLabel={getOptionLabel}
             onClick={(option) => {
-              setExpanded(false);
+              if (!isFilterList) setExpanded(false);
               onChange(option);
             }}
             optionStyle={optionStyle}
-            options={options}
+            options={visibleOptions}
             selected={selected}
           />
         </OptionsContainer>
+
+        {/* "More / Less" toggle for FilterList when there are enough options */}
+        <FilterListMoreButton
+          totalCount={options.length}
+          isExpanded={expanded}
+          toggle={() => setExpanded((prev) => !prev)}
+        />
 
         {/* Standalone option to open/close the dropdown menu */}
         <DropdownButton<T>
@@ -93,7 +121,21 @@ const SelectorContainer: React.FC<
 
   // Prepare the container. If there was a manual display, then wrap in a provider.
   const container = (
-    <div className={'selector ' + display} style={{ ...manualStyle }}>
+    <div
+      className={'selector ' + display}
+      style={{
+        ...(display === SelectorDisplay.FilterList
+          ? {
+              display: 'flex',
+              flexDirection: 'column',
+              width: '100%',
+              alignItems: 'flex-start',
+              alignSelf: 'stretch',
+            }
+          : {}),
+        ...manualStyle,
+      }}
+    >
       {children}
     </div>
   );
@@ -126,6 +168,20 @@ const OptionsContainer: React.FC<React.PropsWithChildren<OptionsContainerProps>>
             flexWrap: 'wrap',
             gap: '0.25em',
             marginLeft: hasSelectorLabel ? '1em' : 'none',
+          }}
+        >
+          {children}
+        </div>
+      );
+    case SelectorDisplay.FilterList:
+      return (
+        <div
+          ref={containerRef}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '0',
+            alignItems: 'flex-start',
           }}
         >
           {children}
@@ -173,6 +229,38 @@ function Options<T extends React.Key>({
     />
   ));
 }
+
+type FilterListMoreButtonProps = {
+  totalCount: number;
+  isExpanded: boolean;
+  toggle: () => void;
+};
+
+const FilterListMoreButton: React.FC<FilterListMoreButtonProps> = ({
+  totalCount,
+  isExpanded,
+  toggle,
+}) => {
+  const { display } = useSelectorDisplay();
+  if (display !== SelectorDisplay.FilterList || totalCount <= FILTER_LIST_INITIAL_COUNT)
+    return null;
+
+  return (
+    <button
+      onClick={toggle}
+      style={{
+        width: 'fit-content',
+        borderRadius: '0.25em',
+        color: 'inherit',
+        cursor: 'pointer',
+        fontSize: '0.9em',
+        padding: '0.2em 3.5em',
+      }}
+    >
+      {isExpanded ? 'Collapse' : 'Expand All'}
+    </button>
+  );
+};
 
 type DropdownButtonProps<T> = {
   getOptionDescription?: (value: T) => React.ReactNode;

--- a/src/features/params/ui/SelectorDisplayContext.tsx
+++ b/src/features/params/ui/SelectorDisplayContext.tsx
@@ -5,6 +5,7 @@ export enum SelectorDisplay {
   InlineDropdown = 'inlineDropdown', // Used to be inline with text
   ButtonGroup = 'buttonGroup', // Unsure if we want to keep this
   ButtonList = 'buttonList',
+  FilterList = 'filterList',
 }
 
 export const SelectorDisplayContext = React.createContext<{

--- a/src/features/params/ui/SelectorLabel.tsx
+++ b/src/features/params/ui/SelectorLabel.tsx
@@ -50,6 +50,9 @@ function getStyle(display: SelectorDisplay): React.CSSProperties {
     case SelectorDisplay.InlineDropdown:
       style.padding = '0 0.5em';
       break;
+    case SelectorDisplay.FilterList:
+      style.padding = '0 0 0.5em 0.5em';
+      break;
     case SelectorDisplay.Dropdown:
       // nothing special
       break;

--- a/src/features/params/ui/SelectorOption.tsx
+++ b/src/features/params/ui/SelectorOption.tsx
@@ -138,6 +138,13 @@ export function getOptionStyle(
       style.borderRadius = '1em';
       if (!isSelected) style.border = '0.125em solid var(--color-button-secondary)';
       break;
+    case SelectorDisplay.FilterList:
+      style.border = 'none';
+      style.borderRadius = '0.5em';
+      style.padding = '0.2em 0.4em';
+      style.lineHeight = '1.5em';
+      style.margin = '0.1em';
+      break;
     case SelectorDisplay.InlineDropdown:
       // The standalone option should match the regular page text
       if (position === PositionInGroup.Standalone) {

--- a/src/features/transforms/filtering/selectors/FilterSelector.tsx
+++ b/src/features/transforms/filtering/selectors/FilterSelector.tsx
@@ -31,17 +31,17 @@ const FilterSelector: React.FC<Props> = ({ field }) => {
     case Field.WritingSystem:
       return <WritingSystemFilterSelector display={SelectorDisplay.ButtonList} />;
     case Field.Modality:
-      return <LanguageModalitySelector />;
+      return <LanguageModalitySelector display={SelectorDisplay.FilterList} />;
     case Field.LanguageScope:
-      return <LanguageScopeSelector />;
+      return <LanguageScopeSelector display={SelectorDisplay.FilterList} />;
     case Field.TerritoryScope:
-      return <TerritoryScopeSelector />;
+      return <TerritoryScopeSelector display={SelectorDisplay.FilterList} />;
     case Field.ISOStatus:
-      return <LanguageISOStatusSelector />;
+      return <LanguageISOStatusSelector display={SelectorDisplay.FilterList} />;
     case Field.Name:
       return <SearchBar />; // Technically correct but not recommended usage
     case Field.SourceForLanguage:
-      return <LanguageSourceSelector display={SelectorDisplay.ButtonList} />;
+      return <LanguageSourceSelector display={SelectorDisplay.FilterList} />;
     case Field.Population:
       return <PopulationFilterSelector />;
     default:

--- a/src/features/transforms/filtering/selectors/LanguageModalitySelector.tsx
+++ b/src/features/transforms/filtering/selectors/LanguageModalitySelector.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 
 import Selector from '@features/params/ui/Selector';
+import { SelectorDisplay } from '@features/params/ui/SelectorDisplayContext';
 import usePageParams from '@features/params/usePageParams';
 
 import { LanguageModality } from '@entities/language/LanguageModality';
 import { getModalityLabel } from '@entities/language/LanguageModalityDisplay';
 
-const LanguageModalitySelector: React.FC = () => {
+type Props = { display?: SelectorDisplay };
+
+const LanguageModalitySelector: React.FC<Props> = ({ display }) => {
   const { modalityFilter, updatePageParams } = usePageParams();
 
   const selectorDescription =
@@ -29,6 +32,7 @@ const LanguageModalitySelector: React.FC = () => {
       }
       selected={modalityFilter}
       getOptionLabel={getModalityLabel}
+      display={display}
     />
   );
 };

--- a/src/features/transforms/filtering/selectors/LanguageScopeSelector.tsx
+++ b/src/features/transforms/filtering/selectors/LanguageScopeSelector.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 
 import Selector from '@features/params/ui/Selector';
+import { SelectorDisplay } from '@features/params/ui/SelectorDisplayContext';
 import usePageParams from '@features/params/usePageParams';
 
 import { LanguageScope } from '@entities/language/LanguageTypes';
 
 import { getLanguageScopeDescription, getLanguageScopeLabel } from '@strings/LanguageScopeStrings';
 
-const LanguageScopeSelector: React.FC = () => {
+type Props = { display?: SelectorDisplay };
+
+const LanguageScopeSelector: React.FC<Props> = ({ display }) => {
   const { languageScopes, updatePageParams } = usePageParams();
 
   const selectorDescription =
@@ -27,6 +30,7 @@ const LanguageScopeSelector: React.FC = () => {
       selected={languageScopes}
       getOptionLabel={getLanguageScopeLabel}
       getOptionDescription={getLanguageScopeDescription}
+      display={display}
     />
   );
 };

--- a/src/features/transforms/filtering/selectors/TerritoryScopeSelector.tsx
+++ b/src/features/transforms/filtering/selectors/TerritoryScopeSelector.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 
 import Selector from '@features/params/ui/Selector';
+import { SelectorDisplay } from '@features/params/ui/SelectorDisplayContext';
 import usePageParams from '@features/params/usePageParams';
 
 import { TerritoryScope } from '@entities/territory/TerritoryTypes';
 
 import { getTerritoryScopeLabel } from '@strings/TerritoryScopeStrings';
 
-const TerritoryScopeSelector: React.FC = () => {
+type Props = { display?: SelectorDisplay };
+
+const TerritoryScopeSelector: React.FC<Props> = ({ display }) => {
   const { territoryScopes, updatePageParams } = usePageParams();
 
   const selectorDescription =
@@ -28,6 +31,7 @@ const TerritoryScopeSelector: React.FC = () => {
       }
       selected={territoryScopes}
       getOptionLabel={getTerritoryScopeLabel}
+      display={display}
     />
   );
 };

--- a/src/features/transforms/filtering/selectors/VitalitySelector.tsx
+++ b/src/features/transforms/filtering/selectors/VitalitySelector.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import Selector from '@features/params/ui/Selector';
+import { SelectorDisplay } from '@features/params/ui/SelectorDisplayContext';
 import usePageParams from '@features/params/usePageParams';
 
 import {
@@ -18,7 +19,9 @@ import {
 
 const ETH_DISABLED = true;
 
-export const LanguageISOStatusSelector: React.FC = () => {
+type Props = { display?: SelectorDisplay };
+
+export const LanguageISOStatusSelector: React.FC<Props> = ({ display }) => {
   const { isoStatus, updatePageParams } = usePageParams();
 
   return (
@@ -34,6 +37,7 @@ export const LanguageISOStatusSelector: React.FC = () => {
       }
       selected={isoStatus}
       getOptionLabel={getLanguageISOStatusLabel}
+      display={display}
     />
   );
 };

--- a/src/features/transforms/filtering/selectors/__tests__/VitalitySelector.test.tsx
+++ b/src/features/transforms/filtering/selectors/__tests__/VitalitySelector.test.tsx
@@ -18,8 +18,8 @@ import {
 
 vi.mock('@features/params/usePageParams', () => ({ default: vi.fn() }));
 vi.mock('@features/params/ui/SelectorDisplayContext', () => ({
-  useSelectorDisplay: vi.fn().mockReturnValue({ display: 'buttonList' }),
-  SelectorDisplay: { ButtonList: 'buttonList', Dropdown: 'dropdown' },
+  useSelectorDisplay: vi.fn().mockReturnValue({ display: 'filterList' }),
+  SelectorDisplay: { ButtonList: 'buttonList', Dropdown: 'dropdown', FilterList: 'filterList' },
   SelectorDisplayProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 vi.mock('@features/layers/hovercard/useHoverCard', () => ({
@@ -59,9 +59,16 @@ describe('VitalitySelector', () => {
   });
 
   describe('LanguageISOStatusSelector', () => {
-    it('displays all ISO vitality options', () => {
+    it('displays all ISO vitality options', async () => {
+      const user = userEvent.setup();
       render(<LanguageISOStatusSelector />);
+
       const expected = Object.values(LanguageISOStatus).filter((v) => typeof v === 'number');
+
+      // If there are more than 4 options expand first so all are visible
+      if (expected.length > 4) {
+        await user.click(screen.getByText('Expand All'));
+      }
 
       expected.forEach((status) => {
         const label = getLanguageISOStatusLabel(status);


### PR DESCRIPTION
Fixes #671

Summary: Replaced dropdown/button displays for enum filters with a new Filter List display mode that shows options as a compact vertical list, showing the first 4 with an "Expand All" toggle when there are 5 or more.

- User experience
  - Enum filters (Language Authority, Modality, Languoid Type, Territory Type, ISO Language Status) now show as a vertical plain-text list instead of a dropdown or button group
  - Options are visible at a glance without needing to open a dropdown
  - "Expand All" / "Collapse" button appears when there are more than 4 options
- Logical changes
  - Added FilterList to the SelectorDisplay enum
  - Selector now slices visible options to the first 4 when in FilterList mode and not expanded
  - FilterListMoreButton component added to Selector for the expand/collapse toggle
  - SelectorContainer renders as flex-column with full width for FilterList
  - useClickOutside guarded to not collapse FilterList state on outside click
- Data
  - No data changes
- Refactors
  - LanguageModalitySelector, LanguageScopeSelector, TerritoryScopeSelector, VitalitySelector updated to accept and forward a display prop
  - VitalitySelector.test updated to include FilterList in the SelectorDisplay mock and added "Expand All" click before checking all options are visible

Out of scope/Future work: The dual meaning of expanded state (dropdown open vs filter list expanded) could be split into two separate state variables for clarity.

### Test Plan and Screenshots

How to test the changes in this PR: Run npm run dev, open the Filter panel, then verify enum filters show as vertical lists and "Expand All" works.

| Before | After |
| ------ | ----- |
| <img width="206" height="647" alt="image" src="https://github.com/user-attachments/assets/68554e19-dc31-4746-b662-f9677d131b2d" /> | <img width="218" height="648" alt="image" src="https://github.com/user-attachments/assets/d5621539-2895-4480-978b-1ac910442d16" /> |

# Checklist

Feel free to check off or just delete items in this section as you have completed them.

## Summary

- [x] Clear description of what and why
- [x] Scope kept focused; note follow-ups if any
- [x] Set yourself as assignee
- [x] Mention the issue (usually by writing "Fixes #ISSUE_NUMBER" or "Closes #ISSUE_NUMBER")

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test`
- [x] Tests added or updated for changed logic
- [x] `npm run dev` -- tried out the website directly
- [x] Include screenshots as noted below
- [x] Write comments on manual testing

## Changes

### Visual changes

- [x] Add screenshots to the table template at the top of this file. You can include images inside the table
- [x] Drag and drop images in the GitHub PR comment box to upload screenshots
- [x] Since more views can be reproduced by just sharing the URL -- add links (eg. [link](https://translation-commons.github.io/lang-nav/data)) to the relevant page and/or conditions to reproduce the view.

### Data changes

- [ ] TSV, SVG, etc. edits in `public/data/`
- [ ] Corresponding readmes updated in `public/data/`
- [ ] Load/connect/compute updates in `src/features/data/` including how we aggregate data or compute derived values

### Internal changes

- [x] Logical changes
- [x] Refactors, moving files around
- [x] If you notice any changes that require explanations, make sure to include the explanations in the code as well.

## Docs

- [x] Code is self-documenting, or if not, comments are added where needed.
- [ ] Updated markdown readme files documenting how the code behaves or how to develop in case there are any relevant changes to make.
