### PR TITLE
Census Batch 2026-06-24 + improve language name decoding

### DIFF
--- a/public/data/census/data.un.org/by.tsv
+++ b/public/data/census/data.un.org/by.tsv
@@ -10,6 +10,7 @@
 #acquisitionOrder			L1	L1
 #responsesPerIndividual		1		1
 #url	https://data.un.org/Data.aspx?d=POP&f=tableCode:27			
+#collectorType	Government			
 #presentedBy	UNdata			
 Language Code	Language Name	by1999	by2009	by2019
 mul	Total	10,045,237	9,503,807	9,413,446

--- a/public/data/census/data.un.org/mo.tsv
+++ b/public/data/census/data.un.org/mo.tsv
@@ -10,6 +10,7 @@
 #languagesIncluded					
 #sampleRate				0.1	
 #url	https://data.un.org/Data.aspx?d=POP&f=tableCode:27				
+#collectorType	Government					
 #presentedBy	UNdata					
 Language Code	Language Name	mo2001	mo2011	mo2016	mo2021
 mul	Total	424,203	539,131	632,857	663,782

--- a/public/data/census/official/censusList.txt
+++ b/public/data/census/official/censusList.txt
@@ -3,6 +3,7 @@ bs2013
 ca2021
 cl2024
 cn-cmn2020
+cw2023
 de
 es2021
 gn2014
@@ -16,6 +17,7 @@ pk2023
 py
 ru2020
 sg
+sr2012
 us_asc
 us2023
 vi

--- a/public/data/census/official/cw2023.tsv
+++ b/public/data/census/official/cw2023.tsv
@@ -1,0 +1,40 @@
+#nameDisplay		Curaçao 2023	Curaçao 2023 L1	Curaçao 2023 L2	Curaçao 2023 L3
+#isoRegionCode	CW				
+#yearCollected	2023				
+### Language Criteria ###					
+#languageUse	Speaks				
+#acquisitionOrder		Any	L1	L2	L3
+### Population Surveyed ###					
+#population	155,826				
+#populationSource					
+#populationWithPositiveResponses	147,498				
+#populationSurveyed	155,826				
+#sampleRate	1				
+#responsesPerIndividual			1	1	1
+### Data Constraints ###					
+#geographicScope	whole country				
+#age	0+				
+#nationality	residents				
+#residenceBasis	de jure				
+#quantity	percent				
+### Creator ###					
+#collectorType	Government				
+#collectorName	Centraal Bureau voor de Statistiek Curaçao				
+#collectorNameShort	CBS Curaçao				
+#author					
+### Source Document ###					
+#url	https://cuatro.sim-cdn.nl/sensocbs/uploads/04062024-publicatie-eerste-resultaten-census-2023.pdf				
+#datePublished	2024-06-04				
+#dateAccessed	2026-06-02				
+#documentName	Publicatie Eerste Resultaten Census 2023				
+#sectionName	Talen gesproken thuis				
+#tableName	Meest gesproken taal/talen thuis				
+#columnName		Gepsroken thuistaal (plaats onwillekeurig)	eerste taal	tweede taal	derde taal
+#citation	Centraal Bureau voor de Statistiek Curaçao (CBS Curaçao). Census 2023 – Talen gesproken thuis, tabel “Meest gesproken taal/talen thuis”, eerste taal.				
+#notes					
+Language Code	Language	Population			
+pap	Papiamentu	89.9%	78.0%	9.9%	2.0%
+nld	Dutch	26.4%	7.9%	11.6%	6.9%
+spa	Spanish	18.0%	8.4%	5.9%	3.7%
+eng	English	22.1%	3.8%	10.8%	7.5%
+mul	Other	3.6%	2.0%	1.1%	0.5%

--- a/public/data/census/official/sr2012.tsv
+++ b/public/data/census/official/sr2012.tsv
@@ -1,0 +1,50 @@
+#codeDisplay		#nl	sr2012.L1	sr2012.L2	sr2012
+#nameDisplay	Suriname 2012				
+#isoRegionCode	SR				
+#yearCollected	2012				
+### Language Criteria ###					
+#languageUse	Speaks				
+#acquisitionOrder			L1	L2	Any
+### Population Surveyed ###					
+#population	140,367				
+#populationSource	2012 Suriname Census – Table 2 (households by most spoken language)				
+#populationWithPositiveResponses	137,174				
+#populationSurveyed	140,367				
+#sampleRate	1				
+#responsesPerIndividual			1	1	1+
+### Data Constraints ###					
+#geographicScope	whole country				
+#age	0+				
+#nationality	residents				
+#languagesIncluded	all				
+#residenceBasis	de facto				
+#quantity	count				
+### Creator ###					
+#collectorType	Government				
+#collectorName	Algemeen Bureau voor de Statistiek Suriname				
+#collectorNameShort	ABS Suriname				
+#author					
+### Source Document ###					
+#url	https://statistics-suriname.org/wp-content/uploads/2019/05/Publicatie-Census-8-Volume-3-Huishoudens-Gezinnen-en-Woonverblijven-Milieu-Criminaliteit.pdf				
+#datePublished	2019-05-01				
+#dateAccessed	2026-05-26				
+#documentName	Census 8 Volume 3: Huishoudens, Gezinnen en Woonverblijven, Milieu, Criminalite				
+#sectionName	Taal in het huishouden				
+#tableName	Tabel 2. Aantal huishoudens naar meest gesproken taal en tweede gesproken taal 				
+#columnName			Meest gesproken taal in het huishouden	Tweede gesproken taal in het huishouden	
+#citation	Algemeen Bureau voor de Statistiek Suriname. Census 8 Volume 3: Huishoudens, Gezinnen en Woonverblijven, Milieu, Criminaliteit. Table: Aantal huishoudens naar meest gesproken taal en tweede gesproken taal.				
+#notes	Counts are household-level, not individual population counts. Unknown responses were excluded from positive responses.				Data added up from prior columns
+Language Code	Language		Population		
+nld	Dutch	Nederlands	69,715	33883	103,598
+srn	Sranan Tongo	Sranan tongo	11,802	50143	61,945
+hns/sarn1238	Sarnami	Sarnami	19,830	10758	30,588
+jav	Javanese	Javaans	5,531	7436	12,967
+mul	Indigenous languages	Inheemse taal	368	329	697
+srm	Marron languages	Marrontaal	21,699	3508	25,207
+zho	Chinese	Chinees	1,564	371	1,935
+por	Portuguese	Portugees	1449	369	1818
+eng	English	Engels	3,222	3711	6,933
+fra	French	Frans	221	378	599
+mul	Other	Andere	1,773	535	2,308
+zxx	No second language	Geen 2e taal		25163	
+mis	Unknown	Onbekend	3,193	3783	

--- a/public/data/census/official/wf.tsv
+++ b/public/data/census/official/wf.tsv
@@ -1,0 +1,30 @@
+#nameDisplay		Wallis & Futuna 2026	Wallis & Futuna 2008 Speaks	Wallis & Futuna 2008 Reads	Wallis & Futuna 2008 Writes	Wallis & Futuna 2008 Primary
+#isoRegionCode	WF					
+#yearCollected		2026	2008	2008	2008	2008
+### Language Criteria ###						
+#languageUse		Speaks	Speaks	Reads	Writes	Speaks
+#acquisitionOrder		L1				
+#domain						Primary
+### Population Surveyed ###						
+#population		11,151	12,246	12,246	12,246	12,246
+#populationWithPositiveResponses			9,672	9,672	9,672	9,672
+#populationSource		WorldData language distribution				
+### Data Constraints ###						
+#nationality		residents				
+#quantity		percent	count	count	count	count
+### Creator ###						
+### Source Document ###						
+#url		https://www.worlddata.info/oceania/wallis-and-futuna/index.php	https://web.archive.org/web/20110604180112/http://www.insee.fr/fr/ppp/bases-de-donnees/irweb/rpwf08/dd/excel/rpwf08_Pop_06.xls	https://web.archive.org/web/20110604180112/http://www.insee.fr/fr/ppp/bases-de-donnees/irweb/rpwf08/dd/excel/rpwf08_Pop_06.xls	https://web.archive.org/web/20110604180112/http://www.insee.fr/fr/ppp/bases-de-donnees/irweb/rpwf08/dd/excel/rpwf08_Pop_06.xls	https://web.archive.org/web/20110604180112/http://www.insee.fr/fr/ppp/bases-de-donnees/irweb/rpwf08/dd/excel/rpwf08_Pop_06.xls
+#datePublished			2008-07-21	2008-07-21	2008-07-21	2008-07-21
+#dateAccessed		2026-06-02	2011-06-04	2011-06-04	2011-06-04	2011-06-04
+#documentName			Recensement général de la population du Territoire des îles Wallis et Futuna - 21 juillet 2008	Recensement général de la population du Territoire des îles Wallis et Futuna - 21 juillet 2008	Recensement général de la population du Territoire des îles Wallis et Futuna - 21 juillet 2008	Recensement général de la population du Territoire des îles Wallis et Futuna - 21 juillet 2008
+#sectionName		Languages				
+#tableName		Mother Tongue Distribution	Tableau Pop_06_1 : Population selon le sexe, la connaissance du français et l'âge décennal			Tableau Pop_06_6 : Population selon le sexe, la langue la plus couramment parlée en famille, l'âge décennal et par village de résidence
+#notes			Multiple tables with prefix Tableau Pop_06			
+Language Code	Language	Population				
+poly1242	Polynesian		8,973	8,662	8,558	
+wls	Wallisian	58.9	6,170	5,952	5,875	5,818
+fud	Futunan	30.1	2,803	2,710	2,683	2,891
+fra	French	10.8	7,997	7,705	7,562	939
+eng	English		1,425			
+mul	other	0.2				24

--- a/public/data/census/official/yt.tsv
+++ b/public/data/census/official/yt.tsv
@@ -10,7 +10,7 @@
 #age		14+	15+	15+	9+	9+	9+	9+
 #responsesPerIndividual		1	1+	1+	1+	1+	1+	1+
 #url		https://data.un.org/Data.aspx?d=POP&f=tableCode:27	http://www.insee.fr/fr/insee_regions/mayotte/themes/dossiers/rp/rp2002/for5.xls	https://web.archive.org/web/20150924164057/https://www.insee.fr/fr/insee_regions/mayotte/themes/dossiers/rp/rp2002/for4.xls	https://web.archive.org/web/20070614075940/http://www.ac-mayotte.fr/IMG/pdf/Interv_BARRETEAU_CM2.pdf	https://web.archive.org/web/20070614075940/http://www.ac-mayotte.fr/IMG/pdf/Interv_BARRETEAU_CM2.pdf	https://web.archive.org/web/20070614075940/http://www.ac-mayotte.fr/IMG/pdf/Interv_BARRETEAU_CM2.pdf	https://web.archive.org/web/20070614075940/http://www.ac-mayotte.fr/IMG/pdf/Interv_BARRETEAU_CM2.pdf
-#collectorType		Government	Government	Government	Study			
+#collectorType		Government	Government	Government	Study	Study	Study	Study
 #notes		Census - de jure - complete tabulation			Recomputed from a highly sampled sociolinguistic dataset. Targetting "Mothertongue"			
 swb	Mahorais/Shimaore		37840	80140	71789	115009	1480	2371
 fra	French/Français	6,696	50607	54784	1795	74166	37	1529

--- a/public/data/census/unofficial/axl.cd.tsv
+++ b/public/data/census/unofficial/axl.cd.tsv
@@ -1,4 +1,4 @@
-#nameDisplay		Congo Kinshasa, Local Languages	Congo Kinshasa, National Languages	Congo Kinshasa, National Languages L1	Congo Kinshasa, National Languages L2	Congo Kinshasa, National Languages Percent	Congo Kinshasa, Official Languages
+#nameDisplay		AXL Congo Kinshasa, Local Languages	AXL Congo Kinshasa, National Languages	AXL Congo Kinshasa, National Languages L1	AXL Congo Kinshasa, National Languages L2	AXL Congo Kinshasa, National Languages Percent	AXL Congo Kinshasa, Official Languages
 #isoRegionCode	CD						
 #yearCollected	1996						
 ### Language Criteria ###							
@@ -12,7 +12,7 @@
 #quantity	count					percent	percent
 ### Creator ###							
 #collectorType	Secondary						
-#author	Jacques LeClerc						
+#author	Jacques Leclerc						
 #presentedBy	AXL						
 ### Source Document ###							
 #url	https://www.axl.cefan.ulaval.ca/afrique/czaire.htm						

--- a/public/data/census/unofficial/axl.cx.tsv
+++ b/public/data/census/unofficial/axl.cx.tsv
@@ -1,5 +1,5 @@
 #codeDisplay		#original french names	axl.cx.eth	axl.cx.spoken
-#nameDisplay			Christmas Island 2001 Ethnicity	Christmas Island 2001 Spoken
+#nameDisplay			AXL Christmas Island Ethnicity	AXL Christmas Island Spoken
 #isoRegionCode	CX			
 #yearCollected	2001			
 ### Language Criteria ###				

--- a/public/data/census/unofficial/axl.gl.tsv
+++ b/public/data/census/unofficial/axl.gl.tsv
@@ -1,5 +1,5 @@
 #codeDisplay		axl.gl.perc	axl.gl.count
-#nameDisplay		Greenland 2024 by Percent	Greenland 2024 Counts
+#nameDisplay		AXL Greenland by Percent	AXL Greenland Counts
 #isoRegionCode	GL		
 #yearCollected	2024		
 ### Language Criteria ###			

--- a/public/data/census/unofficial/axl.nf.tsv
+++ b/public/data/census/unofficial/axl.nf.tsv
@@ -1,0 +1,17 @@
+#codeDisplay		axl.nf
+#nameDisplay	AXL Norfolk Islands	
+#isoRegionCode	NF	
+#yearCollected	2011	
+#languageUse	Speaks	
+#proficiency	Fluent	
+#acquisitionOrder	L1	
+#population	2,302	
+#populationSource	https://www.axl.cefan.ulaval.ca/pacifique/norfolk.htm	
+#responsesPerIndividual	1	
+#quantity		percent
+#collectorType	Secondary	
+#presentedBy	AXL	
+#url	https://www.axl.cefan.ulaval.ca/pacifique/norfolk.htm	
+Language Code	Language	
+eng	English	66
+pih	Pitcairn-Norfolk	33.3

--- a/public/data/census/unofficial/axl.pn.tsv
+++ b/public/data/census/unofficial/axl.pn.tsv
@@ -1,0 +1,15 @@
+#nameDisplay	AXL Pitcairn Islands		
+#isoRegionCode	PN		
+#yearCollected	2021		
+#languageUse		Writes	Speaks
+#acquisitionOrder		L2	L1
+#population	47		
+#populationSource	https://www.axl.cefan.ulaval.ca/pacifique/Pitcairn.htm		
+#responsesPerIndividual	1		
+#quantity	percent		
+#collectorType	Secondary		
+#presentedBy	AXL		
+#url	https://www.axl.cefan.ulaval.ca/pacifique/Pitcairn.htm		
+Language Code	Language		
+eng	English	100	
+pih	Pitcairn Creole		100

--- a/public/data/census/unofficial/axl.qa.tsv
+++ b/public/data/census/unofficial/axl.qa.tsv
@@ -1,0 +1,55 @@
+#codeDisplay		#fr	axl.qa	#axl.qa.perc	#ethnic group
+#nameDisplay			AXL Qatar	Qatar 2025 percent	
+#isoRegionCode	QA				
+#yearCollected	2025				
+### Language Criteria ###					
+#languageUse	Speaks				
+#proficiency	Native				
+#acquisitionOrder	L1				
+#domain	Any				
+### Population Surveyed ###					
+#population	3,116,000				
+#sampleRate					
+#responsesPerIndividual			1		
+### Data Constraints ###					
+#geographicScope	Whole country				
+#age	0+				
+#nationality	Resident				
+#residenceBasis	de facto				
+#quantity			count 	percent	
+### Creator ###					
+#collectorType	Secondary				
+#author	Jacques Leclerc				
+#presentedBy	AXL				
+### Source Document ###					
+#url	https://www.axl.cefan.ulaval.ca/asie/qatar.htm		     		
+#tableName	Section 2.1: ethnic groups table (Ethnie / Langue maternelle / Population / Pourcentage / Affiliation linguistique / Religion principale)				
+#notes					
+Language Code	Languge		Population	Percentage	Ethnic Group 
+ara/afb	Qatari Arabic	arabe qatari (arabe du Golfe)	611000	19.6	Arabe qatari
+ara/apc/ajp	Palestinian Arabic	arabe palestinien	405000	13	Arabe palestinien
+fas/pes	Western Farsi	farsi de l'Ouest	302000	9.7	Iranien (Persan)
+ara/apc	Lebanese Arabic	arabe libanais	292000	9.4	Arabe libanais
+ara/apc	Syrian Arabic	arabe syrien	292000	9.4	Arabe syrien
+urd	Urdu	ourdou	191000	6.1	Ourdou
+nep	Nepali	népali	150000	4.8	Népalais
+fil	Filipino	philippin	135000	4.3	Philippin
+ara/afb	Gulf Arabic	arabe du Golfe	133000	4.3	Yéménite ou Akhdam
+mal	Malayalam	malayalam	84000	2.7	Malayali
+ara/ars	Najdi Arabic	arabe saoudien du Najdi	61000	2	Arabe saoudien du Najdi
+ara/arz	Egyptian Arabic	arabe égyptien	61000	2	Arabe égyptien
+sin	Sinhala	cinghalais	61000	2	Srilankais cinghalais
+bal/bcc	Southern Balochi	baloutchi du Sud	61000	2	Baloutche du Sud
+ara/apd	Sudanese Arabic	arabe soudanais	61000	2	Arabe soudanais
+msa/ind	Indonesian	indonésien	44000	1.4	Indonésien
+ara/acw	Hijazi Arabic	arabe hijazi	30000	1	Arabe saoudien
+tam	Tamil	tamoul	30000	1	Tamoul
+eng	English	anglais	29000	0.9	Britannique
+eng	English	anglais	15000	0.5	Américain
+fra	French	français	9100	0.3	Français
+hye	Armenian	arménien	9000	0.3	Arménien
+deu	German	allemand	6000	0.2	Allemand
+tig	Tigre	tigré	6000	0.2	Érythréen tigré
+tur	Turkish	turc	5600	0.2	Turc
+mul	other		35000	1.1	Autres
+	Total		3116000	100	

--- a/public/data/census/unofficial/axl.sg.tsv
+++ b/public/data/census/unofficial/axl.sg.tsv
@@ -1,5 +1,5 @@
 #codeDisplay		#fr: Langue maternelle	axl.sg
-#nameDisplay			Singapore 2018
+#nameDisplay			AXL Singapore
 #isoRegionCode			SG
 #yearCollected			2018
 ### Language Criteria ###			

--- a/public/data/census/unofficial/axl.tg.tsv
+++ b/public/data/census/unofficial/axl.tg.tsv
@@ -1,0 +1,82 @@
+#codeDisplay		axl.tg	#percent	#fr language names	#fr ethnicity categories
+#nameDisplay		AXL Togo			
+#isoRegionCode	TG				
+#yearCollected		2014			
+### Language Criteria ###					
+#languageUse		Speaks			
+#acquisitionOrder		L1			
+#domain		Home			
+### Population Surveyed ###					
+#population		7,000,000			
+#responsesPerIndividual		1			
+### Data Constraints ###					
+#quantity		count			
+### Creator ###					
+#collectorType		Secondary			
+#presentedBy		AXL			
+### Source Document ###					
+#url		https://www.axl.cefan.ulaval.ca/afrique/togo.htm			
+#datePublished		2023-12-19			
+#dateAccessed		2026-05-13			
+#documentName		Togo			
+#sectionName		2.1 Les ethnies			
+#tableName		Bibliographie sur le Togo et les langues nationales"			
+#columnName		État fédéré; Superficie; Population			
+#citation		Revue juridique et politique - Indépendance et coopération, Paris,			
+					
+Language Code		Population	Pourcentage	Language	Ethnie
+ewe	Ewe	1477000	21,0 %	éwé	Éwé
+kbp	Kabyè	1032000	14,7 %	kabyè	Kabyè
+wci	Waci	740000	10,0 %	gbé (ouatchi)	Ouatchi
+gej	Gen/Mina	413000	5,8 %	gen ou mina	Mina (Gen)
+kdh	Tem	408000	5,8 %	tem	Tem (Kotokoli)
+mfq	Moba (Ben)	379000	5,4 %	moba (ben)	Moba
+gux	Gurmantche	248000	3,5 %	gourmantché	Gourma
+las	Lama	235000	3,3 %	lama	Lama
+kpo	Ikposso	196000	2,7 %	ikposso	Akposso
+ajg	Aja	190000	2,7 %	aja	Aja
+bud	Bassar (ntcham)	166000	2,3 %	bassar (ntcham)	Bassar (Ntcham)
+nmz	Nawdum	161000	2,2 %	nawdum	Nawdum
+ife	Ifè	129000	1,8 %	ifè	Ifè
+yor	Yoruba	105000	1,4 %	yorouba	Yoruba
+ful/fue	Peul/Fulfulde	95000	1,3 %	peul (fulfuldé)	Peuls (Fulfuldé)
+xon	Konkomba	87000	1,2 %	konkomba	Konkomba
+cko	Anoufo	73000	1,0 %	anoufo	Anoufo
+keu	Kebou	71000	1,0 %	kébou	Kébou (akébou)
+aka	Akan	70000	1,0 %	akan	Akan, Ashanti, Twi
+fon	Fon	61000	0,8 %	fon	Fon
+aks	Akaselem	60000	0,8 %	akaselem	Akasselem
+gng	Ngangam	58000	0,8 %	ngangam	Gangam
+xkb	Kambole	51000	0,7 %	kambolé	Kambolé
+mxl	Maxi	44000	0,6 %	gbé (maxi)	Gbé
+gaa	Ga	42000	0,5 %	ga	Ga (Amina)
+tbz	Ditammari	40000	0,5 %	ditammari	Tamberma
+mos	Mossi	34000	0,4 %	mossi (mooré)	Mossi
+xwl	Xwla	27000	0,3 %	gbé (xwla)	Xwla
+bba	Baatonum	21000	0,2 %	baatonum	Bariba
+ade	Adele	20000	0,2 %	adele	Lolo, Adele
+hau	Hausa	19000	0,2 %	haoussa	Haoussa
+dop	Lukpa	18000	0,2 %	lukpa	Lukpa
+wwa	Waama	18000	0,2 %	waama	Waama, Yoabu
+ayg	Ginyanga	17000	0,2 %	ginyanga	Anyanga
+blo	Anii	16000	0,2 %	anii	Anii
+kus	Kusaal	14000	0,1 %	kusaal	Kusasi
+maw	Mampruli	14000	0,1 %	mampruli	Mamprusi
+bqg	Bago-kusuntu	11000	0,1 %	bago-kusuntu	Bago-Koussountou
+dag	Dagbani	11000	0,1 %	dagbani	Dagomba
+ahl	Igo	9500	0,1 %	igo	Bogo, Ahlon
+ajg	Aja	8100	0,1 %	aja	Hwe
+ntr	Delo	7700	0,1 %	delo	Ntrubo
+ara/apc	Lebanese Arabic	7100	0,1 %	arabe libanais	Arabes libanais
+lef	Lelemi	7000	0,1 %	lelemi	Buem, Lelemi
+fra	French	5400	0,0 %	français	Français
+bib	Bissa	5200	0,0 %	bissa	Bissa
+kef	Kpessi	5100	0,0 %	kpessi	Kpessi
+kye	Krache	4900	0,0 %	krache	Krache
+cpe/pcm	Pidgin	3500	0,0 %	pidgin	Créoles togolais
+soy	Miyobe	3000	0,0 %	miyobe	Piyobe
+deu	German	2800	0,0 %	allemand	Métis
+adq	Adangbe	2500	0,0 %	adangbe	Adan, Adangbe
+wud	Woudo	2200	0,0 %	woudou	Woudou
+	Others	62000	0,8 %		Autres
+	Total 2014	7007000	100%		

--- a/public/data/census/unofficial/censusList.txt
+++ b/public/data/census/unofficial/censusList.txt
@@ -2,8 +2,12 @@ af
 axl.cd
 axl.cx
 axl.gl
+axl.nf
 axl.no
+axl.pn
+axl.qa
 axl.sg
+axl.tg
 afrobarometer_r6
 afrobarometer_r9
 afrobarometer_r10

--- a/public/data/tc/locales.tsv
+++ b/public/data/tc/locales.tsv
@@ -10784,3 +10784,23 @@ nih_ZM	Nyiha (Zambia)		Official	11433
 lai_ZM	Lambya (Zambia)		Official	10986	
 mhw_ZM	Mbukushu (Zambia)		Official	6628	
 sbs_ZM	Subiya (Zambia)		Official	225	
+eng_CW	English (Curaçao)		Official	34438	
+pih_PN	Pitcairn-Norfolk (Pitcairn Islands)			47	
+apc_QA	Levantine Arabic (Qatar)			989000	
+pes_QA	Iranian Persian (Qatar)			302000	
+urd_QA	Urdu (Qatar)			191000	
+nep_QA	Nepali languages (Qatar)			150000	
+fil_QA	Filipino (Qatar)			135000	
+ars_QA	Najdi Arabic (Qatar)			61000	
+acw_QA	Hijazi Arabic (Qatar)			30000	
+jav_SR	Javanese (Suriname)		Official	12967	
+eng_SR	English (Suriname)		Official	6933	
+xkb_TG	Kambole (Togo)			51000	
+mxl_TG	Maxi Gbe (Togo)			44000	
+xwl_TG	Western Xwla Gbe (Togo)			27000	
+wwa_TG	Waama (Togo)			18000	
+tbz_TG	Ditammari (Togo)			40000	
+dop_TG	Lukpa (Togo)			18000	
+ntr_TG	Delo (Togo)			7700	
+lef_TG	Lelemi (Togo)			7000	
+kye_TG	Krache (Togo)			4900	

--- a/public/data/tc/organizations.tsv
+++ b/public/data/tc/organizations.tsv
@@ -32,3 +32,7 @@ INE Paraguay	Instituto Nacional de Estadística		PY		https://www.ine.gov.py/
 ABS	Australian Bureau of Statistics		AU		https://www.abs.gov.au/
 WorldAtlas	World Atlas		CA		https://www.worldatlas.com/
 ZamStats	Zambia Statistics Agency		ZM		https://www.zamstats.gov.zm/
+Insee-STSEE	Statistics and Economic Studies Service – Wallis and Futuna	Service de la Statistique et des Études Économiques – Wallis & Futuna	WF	Insee	https://www.statistique.wf/
+Insee	The French National Institute of Statistics and Economic Studies	L'Institut national de la statistique et des études économiques	FR		https://www.insee.fr/
+ABS Suriname	Algemeen Bureau voor de Statistiek Suriname		SR		https://statistics-suriname.org/
+CBS Curaçao	Central Bureau of Statistics Curaçao		CW		https://www.cbs.cw/

--- a/src/entities/census/CensusLanguageCheck.tsx
+++ b/src/entities/census/CensusLanguageCheck.tsx
@@ -13,6 +13,7 @@ import { EntityData } from '@entities/types/DataTypes';
 
 import CommaSeparated from '@shared/ui/CommaSeparated';
 
+import CensusLanguageCheckRow from './CensusLanguageCheckRow';
 import { isIgnoredLanguageCode, parseCensusLanguageName } from './parseCensusLanguageRow';
 import { parseCensusMetadata } from './parseCensusMetadata';
 
@@ -23,11 +24,13 @@ const OVERRIDE_LANGUAGE_MATCH: Record<string, string> = {
   hokkien: 'taib1242',
   teochew: 'chao1238',
   malay: 'zlm',
+  other: 'mul',
 };
 
-type LanguageNotes = {
+export type CensusLanguageNotes = {
   lineNumber: number;
   codePath: string; // allowing for /-separated codes
+  codePathRec?: string;
   specificCode?: string; // the most specific code (eg. `srp` in `hbs/srp`) which will be used for the language name
   originalName: string;
   name?: string;
@@ -37,63 +40,65 @@ type LanguageNotes = {
 
 const CensusLanguageCheck: React.FC<{ fileInput: string }> = ({ fileInput }) => {
   const lines = fileInput.split('\n');
-  const { endOfMetadataLine } = parseCensusMetadata(lines, 'census');
+  const { endOfMetadataLine, singleColumnMode } = parseCensusMetadata(lines, 'census');
   const { getLanguage, languagesInSelectedSource } = useDataContext();
   const { filteredEntities: languageEnts } = useFilteredEntities({
     inputEntities: languagesInSelectedSource,
   });
   const findLanguage = useCallback(
     (searchString: string) => {
-      if (OVERRIDE_LANGUAGE_MATCH[searchString.toLowerCase()]) {
-        const overrideCode = OVERRIDE_LANGUAGE_MATCH[searchString.toLowerCase()];
+      const searchLower = searchString.toLowerCase();
+      if (OVERRIDE_LANGUAGE_MATCH[searchLower]) {
+        const overrideCode = OVERRIDE_LANGUAGE_MATCH[searchLower];
         const overrideLang = languageEnts.find((l) => l.ID === overrideCode);
-        if (overrideLang) return overrideLang;
+        return overrideLang;
       }
       const ents = languageEnts.filter(
         getSubstringFilterOnQuery(searchString, SearchableField.NameAny),
       );
-      const exactMatch = ents.find(
-        (e) => e.nameDisplay.toLowerCase() === searchString.toLowerCase(),
-      );
+      const exactMatch = ents.find((e) => e.nameDisplay.toLowerCase() === searchLower);
       if (exactMatch) return exactMatch;
-      const matchInList = ents.find((e) =>
-        e.names.some((n) => n.toLowerCase() === searchString.toLowerCase()),
-      );
+      const matchInList = ents.find((e) => e.names.some((n) => n.toLowerCase() === searchLower));
       if (matchInList) return matchInList;
       return ents[0];
     },
     [languageEnts],
   );
 
-  const languages = lines
-    .splice(endOfMetadataLine)
-    .map((line, i) => {
-      if (line.trim() === '') return null; // Skip empty lines
-      const parts = line.split('\t');
-      if (parts.length < 3) return null; // Skip lines that do not have enough data
+  // If a use only passes a single column, we'll expect that to be a single column of language names
+  // const singleColumnMode;
 
-      // Most rows specify a single language code (eg. `eng`), but some specify multiple codes separated by a slash (eg. `hbs/srp`)
-      const codes = parts[0]
+  const languages = lines.splice(endOfMetadataLine).map((line, i) => {
+    if (line.trim() === '') return null; // Skip empty lines
+    const parts = line.split('\t');
+    if (!singleColumnMode && parts.length < 1) return null; // Skip lines that do not have enough data
+
+    // Most rows specify a single language code (eg. `eng`), but some specify multiple codes separated by a slash (eg. `hbs/srp`)
+    let codes: string[] = [];
+    if (!singleColumnMode) {
+      codes = parts[0]
         // split if it is not contained in parentheses
         .split(/\/(?![^(]*\))/)
         .map((code) => code.trim())
         .filter(Boolean);
-      // The most specific code is the last one (eg. `srp` in `hbs/srp`)
-      const specificCode = codes.length > 0 ? codes[codes.length - 1] : undefined;
+    }
+    // The most specific code is the last one (eg. `srp` in `hbs/srp`)
+    const specificCode = codes.length > 0 ? codes[codes.length - 1] : undefined;
+    const originalName = singleColumnMode ? parts[0].trim() : parts[1].trim();
 
-      return {
-        lineNumber: i + endOfMetadataLine + 1,
-        codePath: parts[0],
-        specificCode,
-        originalName: parts[1].trim(),
-        name: parseCensusLanguageName(parts[1].trim()),
-        entry: specificCode ? getLanguage(specificCode) : undefined,
-        issues: [],
-      } as LanguageNotes;
-    })
-    .filter((l) => l != null) as LanguageNotes[];
+    return {
+      lineNumber: i + endOfMetadataLine + 1,
+      codePath: !singleColumnMode ? parts[0] : '',
+      specificCode,
+      originalName,
+      name: parseCensusLanguageName(originalName),
+      entry: specificCode ? getLanguage(specificCode) : undefined,
+      issues: [],
+    } as CensusLanguageNotes;
+  }) as (CensusLanguageNotes | undefined)[];
 
   languages.forEach((l) => {
+    if (l == null) return;
     if (!l.name && !l.specificCode) {
       l.issues.push('Language name and code are missing but there appears to be data in the row.');
       return;
@@ -108,49 +113,47 @@ const CensusLanguageCheck: React.FC<{ fileInput: string }> = ({ fileInput }) => 
 
     // Commented out codes and ones for special codes are there for documentation but are ignored in the import.
     if (l.specificCode && isIgnoredLanguageCode(l.specificCode)) return;
+    const foundLanguage = l.name ? findLanguage(l.name) : undefined;
 
     checkName(l);
     checkStatusInName(l);
-    checkFoundLanguage(l, l.name ? findLanguage(l.name) : undefined);
-    checkMacrolanguage(l);
+    checkFoundLanguage(l, foundLanguage);
+    checkMacrolanguage(l, foundLanguage);
   });
 
-  if (!languages.some((l) => l.issues.length > 0)) {
+  const copyLanguageCodes = useCallback(() => {
+    const codesToCopy = languages.map((l) => (l ? (l.codePathRec ?? l.codePath) : '')).join('\n');
+    navigator.clipboard.writeText(codesToCopy);
+  }, [languages]);
+
+  if (!languages.some((l) => l && l.issues.length > 0)) {
     return <div>No issues found with language codes or names.</div>;
   }
 
   return (
-    <table>
-      <thead>
-        <tr>
-          <th>Line</th>
-          <th>Language Code(s)</th>
-          <th>Language Name in Census</th>
-          <th>Issues</th>
-        </tr>
-      </thead>
-      <tbody>
-        {languages.map(
-          (l, i) =>
-            l.issues.length > 0 && (
-              <tr key={i}>
-                <td>{l.lineNumber}</td>
-                <td>{l.codePath}</td>
-                <td>{l.name}</td>
-                <td>
-                  {l.issues.map((issue, index) => (
-                    <div key={index}>{issue}</div>
-                  ))}
-                </td>
-              </tr>
-            ),
-        )}
-      </tbody>
-    </table>
+    <>
+      <table>
+        <thead>
+          <tr>
+            <th>Line</th>
+            <th>Recommended Code(s)</th>
+            <th>Original Language Code(s)</th>
+            <th>Language Name in Census</th>
+            <th>Issues</th>
+          </tr>
+        </thead>
+        <tbody>
+          {languages.map(
+            (l, i) => l && l.issues.length > 0 && <CensusLanguageCheckRow key={i} notes={l} />,
+          )}
+        </tbody>
+      </table>
+      <button onClick={copyLanguageCodes}>Copy language codes after optimistic correction</button>
+    </>
   );
 };
 
-function checkName(l: LanguageNotes) {
+function checkName(l: CensusLanguageNotes) {
   if (l.originalName?.startsWith('#')) return; // Ignore names that are commented out
 
   if (!l.name) {
@@ -175,7 +178,7 @@ function checkName(l: LanguageNotes) {
   );
 }
 
-function checkStatusInName(l: LanguageNotes) {
+function checkStatusInName(l: CensusLanguageNotes) {
   if (!l.name) return;
   if (OKAY_STATUS.includes(l.specificCode || '')) return; // If the code is in the list of exceptions, don't raise an issue
   if (l.name.match(/official|indigenous|native/i)) {
@@ -185,8 +188,9 @@ function checkStatusInName(l: LanguageNotes) {
   }
 }
 
-function checkFoundLanguage(l: LanguageNotes, foundLanguage?: EntityData) {
+function checkFoundLanguage(l: CensusLanguageNotes, foundLanguage?: EntityData) {
   if (!foundLanguage) return;
+  l.codePathRec = foundLanguage.ID;
   if (l.entry?.ID === foundLanguage.ID) return; // If the found language is the same as the entry, that's fine
 
   if (l.entry) {
@@ -209,10 +213,12 @@ function checkFoundLanguage(l: LanguageNotes, foundLanguage?: EntityData) {
   }
 }
 
-function checkMacrolanguage(l: LanguageNotes) {
-  if (!l.entry || !l.specificCode) return;
+function checkMacrolanguage(l: CensusLanguageNotes, foundLanguage?: EntityData) {
+  const matchingLang = l.entry || foundLanguage;
+  const matchingCode = l.specificCode ?? l.codePathRec;
+  if (!matchingLang || !matchingCode) return;
 
-  const languageParents = getObjectParents(l.entry).filter(
+  const languageParents = getObjectParents(matchingLang).filter(
     (p) => p && p.type === 'Language',
   ) as LanguageData[];
   const iso639parents = languageParents.filter(
@@ -220,17 +226,16 @@ function checkMacrolanguage(l: LanguageNotes) {
       p.ISO.code && (p.scope === LanguageScope.Macrolanguage || p.scope === LanguageScope.Language),
   );
 
-  if (!iso639parents) return; // If there is no macrolanguage or language parents, then there is no issue
+  if (!iso639parents || iso639parents.length === 0) return; // If there is no macrolanguage or language parents, then there is no issue
+  if (OKAY_MACRO.includes(matchingCode || '')) return; // If the specific code is in the list of exceptions, don't warn
+  const codePathRecommended = [...iso639parents.map((p) => p.ID), matchingCode].join('/');
+  l.codePathRec = codePathRecommended;
   if (iso639parents.every((p) => l.codePath.includes(p.ID))) return; // If the macrolanguage code is already included in the code path, that's fine
-  if (OKAY_MACRO.includes(l.specificCode || '')) return; // If the specific code is in the list of exceptions, don't warn
 
   l.issues.push(
     <>
-      Code may be{' '}
-      <code>
-        {iso639parents.map((p) => p.ID).join('/')}/{l.specificCode}
-      </code>
-      . <HoverableObjectName object={l.entry} /> is contained by language
+      Code may be <code>{codePathRecommended}</code>
+      . <HoverableObjectName object={matchingLang} /> is contained by language
       {iso639parents.length > 1 ? ' categories ' : ' category '}
       <CommaSeparated>
         {iso639parents.map((p) => (

--- a/src/entities/census/CensusLanguageCheck.tsx
+++ b/src/entities/census/CensusLanguageCheck.tsx
@@ -71,7 +71,7 @@ const CensusLanguageCheck: React.FC<{ fileInput: string }> = ({ fileInput }) => 
   const languages = lines.splice(endOfMetadataLine).map((line, i) => {
     if (line.trim() === '') return null; // Skip empty lines
     const parts = line.split('\t');
-    if (!singleColumnMode && parts.length < 1) return null; // Skip lines that do not have enough data
+    if (!singleColumnMode && parts.length < 2) return null; // Skip lines that do not have enough data
 
     // Most rows specify a single language code (eg. `eng`), but some specify multiple codes separated by a slash (eg. `hbs/srp`)
     let codes: string[] = [];

--- a/src/entities/census/CensusLanguageCheckRow.tsx
+++ b/src/entities/census/CensusLanguageCheckRow.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import Deemphasized from '@shared/ui/Deemphasized';
+
+import { CensusLanguageNotes } from './CensusLanguageCheck';
+
+const CensusLanguageCheckRow: React.FC<{ notes: CensusLanguageNotes }> = ({ notes }) => {
+  if (notes == null || !notes.issues) return null;
+
+  return (
+    <tr>
+      <td>{notes.lineNumber}</td>
+      <td>
+        <CodePathRecommendation notes={notes} />
+      </td>
+      <td>
+        {!notes.codePathRec || notes.codePathRec === notes.codePath ? (
+          <Deemphasized>{notes.codePath}</Deemphasized>
+        ) : (
+          notes.codePath
+        )}
+      </td>
+      <td>{notes.name}</td>
+      <td>
+        {notes.issues.map((issue, index) => (
+          <div key={index}>{issue}</div>
+        ))}
+      </td>
+    </tr>
+  );
+};
+
+function CodePathRecommendation({ notes }: { notes: CensusLanguageNotes }): React.ReactNode {
+  if (!notes.codePathRec || notes.codePathRec === notes.codePath)
+    return <Deemphasized>{notes.codePath}</Deemphasized>;
+  const newParts = notes.codePathRec.split('/');
+  const oldParts = notes.codePath.split('/');
+  return (
+    <>
+      {newParts.map((part, i) => {
+        const isDifferent = !oldParts.includes(part) && part !== '';
+        return (
+          <span key={i} style={{ color: isDifferent ? 'var(--color-red)' : 'inherit' }}>
+            {part}
+            {i < newParts.length - 1 ? '/' : ''}
+          </span>
+        );
+      })}
+    </>
+  );
+}
+
+export default CensusLanguageCheckRow;

--- a/src/entities/census/CensusLanguageCheckRow.tsx
+++ b/src/entities/census/CensusLanguageCheckRow.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Deemphasized from '@shared/ui/Deemphasized';
 
-import { CensusLanguageNotes } from './CensusLanguageCheck';
+import type { CensusLanguageNotes } from './CensusLanguageCheck';
 
 const CensusLanguageCheckRow: React.FC<{ notes: CensusLanguageNotes }> = ({ notes }) => {
   if (notes == null || !notes.issues) return null;

--- a/src/entities/census/CensusTypes.tsx
+++ b/src/entities/census/CensusTypes.tsx
@@ -16,6 +16,7 @@ export enum CensusCollectorType {
   NGO = 'NGO', // Non-governmental organization eg. Endangered Languages Project, Joshua Project
   Media = 'Media', // News article, blog, or other media sources
   Secondary = 'Secondary', // Data repackaged by secondary sources without a clear source of where it came from, eg. Ethnologue, Wikipedia, CLDR
+  Unknown = 'Unknown', // Unknown or unranked
 }
 
 export enum CensusLanguageUse {
@@ -103,6 +104,7 @@ export const getCensusCollectorTypeRank = (collectorType: CensusCollectorType): 
       return 4;
     case CensusCollectorType.Secondary:
       return 5; // Low priority
+    case CensusCollectorType.Unknown:
     default:
       return 6; // Unknown or unranked
   }

--- a/src/entities/census/parseCensusMetadata.ts
+++ b/src/entities/census/parseCensusMetadata.ts
@@ -23,6 +23,9 @@ export type CensusMetadataResults = {
 
   // The column numbers (0-indexed) which contain census data (as opposed to metadata or context columns)
   tsvColumnsWithData: number[];
+
+  // If true, the file only has a single column of language names and no census data
+  singleColumnMode?: boolean;
 };
 
 export function parseCensusMetadata(lines: string[], filePath: string): CensusMetadataResults {
@@ -42,6 +45,18 @@ export function parseCensusMetadata(lines: string[], filePath: string): CensusMe
   // This will be used to initialize metadatas and other arrays
   const tsvColumnsWithData = getColumnIndicesWithData(lines);
   if (tsvColumnsWithData.length <= 0) {
+    // See if its just 1 column of data
+    const singleColumnMode = lines.every((line) => line.includes('\t') === false);
+    if (singleColumnMode) {
+      return {
+        censuses: [],
+        warnings,
+        endOfMetadataLine: 0,
+        tsvColumnsWithData: [],
+        singleColumnMode: true,
+      };
+    }
+    // Otherwise it may be more data but the file is not formatted correctly, so we will return an error
     addWarning('No census data columns found. Check that the file has the correct format.');
   }
 
@@ -58,7 +73,7 @@ export function parseCensusMetadata(lines: string[], filePath: string): CensusMe
     yearCollected: 0,
     population: 0,
     languageEstimates: {},
-    collectorType: CensusCollectorType.Government,
+    collectorType: CensusCollectorType.Unknown,
     url: '',
   }));
 
@@ -129,6 +144,8 @@ export function parseCensusMetadata(lines: string[], filePath: string): CensusMe
     if (!census.population) addWarning('population is not specified');
     if (!census.nameDisplay) addWarning('nameDisplay is not specified');
     if (!census.url) addWarning('url is not specified');
+    if (census.collectorType === CensusCollectorType.Unknown)
+      addWarning('collectorType is not specified');
   });
 
   return {

--- a/src/entities/language/population/LanguagePopulationFromLocales.tsx
+++ b/src/entities/language/population/LanguagePopulationFromLocales.tsx
@@ -33,7 +33,11 @@ export const LanguagePopulationBreakdownFromLocales: React.FC<{ lang: LanguageDa
   const localesFromUniqueTerritories = Object.values(
     groupBy(
       lang.locales
-        .filter((loc) => loc.territory?.scope === TerritoryScope.Country)
+        .filter(
+          (loc) =>
+            loc.territory?.scope === TerritoryScope.Country ||
+            loc.territory?.scope === TerritoryScope.Dependency,
+        )
         .sort(sortByPopulation),
       (locale) => locale.territoryCode || '',
     ),

--- a/src/widgets/details/sections/LanguageSpeakersByTerritorySection.tsx
+++ b/src/widgets/details/sections/LanguageSpeakersByTerritorySection.tsx
@@ -15,7 +15,11 @@ const LanguageSpeakersByTerritorySection: React.FC<{ lang: LanguageData }> = ({ 
   // Get locales from unique territories
   const locales = uniqueBy(
     lang.locales
-      .filter((loc) => loc.territory?.scope === TerritoryScope.Country)
+      .filter(
+        (loc) =>
+          loc.territory?.scope === TerritoryScope.Country ||
+          loc.territory?.scope === TerritoryScope.Dependency,
+      )
       .sort(sortByPopulation),
     (locale) => locale.territoryCode || '',
   );

--- a/src/widgets/reports/ReportCensusInputTool.tsx
+++ b/src/widgets/reports/ReportCensusInputTool.tsx
@@ -64,20 +64,21 @@ const ReportCensusInputTool: React.FC = () => {
         edit changes inline to test them out. Changes update after clicking away.
       </div>
       <textarea
-        onChange={() => {}}
+        onChange={(e) => setTSV(e.target.value)}
         onBlur={(e) => setTSV(e.target.value)}
         style={{ width: '100%', minHeight: '10em', marginTop: '1em' }}
       />
       <h3>Analysis</h3>
       {errorMessage && <div style={{ color: 'var(--color-red)' }}>{errorMessage}</div>}
-      <h4>Metadata</h4>
-      {warnings
-        ? warnings.map((warning, index) => (
-            <div key={index} style={{ color: 'var(--color-red)' }}>
-              {warning}
-            </div>
-          ))
-        : 'No issues found.'}
+      {censuses.length > 0 && <h4>Metadata</h4>}
+      {censuses.length > 0 &&
+        (warnings.length > 0
+          ? warnings.map((warning, index) => (
+              <div key={index} style={{ color: 'var(--color-red)' }}>
+                {warning}
+              </div>
+            ))
+          : 'No issues found.')}
       <h4>Language Codes & Language Names</h4>
       <CensusLanguageCheck fileInput={tsv} />
       <LocalParamsProvider overrides={{ page: 1, limit: 1 }}>

--- a/src/widgets/reports/ReportCensusInputTool.tsx
+++ b/src/widgets/reports/ReportCensusInputTool.tsx
@@ -61,11 +61,10 @@ const ReportCensusInputTool: React.FC = () => {
       <h2>TSV file</h2>
       <div>
         Copy-paste work-in-progress TSV files to load the data and see if it is correct. You can
-        edit changes inline to test them out. Changes update after clicking away.
+        edit changes inline to test them out.
       </div>
       <textarea
         onChange={(e) => setTSV(e.target.value)}
-        onBlur={(e) => setTSV(e.target.value)}
         style={{ width: '100%', minHeight: '10em', marginTop: '1em' }}
       />
       <h3>Analysis</h3>


### PR DESCRIPTION
Summary: This adds new language population data for many countries and locales for them

### Changes

- User experience
  - The [Census report input tool](https://translation-commons.github.io/lang-nav/data?view=Reports&objectType=Census&reportID=2) now highlights language code differences and shows a bit better debugging information
- Logical changes
  - New unknown collector type so we can check if it wasn't filled out.
- Data
  - Added censuses for Curacao, Pitcairn, Wallis & Futuna, Qatar, Suriname, and Togo
  - Added locales for notable languages that we are now aware of
  - Added organizations
  - Some copy-edits to existing census imports to standardize names better and to fix un-annotated collector types
- Refactors
  - `CensusLanguageCheck` was getting big -- I should move more things out but for now I just moved `CensusLanguageCheckRow`

Out of scope/Future work: Always more censuses :) Also I wonder if we will still do the language name -> language code tool since this emulates much of the functionality

### Test Plan and Screenshots

How to test the changes in this PR: Tested various censuses in the census input tool, added them, verified the potential locales tool, etc. Below is a screenshot of the updates to the census input tool.

| Page/View with link | Description of Changes | Screenshot Before | Screenshot After |
| ------------------- | ---------------------- | ----------------- | ---------------- |
|[Census input tool](https://translation-commons.github.io/lang-nav/data?view=Reports&objectType=Census&reportID=2)|New column showing correcting, highlights differences|<img width="1151" height="776" alt="Screenshot 2026-06-24 at 22 01 44" src="https://github.com/user-attachments/assets/46bc0333-3e6f-4b76-a2e3-45cb3a727ce0" />|<img width="1127" height="772" alt="Screenshot 2026-06-24 at 22 02 07" src="https://github.com/user-attachments/assets/b80c094d-1d67-4cef-aa54-8e1c123fd7d8" />