### PR TITLE
Prototype language proximity UI

### DIFF
--- a/docs/language-proximity-github-issues.md
+++ b/docs/language-proximity-github-issues.md
@@ -1,0 +1,60 @@
+# Draft GitHub Issues: Language Proximity
+
+## Issue 1: Add macrolanguage context banner to language detail pages
+
+Add a clear banner or note on language detail pages when a language is a macrolanguage or has
+constituent languages. This helps users understand that some entries represent groups and that more
+specific language choices may be needed depending on use case.
+
+Acceptance criteria:
+
+- Banner only appears for macrolanguages or languages with constituents.
+- Banner is concise.
+- Banner links or jumps to contained languages section if available.
+- Styling matches existing LangNav cards.
+
+## Issue 2: Add related/contained languages widget
+
+Create a reusable widget that displays contained languages, dialects, and related languages as
+clickable cards or list items.
+
+Acceptance criteria:
+
+- Supports language name, code, optional speaker count, optional score.
+- Uses existing LangNav links.
+- Has empty/fallback state.
+- Layout works on desktop and mobile.
+
+## Issue 3: Investigate language proximity data ingestion
+
+Review Jingyi's Language Proximity worksheet and current census TSV parser to determine how proximity
+data should be loaded into LangNav.
+
+Acceptance criteria:
+
+- Document current TSV ingestion flow.
+- Identify reusable parser/validation logic.
+- Propose first data schema for proximity relationships.
+- Identify minimum data needed for UI prototype.
+
+## Issue 4: Prototype language comparison view
+
+Design a simple comparison component for two languages showing written intelligibility, spoken
+intelligibility, bilingualism, and notes or annotations.
+
+Acceptance criteria:
+
+- Avoid new dependencies unless approved.
+- Prefer simple table/cards first.
+- Leave room for source metadata and human annotations.
+
+## Issue 5: Improve family tree display for large language hierarchies
+
+Investigate how to improve the current family tree view when there are many branches or nested
+relationships.
+
+Acceptance criteria:
+
+- Document current tree behavior.
+- Suggest UI improvements.
+- Consider collapse/expand, depth limiting, search/filter, and separate branch/language display.

--- a/docs/language-proximity-workstream.md
+++ b/docs/language-proximity-workstream.md
@@ -1,0 +1,105 @@
+# Language Proximity / Related Languages Workstream
+
+## Goal
+
+Represent macrolanguages, dialects, contained languages, related languages, and intelligibility
+relationships in LangNav so users can choose the right language or variety for their context.
+
+## Meeting Context
+
+- Revive the language proximity workstream.
+- Coordinate with Jun/Wonjoon and Jingyi.
+- Show Jingyi's Language Proximity dataset in LangNav.
+- Think through both UI and data model.
+- Use GitHub issues to keep work reviewable.
+- Make incremental changes instead of a large redesign.
+
+## Current Data Flow
+
+Spreadsheet -> TSV -> parser -> connected objects -> computed objects -> website.
+
+Core TSV files live in `public/data/`. Main language objects are loaded from
+`public/data/tc/languages.tsv` by `src/features/data/load/entities/loadLanguages.ts`.
+Supplemental ISO and Glottolog data is loaded from `src/features/data/load/extra_entities/`.
+Parent/child language links are connected in `src/features/data/connect/connectLanguagesToParent.ts`.
+
+Census data follows the same broad pattern. Census TSV files are listed in `censusList.txt` files,
+loaded by `src/features/data/load/extra_entities/loadCensusData.tsx`, parsed with
+`parseCensusMetadata`, and then language rows are parsed with `parseCensusLanguageRow`.
+
+## Current Challenges
+
+- Macrolanguage vs language vs dialect is not always obvious to users.
+- ISO codes may not exist for some varieties.
+- The same ISO code can map to different dialect or catalog codes.
+- Family tree views can become too tall or hard to follow.
+- Users need context to choose the right language for speech, writing, localization, or research.
+- Written and spoken intelligibility can differ significantly.
+
+## Proposed UI
+
+- Macrolanguage context banner.
+- Contained languages section.
+- Related languages widget.
+- Dialect section.
+- Intelligibility/comparison view.
+- Optional map, tree, and radar chart explorations later.
+
+## First Milestone
+
+- Add a macrolanguage or language-group banner.
+- Add a related/contained languages widget.
+- Use existing fields such as `scope`, `childLanguages`, and CLDR language matches first.
+- Avoid a large data model refactor.
+
+## Future Milestones
+
+- Load Jingyi's Language Proximity dataset.
+- Generalize TSV validation utilities where reusable.
+- Add comparison page/details.
+- Improve tree/map views for large hierarchies.
+- Support annotations and source metadata.
+
+## Proposed First Data Model
+
+Start with a relationship table that can be loaded independently from core language definitions:
+
+| Field                    | Purpose                                                             |
+| ------------------------ | ------------------------------------------------------------------- |
+| `sourceLanguageCode`     | LangNav language, ISO code, or Glottocode for the first language.   |
+| `targetLanguageCode`     | LangNav language, ISO code, or Glottocode for the related language. |
+| `relationshipType`       | `contained`, `dialect`, `related`, `intelligible_with`, or similar. |
+| `writtenIntelligibility` | Optional numeric score or category.                                 |
+| `spokenIntelligibility`  | Optional numeric score or category.                                 |
+| `bilingualism`           | Optional numeric score or category.                                 |
+| `lexicalSimilarity`      | Optional numeric score or category.                                 |
+| `notes`                  | Human-readable explanation or annotation.                           |
+| `source`                 | Citation, worksheet name, or source URL.                            |
+
+This can be refined after reviewing Jingyi's worksheet columns.
+
+## Relevant Files
+
+- `src/widgets/details/LanguageDetails.tsx`
+- `src/widgets/details/sections/LanguageConnections.tsx`
+- `src/entities/language/LanguageTypes.ts`
+- `src/features/data/load/entities/loadLanguages.ts`
+- `src/features/data/load/extra_entities/ISOData.tsx`
+- `src/features/data/load/extra_entities/GlottologData.tsx`
+- `src/features/data/connect/connectLanguagesToParent.ts`
+- `src/features/data/load/extra_entities/loadCensusData.tsx`
+- `src/entities/census/parseCensusMetadata.ts`
+- `src/entities/census/parseCensusLanguageRow.ts`
+- `public/data/tc/languages.tsv`
+- `public/data/iso/macrolanguages.tsv`
+- `public/data/glottolog/glottolog.tsv`
+- `public/data/census/`
+
+## Open Questions
+
+- Should contained languages appear near the top or bottom?
+- Should branches be visually separated from languages?
+- Should a radar chart be used, or is a table clearer?
+- What exact fields from Jingyi's worksheet should become first-class data?
+- Should map auto-zoom show constituents by default?
+- How should we represent a family containing a macrolanguage that contains another family?

--- a/src/widgets/details/LanguageDetails.tsx
+++ b/src/widgets/details/LanguageDetails.tsx
@@ -10,6 +10,9 @@ import LanguageConnections from './sections/LanguageConnections';
 import LanguageLocation from './sections/LanguageLocation';
 import LanguageNames from './sections/LanguageNames';
 import LanguagePopulationDetails from './sections/LanguagePopulationDetails';
+import LanguageRelationsWidget, {
+  LanguageRelationContextBanner,
+} from './sections/LanguageRelationsWidget';
 import LanguageSpeakersByTerritorySection from './sections/LanguageSpeakersByTerritorySection';
 import LanguageWikipediaSection from './sections/LanguageWikipediaSection';
 
@@ -22,6 +25,7 @@ const LanguageDetails: React.FC<Props> = ({ lang }) => {
     <div className="Details">
       <LanguageNames lang={lang} />
       <LanguageCodes lang={lang} />
+      <LanguageRelationContextBanner lang={lang} />
 
       <FlexRow>
         <FlexItem>
@@ -34,6 +38,8 @@ const LanguageDetails: React.FC<Props> = ({ lang }) => {
           <LanguageVitalitySection lang={lang} />
         </FlexItem>
       </FlexRow>
+
+      <LanguageRelationsWidget lang={lang} />
 
       <FlexRow>
         <FlexItem flex="2 1 300px">

--- a/src/widgets/details/sections/LanguageRelationsWidget.tsx
+++ b/src/widgets/details/sections/LanguageRelationsWidget.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+
+import { useDataContext } from '@features/data/context/useDataContext';
+import HoverableObjectName from '@features/layers/hovercard/HoverableObjectName';
+import { getSortFunction } from '@features/transforms/sorting/sort';
+
+import { LanguageData, LanguageScope } from '@entities/language/LanguageTypes';
+
+import DetailsSection from '@shared/containers/DetailsSection';
+import CountOfPeople from '@shared/ui/CountOfPeople';
+import Deemphasized from '@shared/ui/Deemphasized';
+
+import { getLanguageScopeLabel } from '@strings/LanguageScopeStrings';
+
+const LANGUAGE_RELATIONS_SECTION_ID = 'language-relations';
+
+export const LanguageRelationContextBanner: React.FC<{ lang: LanguageData }> = ({ lang }) => {
+  const hasChildren = lang.childLanguages.length > 0;
+  const isMacrolanguage = lang.scope === LanguageScope.Macrolanguage;
+
+  if (!isMacrolanguage && !hasChildren) return null;
+
+  return (
+    <div
+      style={{
+        marginBottom: '1em',
+        border: '1px solid var(--color-button-secondary)',
+        borderRadius: '0.5em',
+        padding: '0.85em 1em',
+        backgroundColor: 'var(--color-background-hover)',
+      }}
+    >
+      <strong>{isMacrolanguage ? 'Macrolanguage context' : 'Language group context'}</strong>
+      <div style={{ marginTop: '0.35em' }}>
+        This entry represents a macrolanguage or language group. It may contain multiple constituent
+        languages or varieties. For some uses, such as speech, a more specific language may be more
+        appropriate.
+        {hasChildren && (
+          <>
+            {' '}
+            <a href={`#${LANGUAGE_RELATIONS_SECTION_ID}`}>See contained languages.</a>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const LanguageRelationsWidget: React.FC<{ lang: LanguageData }> = ({ lang }) => {
+  const { getCLDRLanguage } = useDataContext();
+  const sortFunction = getSortFunction();
+  const childLanguages = [...lang.childLanguages].sort(sortFunction);
+  const dialects = childLanguages.filter((child) => child.scope === LanguageScope.Dialect);
+  const containedLanguages = childLanguages.filter(
+    (child) => child.scope !== LanguageScope.Dialect,
+  );
+  const relatedLanguages = (lang.CLDR.languageMatch ?? [])
+    .map((match) => ({ match, language: getCLDRLanguage(match.supported) }))
+    .filter(
+      (entry): entry is { match: (typeof entry)['match']; language: LanguageData } =>
+        entry.language != null && entry.language.ID !== lang.ID,
+    );
+
+  const hasRelations =
+    containedLanguages.length > 0 || dialects.length > 0 || relatedLanguages.length > 0;
+
+  return (
+    <div id={LANGUAGE_RELATIONS_SECTION_ID}>
+      <DetailsSection title="Related Languages">
+        {!hasRelations && (
+          <Deemphasized>
+            No contained, dialect, or related-language data available yet.
+          </Deemphasized>
+        )}
+
+        {containedLanguages.length > 0 && (
+          <RelationGroup title="Contained Languages">
+            {containedLanguages.map((language) => (
+              <LanguageRelationCard key={language.ID} language={language} />
+            ))}
+          </RelationGroup>
+        )}
+
+        {dialects.length > 0 && (
+          <RelationGroup title="Dialects and Varieties">
+            {dialects.map((language) => (
+              <LanguageRelationCard key={language.ID} language={language} />
+            ))}
+          </RelationGroup>
+        )}
+
+        {relatedLanguages.length > 0 && (
+          <RelationGroup title="Related Languages from CLDR">
+            {relatedLanguages.map(({ match, language }) => (
+              <CLDRRelationCard
+                key={`${match.desired}:${match.supported}:${match.distance}`}
+                language={language}
+                distance={match.distance}
+              />
+            ))}
+          </RelationGroup>
+        )}
+      </DetailsSection>
+    </div>
+  );
+};
+
+type RelationGroupProps = {
+  title: string;
+  children: React.ReactNode;
+};
+
+const RelationGroup: React.FC<RelationGroupProps> = ({ title, children }) => {
+  return (
+    <div style={{ marginTop: '0.85em' }}>
+      <h4 style={{ margin: '0 0 0.5em' }}>{title}</h4>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+          gap: '0.75em',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+const LanguageRelationCard: React.FC<{ language: LanguageData }> = ({ language }) => {
+  return (
+    <RelationCard>
+      <div style={{ fontWeight: 'bold' }}>
+        <HoverableObjectName object={language} labelSource="name and code" />
+      </div>
+      <RelationMeta label="Type" value={getLanguageScopeLabel(language.scope) ?? 'Language'} />
+      <RelationMeta
+        label="Speakers"
+        value={<CountOfPeople count={language.populationEstimate} />}
+      />
+    </RelationCard>
+  );
+};
+
+const CLDRRelationCard: React.FC<{ language: LanguageData; distance: number }> = ({
+  language,
+  distance,
+}) => {
+  return (
+    <RelationCard>
+      <div style={{ fontWeight: 'bold' }}>
+        <HoverableObjectName object={language} labelSource="name and code" />
+      </div>
+      <RelationMeta label="CLDR distance" value={distance} />
+    </RelationCard>
+  );
+};
+
+const RelationCard: React.FC<React.PropsWithChildren> = ({ children }) => {
+  return (
+    <div
+      style={{
+        border: '1px solid var(--color-button-secondary)',
+        borderRadius: '0.5em',
+        padding: '0.75em',
+        minHeight: '5.25em',
+        boxSizing: 'border-box',
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+const RelationMeta: React.FC<{ label: string; value: React.ReactNode }> = ({ label, value }) => {
+  return (
+    <div style={{ marginTop: '0.35em', color: 'var(--color-text-secondary)' }}>
+      <span>{label}: </span>
+      {value}
+    </div>
+  );
+};
+
+export default LanguageRelationsWidget;


### PR DESCRIPTION
## Summary

This PR starts the Language Proximity / Related Languages workstream by adding an initial UI/documentation foundation for representing macrolanguages, contained languages, dialects, and related-language relationships in LangNav.

## Context

This follows a sync with Conrad about reviving the language proximity workstream with Jun/Wonjoon and Jingyi. The goal is to make LangNav better at explaining complex language relationships such as Chinese as a macrolanguage containing Mandarin, Cantonese, Wu, and other constituent languages.

## Changes

* Added initial documentation for the Language Proximity workstream.
* Drafted GitHub issue breakdown for future work.
* Added/prototyped a macrolanguage context note/banner if implemented.
* Added/prototyped a related/contained languages widget if implemented.
* Investigated current TSV/data ingestion flow if documented.

## Notes

This is intentionally incremental. The goal is to create a small reviewable starting point before deeper ingestion/data-model work.

## Future Work

* Review Jingyi's Language Proximity worksheet.
* Align with Wonjoon on language scope modeling.
* Load proximity data into LangNav.
* Add language comparison view.
* Improve family tree/map visualizations.
* Consider whether radar charts or simpler tables are more effective.