### PR TITLE
feat: add card pinning and keep pinned results at top

### DIFF
--- a/src/features/layers/hovercard/HoverableButton.tsx
+++ b/src/features/layers/hovercard/HoverableButton.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import useHoverCard from './useHoverCard';
 
 type HoverableProps = {
+  ariaLabel?: string;
   buttonType?: 'button' | 'submit' | 'reset';
   children: React.ReactNode;
   className?: string;
@@ -14,6 +15,7 @@ type HoverableProps = {
 };
 
 const HoverableButton: React.FC<HoverableProps> = ({
+  ariaLabel,
   buttonType = 'button',
   children,
   className,
@@ -28,6 +30,7 @@ const HoverableButton: React.FC<HoverableProps> = ({
   if (hoverContent == null) {
     return (
       <button
+        aria-label={ariaLabel}
         className={className}
         disabled={disabled}
         onClick={onClick}
@@ -53,6 +56,7 @@ const HoverableButton: React.FC<HoverableProps> = ({
 
   return (
     <button
+      aria-label={ariaLabel}
       className={className}
       disabled={disabled}
       onMouseEnter={handleMouseEnter}

--- a/src/features/transforms/filtering/useFilteredEntities.tsx
+++ b/src/features/transforms/filtering/useFilteredEntities.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import useEntities from '@features/data/context/useEntities';
+import usePageParams from '@features/params/usePageParams';
 import { getSortFunction } from '@features/transforms/sorting/sort';
 
 import { ObjectData } from '@entities/types/DataTypes';
@@ -31,6 +32,7 @@ const useFilteredEntities = <T extends ObjectData>({
 }: UseFilteredEntitiesParams<T>): { filteredEntities: T[]; allEntities: T[] } => {
   // Implementation of filtering logic goes here
   const pageEntities = useEntities() as T[]; // Get all objects of the relevant type from context
+  const { pinned } = usePageParams();
   // TODO use useFilters for all of these
   const filters = useFilters();
   const filterByScope = useScope ? getScopeFilter() : () => true;
@@ -45,15 +47,28 @@ const useFilteredEntities = <T extends ObjectData>({
     return allEntities
       .filter(
         (obj) =>
-          filterByScope(obj) &&
-          filterBySubstring(obj) &&
-          filterByConnections(obj) &&
-          filterByVitality(obj) &&
-          filterByPopulation(obj),
+          // Pinned entities always remain visible regardless of the active filters.
+          pinned.includes(obj.ID) ||
+          (filterByScope(obj) &&
+            filterBySubstring(obj) &&
+            filterByConnections(obj) &&
+            filterByVitality(obj) &&
+            filterByPopulation(obj)),
       )
-      .sort(sortFunction);
+      .sort((a, b) => {
+        const aIndex = pinned.indexOf(a.ID);
+        const bIndex = pinned.indexOf(b.ID);
+        const aPinned = aIndex !== -1;
+        const bPinned = bIndex !== -1;
+        // Pinned entities always come first, in the order they were pinned, so they
+        // reliably stay at the top (and on the first page) across refreshes.
+        if (aPinned && bPinned) return aIndex - bIndex;
+        if (aPinned !== bPinned) return aPinned ? -1 : 1;
+        return sortFunction(a, b);
+      });
   }, [
     allEntities,
+    pinned,
     filterByScope,
     filterBySubstring,
     filterByConnections,

--- a/src/widgets/cardlists/CardInCardList.tsx
+++ b/src/widgets/cardlists/CardInCardList.tsx
@@ -1,10 +1,12 @@
-import { PinIcon, PinOffIcon } from 'lucide-react';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 
-import HoverableButton from '@features/layers/hovercard/HoverableButton';
 import usePageParams from '@features/params/usePageParams';
 
 import { ObjectData } from '@entities/types/DataTypes';
+
+import CardPinButton from './CardPinButton';
+
+import './cardListStyles.css';
 
 interface Props {
   children: React.ReactNode;
@@ -14,8 +16,6 @@ interface Props {
 
 const CardInCardList: React.FC<Props> = ({ children, getBackgroundColor, object }) => {
   const { updatePageParams, objectID, pinned } = usePageParams();
-  const [isHovering, setIsHovering] = React.useState(false);
-  const [isHoveringPin, setIsHoveringPin] = React.useState(false);
 
   const isPinned = pinned.includes(object.ID);
   const togglePin = useCallback(() => {
@@ -24,15 +24,6 @@ const CardInCardList: React.FC<Props> = ({ children, getBackgroundColor, object 
     });
   }, [isPinned, pinned, object.ID, updatePageParams]);
 
-  // The pin button is only visible while hovering the card or when the card is already pinned.
-  const showPinButton = isHovering || isPinned;
-  // When a pinned card's button is hovered, show the "unpin" affordance instead.
-  const PinButtonIcon = isPinned && isHoveringPin ? PinOffIcon : PinIcon;
-  const borderColor = useMemo(() => {
-    if (objectID === object.ID) return 'var(--color-button-primary)';
-    if (isHovering) return 'var(--color-button-hover)';
-    return 'transparent';
-  }, [getBackgroundColor, object, isHovering, objectID]);
   const openObject = useCallback(() => {
     if (object) updatePageParams({ objectID: object.ID });
   }, [object, updatePageParams]);
@@ -66,49 +57,13 @@ const CardInCardList: React.FC<Props> = ({ children, getBackgroundColor, object 
       className={`CardInCardList ${object.ID === objectID ? 'selected' : ''}`}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
-      onMouseEnter={() => setIsHovering(true)}
-      onMouseLeave={() => setIsHovering(false)}
       role="button"
       style={{
-        position: 'relative',
-        borderWidth: '2px',
-        borderStyle: 'solid',
-        borderRadius: '0.5em',
-        boxShadow: 'var(--color-shadow) 0 0 1rem 2px',
-        padding: '1rem',
-        textAlign: 'start',
-        cursor: 'pointer',
-        borderColor: borderColor,
         backgroundColor: getBackgroundColor ? (getBackgroundColor(object) ?? 'inherit') : undefined,
       }}
       tabIndex={0}
     >
-      {showPinButton && (
-        <HoverableButton
-          hoverContent={isPinned ? 'Unpin from the page' : 'Pin to the page'}
-          onClick={togglePin}
-          className="CardPinButton"
-          style={{
-            position: 'absolute',
-            top: '0.5rem',
-            right: '0.5rem',
-            background: 'transparent',
-            border: 'none',
-            padding: '0.25rem',
-            lineHeight: 0,
-            color: isPinned ? 'var(--color-button-primary)' : 'var(--color-text)',
-          }}
-        >
-          <span
-            aria-label={isPinned ? 'Unpin from the page' : 'Pin to the page'}
-            onMouseEnter={() => setIsHoveringPin(true)}
-            onMouseLeave={() => setIsHoveringPin(false)}
-            style={{ display: 'inline-flex' }}
-          >
-            <PinButtonIcon size="1em" />
-          </span>
-        </HoverableButton>
-      )}
+      <CardPinButton isPinned={isPinned} onTogglePin={togglePin} />
       {children}
     </div>
   );

--- a/src/widgets/cardlists/CardInCardList.tsx
+++ b/src/widgets/cardlists/CardInCardList.tsx
@@ -1,5 +1,7 @@
+import { PinIcon, PinOffIcon } from 'lucide-react';
 import React, { useCallback, useMemo } from 'react';
 
+import HoverableButton from '@features/layers/hovercard/HoverableButton';
 import usePageParams from '@features/params/usePageParams';
 
 import { ObjectData } from '@entities/types/DataTypes';
@@ -11,8 +13,21 @@ interface Props {
 }
 
 const CardInCardList: React.FC<Props> = ({ children, getBackgroundColor, object }) => {
-  const { updatePageParams, objectID } = usePageParams();
+  const { updatePageParams, objectID, pinned } = usePageParams();
   const [isHovering, setIsHovering] = React.useState(false);
+  const [isHoveringPin, setIsHoveringPin] = React.useState(false);
+
+  const isPinned = pinned.includes(object.ID);
+  const togglePin = useCallback(() => {
+    updatePageParams({
+      pinned: isPinned ? pinned.filter((id) => id !== object.ID) : [...pinned, object.ID],
+    });
+  }, [isPinned, pinned, object.ID, updatePageParams]);
+
+  // The pin button is only visible while hovering the card or when the card is already pinned.
+  const showPinButton = isHovering || isPinned;
+  // When a pinned card's button is hovered, show the "unpin" affordance instead.
+  const PinButtonIcon = isPinned && isHoveringPin ? PinOffIcon : PinIcon;
   const borderColor = useMemo(() => {
     if (objectID === object.ID) return 'var(--color-button-primary)';
     if (isHovering) return 'var(--color-button-hover)';
@@ -55,6 +70,7 @@ const CardInCardList: React.FC<Props> = ({ children, getBackgroundColor, object 
       onMouseLeave={() => setIsHovering(false)}
       role="button"
       style={{
+        position: 'relative',
         borderWidth: '2px',
         borderStyle: 'solid',
         borderRadius: '0.5em',
@@ -67,6 +83,32 @@ const CardInCardList: React.FC<Props> = ({ children, getBackgroundColor, object 
       }}
       tabIndex={0}
     >
+      {showPinButton && (
+        <HoverableButton
+          hoverContent={isPinned ? 'Unpin from the page' : 'Pin to the page'}
+          onClick={togglePin}
+          className="CardPinButton"
+          style={{
+            position: 'absolute',
+            top: '0.5rem',
+            right: '0.5rem',
+            background: 'transparent',
+            border: 'none',
+            padding: '0.25rem',
+            lineHeight: 0,
+            color: isPinned ? 'var(--color-button-primary)' : 'var(--color-text)',
+          }}
+        >
+          <span
+            aria-label={isPinned ? 'Unpin from the page' : 'Pin to the page'}
+            onMouseEnter={() => setIsHoveringPin(true)}
+            onMouseLeave={() => setIsHoveringPin(false)}
+            style={{ display: 'inline-flex' }}
+          >
+            <PinButtonIcon size="1em" />
+          </span>
+        </HoverableButton>
+      )}
       {children}
     </div>
   );

--- a/src/widgets/cardlists/CardPinButton.tsx
+++ b/src/widgets/cardlists/CardPinButton.tsx
@@ -1,0 +1,28 @@
+import { PinIcon, PinOffIcon } from 'lucide-react';
+import React from 'react';
+
+import HoverableButton from '@features/layers/hovercard/HoverableButton';
+
+interface Props {
+  isPinned: boolean;
+  onTogglePin: () => void;
+}
+
+const CardPinButton: React.FC<Props> = ({ isPinned, onTogglePin }) => {
+  // The action on a pinned card is always to unpin it, so the label reflects that.
+  const label = isPinned ? 'Unpin from the page' : 'Pin to the page';
+
+  return (
+    <HoverableButton
+      ariaLabel={label}
+      className={'CardPinButton' + (isPinned ? ' pinned' : '')}
+      hoverContent={label}
+      onClick={onTogglePin}
+    >
+      <PinIcon className="CardPinButton-iconPin" size="1em" />
+      <PinOffIcon className="CardPinButton-iconUnpin" size="1em" />
+    </HoverableButton>
+  );
+};
+
+export default CardPinButton;

--- a/src/widgets/cardlists/cardListStyles.css
+++ b/src/widgets/cardlists/cardListStyles.css
@@ -1,0 +1,65 @@
+.CardInCardList {
+  position: relative;
+  border: 2px solid transparent;
+  border-radius: 0.5em;
+  box-shadow: var(--color-shadow) 0 0 1rem 2px;
+  padding: 1rem;
+  text-align: start;
+  cursor: pointer;
+}
+
+.CardInCardList:hover {
+  border-color: var(--color-button-hover);
+}
+
+/* Selected takes priority over hover (declared later, equal specificity). */
+.CardInCardList.selected {
+  border-color: var(--color-button-primary);
+}
+
+.CardPinButton {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  padding: 0.25rem;
+  background: transparent;
+  border: none;
+  line-height: 0;
+  color: var(--color-text);
+  /* Hidden until the card is hovered (or the card is pinned, see below). */
+  visibility: hidden;
+}
+
+.CardInCardList:hover .CardPinButton,
+.CardPinButton.pinned {
+  visibility: visible;
+}
+
+/* Keep the icon button transparent even when focused/hovered. Without this the
+   global `button:focus`/`button:hover` rules paint a blue background that lingers
+   (e.g. after clicking) until focus moves elsewhere. */
+.CardPinButton:hover,
+.CardPinButton:focus {
+  background: transparent;
+  border-color: transparent;
+  color: var(--color-text);
+}
+
+.CardPinButton.pinned,
+.CardPinButton.pinned:hover,
+.CardPinButton.pinned:focus {
+  color: var(--color-button-primary);
+}
+
+/* Show the "unpin" affordance only while hovering an already-pinned button. */
+.CardPinButton-iconUnpin {
+  display: none;
+}
+
+.CardPinButton.pinned:hover .CardPinButton-iconPin {
+  display: none;
+}
+
+.CardPinButton.pinned:hover .CardPinButton-iconUnpin {
+  display: inline-block;
+}


### PR DESCRIPTION
Fixes #659 

Summary: Adds card pinning from the card list and ensures pinned entities stay visible at the top of filtered results.

### Changes

- User experience
  - Added a floating pin button to cards
  - The pin button appears when the card is hovered or when the card is already pinned.
  - Added hover text for **Pin to the page** and **Unpin from the page**.
  - Pinned cards keep the pin button visible.
  - Hovering over the pin button on a pinned card switches the icon from PinIcon to PinOffIcon.
  
- Logical changes
  - Pinned entities bypass active filters.
  - Pinned entities remain visible even when the current search or filters would normally hide them.
  - Pinned entities are sorted to the front
  - Pinned entities preserve the order stored in the pinned page param.
  - Non-pinned entities continue to follow the normal sort order.
  

### Screenshots
- Pinned
<img width="1197" height="696" alt="image" src="https://github.com/user-attachments/assets/fb479fa0-1827-41dc-be05-7055f2bace84" />

- Pinned entities bypass active filters
<img width="1197" height="747" alt="image" src="https://github.com/user-attachments/assets/2a00f998-8822-4f02-8bdc-65628cf1f76f" />

- Hover text for **Pin to the page** and **Unpin from the page**
<img width="524" height="437" alt="image" src="https://github.com/user-attachments/assets/8b2cd243-db2a-42e9-8800-890c5d97878b" />
<img width="855" height="500" alt="image" src="https://github.com/user-attachments/assets/1f80f1dc-b8dc-4a76-89a7-b615779f8633" />


