### PR TITLE
Fix Combined language hierarchy for ISO-only groupings

### DIFF
--- a/public/data/tc/languageFamilyCombinedOverrides.tsv
+++ b/public/data/tc/languageFamilyCombinedOverrides.tsv
@@ -1,0 +1,25 @@
+# Manual overrides for Combined language family hierarchy.
+# ISO-only groupings that Glottolog does not use need explicit Combined parent/child fixes.
+# Only Combined.parentLanguageCode is modified; ISO and Glottolog sources are unchanged.
+parentLanguageCode	childLanguageCode	notes
+sqj	sqi	Albanian macrolanguage in Albanian family
+qwe	que	Quechuan macrolanguage in Quechuan family
+euq	eus	Basque language in Basque family
+map	fox	Formosan in Austronesian
+fox	east2493	East Formosan in Formosan
+fox	atay1246	Atayalic in Formosan
+fox	pwn	Paiwan in Formosan
+fox	bnn	Bunun in Formosan
+fox	dru	Rukai in Formosan
+fox	nort2899	Northwest Formosan in Formosan
+fox	tsou1250	Tsouic in Formosan
+fox	pyu	Puyuma in Formosan
+fox	west2572	Western Plains Austronesian in Formosan
+sdv	nilo1247	Nilotic in Eastern Sudanic
+omv	gong1255	Ta-Ne-Omotic in Omotic
+omv	sout2845	South Omotic in Omotic
+sai	ayma1253	Aymaran in South American Indian
+sai	arau1255	Araucanian in South American Indian
+ssa	fura1235	Furan in Nilo-Saharan
+ssa	maba1274	Maban in Nilo-Saharan
+nic	dogo1299	Dogon in Niger-Kordofanian

--- a/src/features/data/load/CoreData.tsx
+++ b/src/features/data/load/CoreData.tsx
@@ -27,6 +27,10 @@ import { loadOrganizations } from './entities/loadOrganizations';
 import { loadTerritories } from './entities/loadTerritories';
 import { loadWritingSystems } from './entities/loadWritingSystems';
 import {
+  applyCombinedFamilyOverrides,
+  loadCombinedFamilyOverrides,
+} from './extra_entities/CombinedFamilyOverrides';
+import {
   addGlottologLanguages,
   loadGlottocodeToISO,
   loadGlottologLanguages,
@@ -94,6 +98,7 @@ export function useCoreData(): {
       ethnologueLangs,
       glottologImport,
       glottocodeToISO,
+      combinedFamilyOverrides,
       territories,
       locales,
       writingSystems,
@@ -111,6 +116,7 @@ export function useCoreData(): {
       loadEthnologueLanguages(),
       loadGlottologLanguages(),
       loadGlottocodeToISO(),
+      loadCombinedFamilyOverrides(),
       loadTerritories(),
       loadLocales(),
       loadWritingSystems(),
@@ -143,6 +149,7 @@ export function useCoreData(): {
     addISOMacrolanguageData(languagesBySource.ISO, macroLangs || []);
     addISORetirementsToLanguages(languagesBySource, isoRetirements || []);
     addGlottologLanguages(languagesBySource, glottologImport || [], glottocodeToISO || {});
+    applyCombinedFamilyOverrides(languagesBySource, combinedFamilyOverrides || []);
     addCLDRLanguageDetails(languagesBySource);
     addIANAVariantLocales(languagesBySource.BCP, locales, variants);
 

--- a/src/features/data/load/extra_entities/CombinedFamilyOverrides.tsx
+++ b/src/features/data/load/extra_entities/CombinedFamilyOverrides.tsx
@@ -1,0 +1,71 @@
+import {
+  LanguageCode,
+  LanguageDictionary,
+  LanguagesBySource,
+} from '@entities/language/LanguageTypes';
+
+export type CombinedFamilyOverride = {
+  parentLanguageCode: LanguageCode;
+  childLanguageCode: LanguageCode;
+};
+
+const HEADER_PARENT_COLUMN = 'parentLanguageCode';
+
+export async function loadCombinedFamilyOverrides(): Promise<CombinedFamilyOverride[] | void> {
+  return await fetch('data/tc/languageFamilyCombinedOverrides.tsv')
+    .then((res) => res.text())
+    .then((text) =>
+      text
+        .split('\n')
+        .filter((line) => line !== '' && !line.startsWith('#'))
+        .map(parseCombinedFamilyOverrideLine)
+        .filter((override): override is CombinedFamilyOverride => override != null),
+    )
+    .catch((err) => console.error('Error loading TSV:', err));
+}
+
+function parseCombinedFamilyOverrideLine(line: string): CombinedFamilyOverride | null {
+  const parts = line.split('\t');
+  const parentLanguageCode = parts[0];
+  if (parentLanguageCode === HEADER_PARENT_COLUMN) return null;
+
+  const childLanguageCode = parts[1];
+  return { parentLanguageCode, childLanguageCode };
+}
+
+/**
+ * Apply manual Combined-family overrides after ISO and Glottolog data have been merged.
+ * Only Combined.parentLanguageCode is modified; ISO and Glottolog sources are unchanged.
+ */
+export function applyCombinedFamilyOverrides(
+  languagesBySource: LanguagesBySource,
+  overrides: CombinedFamilyOverride[],
+): void {
+  const combined = languagesBySource.Combined;
+
+  overrides.forEach((override) => {
+    setCombinedParent(combined, override.childLanguageCode, override.parentLanguageCode);
+  });
+}
+
+function setCombinedParent(
+  combined: LanguageDictionary,
+  childLanguageCode: LanguageCode,
+  parentLanguageCode: LanguageCode,
+): void {
+  const child = combined[childLanguageCode];
+  const parent = combined[parentLanguageCode];
+  if (child == null || parent == null) {
+    console.debug(
+      `Combined family override: child ${childLanguageCode} or parent ${parentLanguageCode} not found`,
+    );
+    return;
+  }
+  if (!child.Combined || !parent.Combined) {
+    console.debug(
+      `Combined family override: missing Combined source for ${childLanguageCode} or ${parentLanguageCode}`,
+    );
+    return;
+  }
+  child.Combined.parentLanguageCode = parentLanguageCode;
+}

--- a/src/features/data/load/extra_entities/__tests__/CombinedFamilyOverrides.test.ts
+++ b/src/features/data/load/extra_entities/__tests__/CombinedFamilyOverrides.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { EMPTY_LANGUAGES_BY_SCHEMA } from '@features/data/load/CoreData';
+
+import { getBaseLanguageData, LanguageData } from '@entities/language/LanguageTypes';
+
+import { applyCombinedFamilyOverrides } from '../CombinedFamilyOverrides';
+
+function makeLang(id: string, parentCode?: string) {
+  const lang = getBaseLanguageData(id, id);
+  lang.Combined.parentLanguageCode = parentCode;
+  lang.ISO.parentLanguageCode = parentCode;
+  lang.Glottolog.parentLanguageCode = parentCode;
+  return lang;
+}
+
+describe('applyCombinedFamilyOverrides', () => {
+  it('sets Combined parent without changing ISO or Glottolog parents', () => {
+    const sqi = makeLang('sqi', 'clas1257');
+    const sqj = makeLang('sqj', 'ine');
+    const languagesBySource = {
+      ...EMPTY_LANGUAGES_BY_SCHEMA,
+      Combined: { sqi, sqj },
+      ISO: { sqi, sqj },
+      Glottolog: { sqi, sqj },
+    };
+
+    applyCombinedFamilyOverrides(languagesBySource, [
+      { parentLanguageCode: 'sqj', childLanguageCode: 'sqi' },
+    ]);
+
+    expect(sqi.Combined.parentLanguageCode).toBe('sqj');
+    expect(sqi.ISO.parentLanguageCode).toBe('clas1257');
+    expect(sqi.Glottolog.parentLanguageCode).toBe('clas1257');
+  });
+
+  it('applies explicit Formosan child overrides under fox', () => {
+    const map = makeLang('map');
+    const fox = makeLang('fox', 'map');
+    const east2493 = makeLang('east2493', 'map');
+    const pwn = makeLang('pwn', 'map');
+    const poz = makeLang('poz', 'map');
+    const languagesBySource = {
+      ...EMPTY_LANGUAGES_BY_SCHEMA,
+      Combined: { map, fox, east2493, pwn, poz },
+    };
+
+    applyCombinedFamilyOverrides(languagesBySource, [
+      { parentLanguageCode: 'fox', childLanguageCode: 'east2493' },
+      { parentLanguageCode: 'fox', childLanguageCode: 'pwn' },
+    ]);
+
+    expect(east2493.Combined.parentLanguageCode).toBe('fox');
+    expect(pwn.Combined.parentLanguageCode).toBe('fox');
+    expect(poz.Combined.parentLanguageCode).toBe('map');
+  });
+
+  it('skips entries missing Combined source objects', () => {
+    const child = makeLang('sqi', 'clas1257');
+    const parent = makeLang('sqj', 'ine');
+    (child as LanguageData).Combined = undefined as unknown as LanguageData['Combined'];
+
+    const languagesBySource = {
+      ...EMPTY_LANGUAGES_BY_SCHEMA,
+      Combined: { sqi: child, sqj: parent },
+    };
+
+    applyCombinedFamilyOverrides(languagesBySource, [
+      { parentLanguageCode: 'sqj', childLanguageCode: 'sqi' },
+    ]);
+
+    expect(child.Combined).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Rebased on latest `master` and addresses @conradarcturus review on #651.

- Replace `reparent-children-except` with explicit row-per-child entries in `languageFamilyCombinedOverrides.tsv`
- Add Formosan children under `fox`, plus Conrad's additional ISO-only groupings (`sdv`, `omv`, `sai`, `ssa`, `nic`)
- Apply overrides after Glottolog load; only `Combined.parentLanguageCode` is modified

Fixes #650

Supersedes #651 and #684 (same change set, now on upstream branch for deploy-preview).

## Test plan

- [x] `npm run test:run` — `CombinedFamilyOverrides.test.ts`
- [x] `npm run lint` && `npm run build`
- [x] Hierarchy UI verified locally (Combined source) — see PR comment with screenshots


Made with [Cursor](https://cursor.com)