### PR TITLE
HoverableIcon

### DIFF
--- a/src/features/layers/hovercard/HoverableButton.tsx
+++ b/src/features/layers/hovercard/HoverableButton.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import useHoverCard from './useHoverCard';
 
 type HoverableProps = {
+  ariaLabel?: string;
   buttonType?: 'button' | 'submit' | 'reset';
   children: React.ReactNode;
   className?: string;
@@ -14,6 +15,7 @@ type HoverableProps = {
 };
 
 const HoverableButton: React.FC<HoverableProps> = ({
+  ariaLabel,
   buttonType = 'button',
   children,
   className,
@@ -53,6 +55,7 @@ const HoverableButton: React.FC<HoverableProps> = ({
 
   return (
     <button
+      aria-label={ariaLabel}
       className={className}
       disabled={disabled}
       onMouseEnter={handleMouseEnter}

--- a/src/features/layers/hovercard/HoverableIcon.tsx
+++ b/src/features/layers/hovercard/HoverableIcon.tsx
@@ -1,0 +1,28 @@
+import { LucideIcon } from 'lucide-react';
+import React from 'react';
+
+import HoverableButton from './HoverableButton';
+
+type Props = {
+  Icon: LucideIcon;
+  onClick: () => void;
+  description: string;
+};
+
+/**
+ * Provides an icon that is correctly centered in a button
+ */
+const HoverableIcon: React.FC<Props> = ({ Icon, onClick, description }) => {
+  return (
+    <HoverableButton
+      onClick={onClick}
+      hoverContent={description}
+      style={{ padding: '0.5em' }}
+      aria-label={description}
+    >
+      <Icon size="1.5em" style={{ display: 'block' }} />
+    </HoverableButton>
+  );
+};
+
+export default HoverableIcon;

--- a/src/features/layers/hovercard/HoverableIcon.tsx
+++ b/src/features/layers/hovercard/HoverableIcon.tsx
@@ -4,21 +4,23 @@ import React from 'react';
 import HoverableButton from './HoverableButton';
 
 type Props = {
+  className?: string;
+  description: string;
   Icon: LucideIcon;
   onClick: () => void;
-  description: string;
 };
 
 /**
  * Provides an icon that is correctly centered in a button
  */
-const HoverableIcon: React.FC<Props> = ({ Icon, onClick, description }) => {
+const HoverableIcon: React.FC<Props> = ({ Icon, onClick, description, className }) => {
   return (
     <HoverableButton
+      ariaLabel={description}
+      className={className}
       onClick={onClick}
       hoverContent={description}
       style={{ padding: '0.5em' }}
-      aria-label={description}
     >
       <Icon size="1.5em" style={{ display: 'block' }} />
     </HoverableButton>

--- a/src/features/map/MapCard.tsx
+++ b/src/features/map/MapCard.tsx
@@ -1,7 +1,8 @@
-import { ExternalLinkIcon, X } from 'lucide-react';
+import { PinOffIcon, SquareArrowUpRightIcon } from 'lucide-react';
 import React from 'react';
 
-import HoverableButton from '@features/layers/hovercard/HoverableButton';
+import HoverableIcon from '@features/layers/hovercard/HoverableIcon';
+import ZIndex from '@features/layers/ZIndex';
 import { ObjectType, View } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 
@@ -39,31 +40,33 @@ const MapCard: React.FC<{
     <div
       style={{
         position: 'relative',
-        maxWidth: 260,
+        maxWidth: 300,
         fontSize: '0.75em',
         background: 'var(--color-background)',
         borderRadius: '0.75em',
         boxShadow: '0 0.25em 1em rgba(0, 0, 0, 0.18)',
-        padding: '3.25em 1em 1em',
+        padding: '1em',
+        textAlign: 'left',
       }}
     >
       <div
         style={{
           position: 'absolute',
-          top: '0.5em',
+          top: '0',
           right: '0.5em',
+          transform: 'translateY(-50%)',
           display: 'flex',
-          gap: '0.25em',
-          zIndex: 1,
+          gap: '0.5em',
+          zIndex: ZIndex.MapZoomControls,
+          fontSize: '.8em',
         }}
       >
-        <HoverableButton onClick={openDetails}>
-          <ExternalLinkIcon size="1.25em" />
-        </HoverableButton>
-
-        <HoverableButton onClick={onClose}>
-          <X size="1.25em" />
-        </HoverableButton>
+        <HoverableIcon
+          Icon={SquareArrowUpRightIcon}
+          onClick={openDetails}
+          description="Open in details panel"
+        />
+        <HoverableIcon Icon={PinOffIcon} onClick={onClose} description="Unpin" />
       </div>
 
       {content}

--- a/src/features/map/MapCard.tsx
+++ b/src/features/map/MapCard.tsx
@@ -27,14 +27,24 @@ const MapCard: React.FC<{
         : { objectID: drawnEntity.ID },
     );
 
-  let content: React.ReactNode;
-  if (objectType === ObjectType.Census && drawnEntity.type === ObjectType.Territory)
-    content = <CensusesInTerritory territory={drawnEntity} />;
-  else if (objectType === ObjectType.Locale && drawnEntity.type === ObjectType.Territory)
-    content = <LocalesInTerritoryCard territory={drawnEntity} />;
-  else if (objectType === ObjectType.WritingSystem && drawnEntity.type === ObjectType.Territory)
-    content = <WritingSystemsInTerritoryCard territory={drawnEntity} />;
-  else content = <ObjectCard object={drawnEntity} />;
+  let content: React.ReactNode = <ObjectCard object={drawnEntity} />;
+  let clickDescription = 'Open in details panel';
+  if (drawnEntity.type === ObjectType.Territory) {
+    switch (objectType) {
+      case ObjectType.Census:
+        content = <CensusesInTerritory territory={drawnEntity} />;
+        clickDescription = 'Open table of censuses in this territory';
+        break;
+      case ObjectType.Locale:
+        content = <LocalesInTerritoryCard territory={drawnEntity} />;
+        clickDescription = 'Open table of locales in this territory';
+        break;
+      case ObjectType.WritingSystem:
+        content = <WritingSystemsInTerritoryCard territory={drawnEntity} />;
+        clickDescription = 'Open table of writing systems in this territory';
+        break;
+    }
+  }
 
   return (
     <div
@@ -64,7 +74,7 @@ const MapCard: React.FC<{
         <HoverableIcon
           Icon={SquareArrowUpRightIcon}
           onClick={openDetails}
-          description="Open in details panel"
+          description={clickDescription}
         />
         <HoverableIcon Icon={PinOffIcon} onClick={onClose} description="Unpin" />
       </div>

--- a/src/features/map/ZoomControls.tsx
+++ b/src/features/map/ZoomControls.tsx
@@ -1,7 +1,7 @@
 import { Maximize2Icon, ZoomInIcon, ZoomOutIcon } from 'lucide-react';
 import React from 'react';
 
-import HoverableButton from '@features/layers/hovercard/HoverableButton';
+import HoverableIcon from '@features/layers/hovercard/HoverableIcon';
 import ZIndex from '@features/layers/ZIndex';
 
 type Props = {
@@ -13,17 +13,9 @@ type Props = {
 const ZoomControls: React.FC<Props> = ({ zoomIn, zoomOut, resetTransform }) => {
   return (
     <div style={containerStyle}>
-      <HoverableButton onClick={zoomIn} style={buttonStyle} aria-label="Zoom in">
-        <ZoomInIcon />
-      </HoverableButton>
-
-      <HoverableButton onClick={zoomOut} style={buttonStyle} aria-label="Zoom out">
-        <ZoomOutIcon />
-      </HoverableButton>
-
-      <HoverableButton onClick={resetTransform} style={buttonStyle} aria-label="Reset">
-        <Maximize2Icon />
-      </HoverableButton>
+      <HoverableIcon onClick={zoomIn} description="Zoom in" Icon={ZoomInIcon} />
+      <HoverableIcon onClick={zoomOut} description="Zoom out" Icon={ZoomOutIcon} />
+      <HoverableIcon onClick={resetTransform} description="Reset" Icon={Maximize2Icon} />
     </div>
   );
 };
@@ -36,13 +28,6 @@ const containerStyle: React.CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
   gap: '0.5em',
-};
-
-const buttonStyle: React.CSSProperties = {
-  padding: '0.5em',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
 };
 
 export default ZoomControls;


### PR DESCRIPTION
Fixes #690

Summary: The MapCards have huge icons that are frankly in the way and we can format it better.

### Changes

- User experience
  - Map Icons are placed better now, map cards are aligned left now too to match regular cards
- Logical changes
  - n/a
- Data
  - n/a
- Refactors
  - New HoverableIcon component used by both Zoom Controls and the Map Cards

Out of scope/Future work: See how this impacts the new card list pins

### Test Plan and Screenshots

How to test the changes in this PR: ...

| Page/View with link | Description of Changes | Screenshot Before | Screenshot After |
| ------------------- | ---------------------- | ----------------- | ---------------- |
|[Map with some pinned cards](https://translation-commons.github.io/lang-nav/data?view=Map&pinned=apc%2Cmon)|Map cards are more compact yet still interactive. Zoom controls use this new pattern too|<img width="678" height="542" alt="Screenshot 2026-06-26 at 13 26 14" src="https://github.com/user-attachments/assets/184a1c93-22e3-4b94-8fe1-4ddb6f741607" />|<img width="707" height="517" alt="Screenshot 2026-06-26 at 13 26 08" src="https://github.com/user-attachments/assets/194f6488-03b7-4d52-9420-1f02b61fdd1a" />
