### PR TITLE
fix: scale zoom control icon size based on mapContainerWidth

### DIFF
--- a/src/features/map/EntityMap.tsx
+++ b/src/features/map/EntityMap.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { ObjectType } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
@@ -53,6 +53,19 @@ const EntityMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
 
   const { colorBy, objectType, pinned, updatePageParams } = usePageParams();
   const [mapScale, setMapScale] = useState(1);
+  const mapContainerRef = useRef<HTMLDivElement>(null);
+  const [mapContainerWidth, setMapContainerWidth] = useState(800);
+
+  useEffect(() => {
+    const el = mapContainerRef.current;
+    if (!el) return;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width;
+      if (width) setMapContainerWidth(width);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
   const updateMapScale = useCallback(() => {
     const rect = contentRef.current?.getBoundingClientRect();
@@ -140,11 +153,12 @@ const EntityMap: React.FC<Props> = ({ entities, maxWidth = 2000 }) => {
   }, [updateMapScale]);
 
   return (
-    <div style={{ maxWidth, width: '100%', position: 'relative' }}>
+    <div ref={mapContainerRef} style={{ maxWidth, width: '100%', position: 'relative' }}>
       <ZoomControls
         zoomIn={handleZoomIn}
         zoomOut={handleZoomOut}
         resetTransform={handleResetTransform}
+        containerWidth={mapContainerWidth}
       />
 
       <div

--- a/src/features/map/ZoomControls.tsx
+++ b/src/features/map/ZoomControls.tsx
@@ -8,11 +8,18 @@ type Props = {
   zoomIn: () => void;
   zoomOut: () => void;
   resetTransform: () => void;
+  containerWidth?: number;
 };
 
-const ZoomControls: React.FC<Props> = ({ zoomIn, zoomOut, resetTransform }) => {
+const ZoomControls: React.FC<Props> = ({
+  zoomIn,
+  zoomOut,
+  resetTransform,
+  containerWidth = 800,
+}) => {
+  const fontSize = containerWidth < 500 ? '0.7em' : containerWidth < 700 ? '0.85em' : '1em';
   return (
-    <div style={containerStyle}>
+    <div style={{ ...containerStyle, fontSize }}>
       <HoverableIcon onClick={zoomIn} description="Zoom in" Icon={ZoomInIcon} />
       <HoverableIcon onClick={zoomOut} description="Zoom out" Icon={ZoomOutIcon} />
       <HoverableIcon onClick={resetTransform} description="Reset" Icon={Maximize2Icon} />


### PR DESCRIPTION
Fixes #698

Summary: Scale zoom control icon size responsively based on the map container's actual rendered width, so the controls don't appear oversized on narrow screens or small map views.

### Changes

- User experience
  - Zoom control icons now shrink on narrow map containers (< 500px → 0.7em, < 700px → 0.85em, ≥ 700px → 1em)
- Logical changes
  - `EntityMap` uses a `ResizeObserver` on its outer `<div>` to track `mapContainerWidth` and passes it down to `ZoomControls`
  - `ZoomControls` accepts a new optional `containerWidth` prop and derives `fontSize` from it

### Test Plan and Screenshots

How to test: Open the map view and resize the browser window (or resize the map panel if in a split layout). The zoom control icons should scale down visibly at narrow widths (below ~500px and ~700px).

<img width="2052" height="1082" alt="image" src="https://github.com/user-attachments/assets/0b589599-e66f-4913-86d3-aa4e01aae552" />
