### PR TITLE
Respect scope filter in Scope Issues report

### DIFF
--- a/src/widgets/reports/ReportLanguageScopeIssues.tsx
+++ b/src/widgets/reports/ReportLanguageScopeIssues.tsx
@@ -24,12 +24,10 @@ const ReportLanguageScopeIssues: React.FC = () => {
   return (
     <>
       This report flags languages in the current language source whose scope is broader than their
-      direct parent&apos;s scope, which may indicate a hierarchy inconsistency. Results are shown
-      regardless of the sidebar Language Scope filter so dialect and family issues remain visible.
+      direct parent&apos;s scope, which may indicate a hierarchy inconsistency.
       <InteractiveEntityTable<LanguageData>
         tableID={TableID.LanguageScopeIssues}
         shouldFilterUsingSearchBar={false}
-        useScope={false}
         columns={[
           {
             key: 'Parent Code',


### PR DESCRIPTION
This follow-up removes the scope filter bypass from the Scope Issues report so it behaves consistently with the other report pages.

Follow-up to #652 review feedback from @conradarcturus.

## Changes
- Remove `useScope={false}` from `ReportLanguageScopeIssues.tsx`
- Remove copy stating results ignore the sidebar Language Scope filter

## Test plan
- [ ] Open Scope Issues report with default Language Scope filter — table respects filter
- [ ] Expand Language Scope filter to include Dialect/Family — additional rows appear
- [ ] `npm run lint` and `npm run build`
