### PR TITLE
Language Details: Update location display

### DIFF
--- a/src/entities/language/LanguageTypes.ts
+++ b/src/entities/language/LanguageTypes.ts
@@ -122,6 +122,7 @@ export interface LanguageData extends ObjectBase {
 
   latitude?: number;
   longitude?: number;
+  coordsSource?: LanguageSource;
   depth?: number; // Computed depth in the language family tree, with 0 being a root language
 
   // References to other objects, filled in after loading the TSV

--- a/src/features/data/compute/computeRecursiveLanguageData.ts
+++ b/src/features/data/compute/computeRecursiveLanguageData.ts
@@ -1,4 +1,4 @@
-import { LanguageData } from '@entities/language/LanguageTypes';
+import { LanguageData, LanguageSource } from '@entities/language/LanguageTypes';
 import { getVitalityMetascore } from '@entities/language/vitality/LanguageVitalityComputation';
 
 import averageCoordinates from '@shared/lib/averageCoordinates';
@@ -73,6 +73,7 @@ function computeCoordinates(lang: LanguageData): void {
   const { latitude, longitude } = averageCoordinates(children);
   lang.latitude = latitude;
   lang.longitude = longitude;
+  if (lang.latitude != null && lang.longitude != null) lang.coordsSource = LanguageSource.Combined;
 }
 
 export default computeRecursiveLanguageData;

--- a/src/features/data/load/extra_entities/GlottologData.tsx
+++ b/src/features/data/load/extra_entities/GlottologData.tsx
@@ -5,6 +5,7 @@ import {
   LanguageData,
   LanguagesBySource,
   LanguageScope,
+  LanguageSource,
 } from '@entities/language/LanguageTypes';
 import { setLanguageNames } from '@entities/language/setLanguageNames';
 
@@ -130,6 +131,9 @@ export function addGlottologLanguages(
       lang.Glottolog.name = name;
       lang.latitude = latitude;
       lang.longitude = longitude;
+      if (lang.latitude != null && lang.longitude != null)
+        lang.coordsSource = LanguageSource.Glottolog;
+
       setLanguageNames(lang);
       if (lang.scope == null) {
         lang.scope = scope;

--- a/src/features/transforms/filtering/selectors/LanguageScopeSelector.tsx
+++ b/src/features/transforms/filtering/selectors/LanguageScopeSelector.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 
 import Selector from '@features/params/ui/Selector';
+import { SelectorDisplay } from '@features/params/ui/SelectorDisplayContext';
 import usePageParams from '@features/params/usePageParams';
 
 import { LanguageScope } from '@entities/language/LanguageTypes';
 
 import { getLanguageScopeDescription, getLanguageScopeLabel } from '@strings/LanguageScopeStrings';
 
-const LanguageScopeSelector: React.FC = () => {
+type Props = { display?: SelectorDisplay };
+
+const LanguageScopeSelector: React.FC<Props> = ({ display }) => {
   const { languageScopes, updatePageParams } = usePageParams();
 
   const selectorDescription =
@@ -27,6 +30,7 @@ const LanguageScopeSelector: React.FC = () => {
       selected={languageScopes}
       getOptionLabel={getLanguageScopeLabel}
       getOptionDescription={getLanguageScopeDescription}
+      display={display}
     />
   );
 };

--- a/src/widgets/details/sections/LanguageConnections.tsx
+++ b/src/widgets/details/sections/LanguageConnections.tsx
@@ -7,7 +7,8 @@ import { useDataContext } from '@features/data/context/useDataContext';
 import HoverableButton from '@features/layers/hovercard/HoverableButton';
 import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
 import usePageParams from '@features/params/usePageParams';
-import { getScopeFilter } from '@features/transforms/filtering/filter';
+import Field from '@features/transforms/fields/Field';
+import useFilters from '@features/transforms/filtering/useFilters';
 import { getSortFunction } from '@features/transforms/sorting/sort';
 import { TreeNodeData } from '@features/treelist/TreeListNode';
 import TreeListRoot from '@features/treelist/TreeListRoot';
@@ -23,7 +24,7 @@ const LanguageConnections: React.FC<{ lang: LanguageData }> = ({ lang }) => {
   const { languageSource } = usePageParams();
   const { getCLDRLanguage } = useDataContext();
   const sortFunction = getSortFunction();
-  const filterByScope = getScopeFilter();
+  const filterByScope = useFilters()[Field.TerritoryScope];
   const { childLanguages, ISO, Glottolog, variants, equivalentVariant } = lang;
   const relatedLanguages = (lang.CLDR.languageMatch ?? [])
     .map((match) => ({
@@ -72,14 +73,14 @@ const LanguageConnections: React.FC<{ lang: LanguageData }> = ({ lang }) => {
           </CommaSeparated>
         </DetailsField>
       )}
-      <DetailsField title="Descendant Languages">
+      <DetailsField title="Constituents">
         <TreeOrList
           treeNodes={
             childLanguages.length > 0
               ? getLanguageTreeNodes([lang], languageSource, sortFunction)
               : []
           }
-          listNodes={childLanguages.map((l) => (
+          listNodes={childLanguages.sort(sortFunction).map((l) => (
             <HoverableObjectName key={l.ID} object={l} />
           ))}
           emptyMessage="No languages come from this language."
@@ -90,9 +91,12 @@ const LanguageConnections: React.FC<{ lang: LanguageData }> = ({ lang }) => {
           treeNodes={
             lang.locales.length > 0 ? getLocaleTreeNodes([lang], sortFunction, filterByScope) : []
           }
-          listNodes={(lang.locales ?? []).map((v) => (
-            <HoverableObjectName key={v.ID} object={v} />
-          ))}
+          listNodes={(lang.locales ?? [])
+            .filter(filterByScope)
+            .sort(sortFunction)
+            .map((v) => (
+              <HoverableObjectName key={v.ID} object={v} />
+            ))}
           emptyMessage="No locales available for this language."
         />
       </DetailsField>

--- a/src/widgets/details/sections/LanguageConnections.tsx
+++ b/src/widgets/details/sections/LanguageConnections.tsx
@@ -80,10 +80,10 @@ const LanguageConnections: React.FC<{ lang: LanguageData }> = ({ lang }) => {
               ? getLanguageTreeNodes([lang], languageSource, sortFunction)
               : []
           }
-          listNodes={childLanguages.sort(sortFunction).map((l) => (
+          listNodes={[...childLanguages].sort(sortFunction).map((l) => (
             <HoverableObjectName key={l.ID} object={l} />
           ))}
-          emptyMessage="No languages come from this language."
+          emptyMessage={`${lang.nameDisplay} has no constituent languages or dialects.`}
         />
       </DetailsField>
       <DetailsField title="Locales">

--- a/src/widgets/details/sections/LanguageLocation.tsx
+++ b/src/widgets/details/sections/LanguageLocation.tsx
@@ -1,14 +1,17 @@
-import React from 'react';
+import { CheckSquare2Icon, SquareArrowUpLeftIcon, SquareIcon } from 'lucide-react';
+import React, { useMemo } from 'react';
 
 import HoverableButton from '@features/layers/hovercard/HoverableButton';
 import ObjectMap from '@features/map/EntityMap';
 import LocalParamsProvider from '@features/params/LocalParamsProvider';
 import { ObjectType, PageParamsOptional, View } from '@features/params/PageParamTypes';
+import { SelectorDisplay } from '@features/params/ui/SelectorDisplayContext';
 import usePageParams from '@features/params/usePageParams';
 import Field from '@features/transforms/fields/Field';
+import LanguageScopeSelector from '@features/transforms/filtering/selectors/LanguageScopeSelector';
 import useFilteredEntities from '@features/transforms/filtering/useFilteredEntities';
 
-import { LanguageData } from '@entities/language/LanguageTypes';
+import { LanguageData, LanguageSource } from '@entities/language/LanguageTypes';
 
 import DetailsField from '@shared/containers/DetailsField';
 import DetailsSection from '@shared/containers/DetailsSection';
@@ -17,7 +20,7 @@ import Pill from '@shared/ui/Pill';
 
 import { getLanguageScopeLabel } from '@strings/LanguageScopeStrings';
 
-const MAP_CIRCLE_LIMIT = 200;
+const MAP_CIRCLE_LIMIT = 100;
 
 const LanguageLocation: React.FC<{ lang: LanguageData }> = ({ lang }) => {
   const { updatePageParams } = usePageParams();
@@ -27,7 +30,24 @@ const LanguageLocation: React.FC<{ lang: LanguageData }> = ({ lang }) => {
       <DetailsField title="Coordinates">
         {lang.latitude && lang.longitude ? (
           <>
-            {lang.latitude.toFixed(4)}°, {lang.longitude.toFixed(4)}° <Pill>Glottolog</Pill>
+            {lang.latitude.toFixed(4)}°, {lang.longitude.toFixed(4)}°{' '}
+            {lang.coordsSource && <Pill>{lang.coordsSource}</Pill>}
+            {lang.coordsSource === LanguageSource.Glottolog && (
+              <>
+                {' '}
+                These coordinates represent the &quot;primary&quot; location of the{' '}
+                {getLanguageScopeLabel(lang.scope).toLowerCase()}. This could be the centroid of the
+                area where the language is spoken or a significant location such as a major city for
+                which the language is known.
+              </>
+            )}
+            {lang.coordsSource === LanguageSource.Combined && (
+              <>
+                {' '}
+                These coordinates represent the average location of the constituents of this{' '}
+                {getLanguageScopeLabel(lang.scope).toLowerCase()}.
+              </>
+            )}
           </>
         ) : (
           <Deemphasized>
@@ -43,6 +63,7 @@ const LanguageLocation: React.FC<{ lang: LanguageData }> = ({ lang }) => {
           objectType: ObjectType.Language,
           languageFilter: lang.nameCanonical + ' [' + lang.ID + ']',
           sortBy: Field.Population,
+          searchString: '',
         }}
       >
         <Maps lang={lang} updatePageParams={updatePageParams} />
@@ -57,44 +78,60 @@ type MapsProps = {
   updatePageParams: (newParams: PageParamsOptional) => void;
 };
 function Maps({ lang, updatePageParams }: MapsProps) {
-  const descendants = useFilteredEntities({}).filteredEntities.filter(
-    (l) => l.type == ObjectType.Language && l.latitude && l.longitude,
+  const [showConstituents, setShowConstituents] = React.useState(true);
+  const nodes = useFilteredEntities<LanguageData>({}).filteredEntities; // Use a LocalParamsProvider to limit the visible entities
+  const drawableNodes = useMemo(
+    () => [
+      lang, // always show the selected language
+      ...nodes.filter((l) => l.ID !== lang.ID && l.latitude != null && l.longitude != null),
+    ],
+    [nodes],
   );
+  if (nodes.length === 0) return null;
   return (
     <>
-      {lang.latitude && lang.longitude ? (
-        <>
-          These coordinates show the &quot;primary&quot; location of the language, as defined by
-          Glottolog. This could be the centroid of the area where the language is spoken, or a
-          significant location such as a major city where the language has a presence. It does not
-          represent all the locations where the language is spoken.
-          <ObjectMap entities={[lang]} maxWidth={400} />
-        </>
-      ) : null}
-      {descendants.length > 0 && (
-        <>
-          <div>
-            These are the locations of descendant languages/dialects.
-            {descendants.length > MAP_CIRCLE_LIMIT && (
+      <div>
+        This map shows the center of the {getLanguageScopeLabel(lang.scope).toLowerCase()}
+        {drawableNodes.length > 1 ? ' and its constituents' : ''}. It does not capture every
+        location that the {getLanguageScopeLabel(lang.scope).toLowerCase()} is used.{' '}
+        <HoverableButton
+          style={{ padding: '0.25em', display: 'inline-flex', alignItems: 'center', gap: '0.25em' }}
+          onClick={() =>
+            updatePageParams({
+              view: View.Map,
+              languageFilter: lang.nameCanonical + ' [' + lang.ID + ']',
+            })
+          }
+        >
+          <SquareArrowUpLeftIcon size="1em" /> See the full map in the explore panel
+        </HoverableButton>{' '}
+        {drawableNodes.length > 1 && (
+          <HoverableButton
+            style={{
+              padding: '0.25em',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '0.25em',
+            }}
+            onClick={() => setShowConstituents((prev) => !prev)}
+            hoverContent={showConstituents ? 'Hide constituents' : 'Show constituents'}
+          >
+            {showConstituents ? <CheckSquare2Icon size="1em" /> : <SquareIcon size="1em" />}
+            {showConstituents ? ' Showing constituents' : ' Not showing constituents'}
+            {showConstituents && drawableNodes.length > MAP_CIRCLE_LIMIT && (
               <Deemphasized>
                 {' '}
-                Showing first {MAP_CIRCLE_LIMIT} of {descendants.length}.
+                (first {MAP_CIRCLE_LIMIT} of {drawableNodes.length})
               </Deemphasized>
-            )}{' '}
-            <HoverableButton
-              style={{ padding: '0.25em' }}
-              onClick={() =>
-                updatePageParams({
-                  view: View.Map,
-                  languageFilter: lang.nameCanonical + ' [' + lang.ID + ']',
-                })
-              }
-            >
-              See the full map in explore panel
-            </HoverableButton>
-          </div>
-          <ObjectMap entities={descendants} maxWidth={1000} />
-        </>
+            )}
+          </HoverableButton>
+        )}
+      </div>
+      <div style={{ margin: '.5em 0' }}>
+        <ObjectMap entities={showConstituents ? drawableNodes : [lang]} maxWidth={1000} />
+      </div>
+      {showConstituents && drawableNodes.length > 1 && (
+        <LanguageScopeSelector display={SelectorDisplay.Dropdown} />
       )}
     </>
   );

--- a/src/widgets/details/sections/LanguageLocation.tsx
+++ b/src/widgets/details/sections/LanguageLocation.tsx
@@ -28,7 +28,7 @@ const LanguageLocation: React.FC<{ lang: LanguageData }> = ({ lang }) => {
   return (
     <DetailsSection title="Location">
       <DetailsField title="Coordinates">
-        {lang.latitude && lang.longitude ? (
+        {lang.latitude != null && lang.longitude != null ? (
           <>
             {lang.latitude.toFixed(4)}°, {lang.longitude.toFixed(4)}°{' '}
             {lang.coordsSource && <Pill>{lang.coordsSource}</Pill>}
@@ -85,7 +85,7 @@ function Maps({ lang, updatePageParams }: MapsProps) {
       lang, // always show the selected language
       ...nodes.filter((l) => l.ID !== lang.ID && l.latitude != null && l.longitude != null),
     ],
-    [nodes],
+    [lang, nodes],
   );
   if (nodes.length === 0) return null;
   return (


### PR DESCRIPTION
Fixes #675 

Summary: This updates the language details view, in particular the maps shown

### Changes

- User experience
  - Language Details Location coordinate descriptions updated -- now differentiates between data from Glottolog and data algorithmically combined
  - Language details Location section redone, now combined both maps into 1
    - Fixed filters that may leave out constituents incidentally
    - Will always show the selected entity
    - Default shows all constituents (languages, dialects, ...) but you can turn them off
    - I wasn't sure whether to limit constituents to languages, dialects, etc... so I just put in a scope filter there (if there are nodes to filter)
  - Also made some improvements to the Language Connections section
    - Sorting by the list items by the page source
    - Fixing it so if we are viewing a language family the locales are not filtered in the tree view.
- Logical changes
  - n/a
- Data
  - New language field for the source of the coordinates
- Refactors
  - ...

Out of scope/Future work: I would really like auto-zoom but that's a different github issue #678 

### Test Plan and Screenshots

How to test the changes in this PR: Viewed details for various languages/language families

| Page/View with link | Screenshot Before | Screenshot After |
| ------------------- | ----------------- | ---------------- |
|[Sino-Tibetan](https://translation-commons.github.io/lang-nav/data?objectID=sit&view=Map)|<img width="799" height="817" alt="Screenshot 2026-06-27 at 10 45 10" src="https://github.com/user-attachments/assets/76f4babe-498c-4ddd-ab7c-1b8b0004ef19" />|<img width="797" height="806" alt="Screenshot 2026-06-27 at 10 45 18" src="https://github.com/user-attachments/assets/0cb7ea1f-56b4-4b49-b6fb-ef125403d2d7" />|
|[Chinese](https://translation-commons.github.io/lang-nav/data?objectID=zho&view=Map)|<img width="793" height="814" alt="Screenshot 2026-06-27 at 10 45 23" src="https://github.com/user-attachments/assets/a44246fc-85dc-45d6-80b2-6130d1b06839" />|<img width="797" height="820" alt="Screenshot 2026-06-27 at 10 45 29" src="https://github.com/user-attachments/assets/d60d8206-6b81-4e76-80af-90d7babdfa58" />|
|[French](https://translation-commons.github.io/lang-nav/data?objectID=fra&view=Map&searchString=French)|<img width="797" height="815" alt="Screenshot 2026-06-27 at 10 45 34" src="https://github.com/user-attachments/assets/e40c2adc-f523-4bb2-9a57-f73fe69cc8ea" />|<img width="773" height="814" alt="Screenshot 2026-06-27 at 10 45 40" src="https://github.com/user-attachments/assets/4b490320-ae38-46ad-83aa-ecae5f58a8e3" />

View when the constituents are off:
<img width="785" height="794" alt="Screenshot 2026-06-27 at 10 47 40" src="https://github.com/user-attachments/assets/3f375440-d006-4bc8-bac6-6d51ff1c712e" />


