### PR TITLE
Data: Add Windows 11 language pack support

### DIFF
--- a/public/data/google/gtranslate.tsv
+++ b/public/data/google/gtranslate.tsv
@@ -46,13 +46,13 @@ ceb	Cebuano
 cha	Chamorro		
 che	Chechen		
 nya	Chichewa		
-zho	Chinese (Simplified)		
-zho	Chinese (Traditional)		
+zho/cmn	Chinese (Simplified)		
+zho/cmn	Chinese (Traditional)		
 chk	Chuukese		
 chv	Chuvash		
 cos	Corsican		
 crh	Crimean Tatar (Cyrillic)		Cyrillic
-crh	Crimean Tatar (Latin		Latin
+crh	Crimean Tatar (Latin)		Latin
 hbs/hrv	Croatian		
 ces	Czech		
 dan	Danish		
@@ -124,8 +124,8 @@ kom	Komi
 kok	Konkani		
 kor	Korean		
 kri	Krio		
-kmr	Kurdish (Kurmanji)		
-ckb	Kurdish (Sorani)		
+kur/kmr	Kurdish (Kurmanji)		
+kur/ckb	Kurdish (Sorani)		
 kir	Kyrgyz		
 lao	Lao		
 lav/ltg	Latgalian		

--- a/public/data/other_sources/win11_language_packs.tsv
+++ b/public/data/other_sources/win11_language_packs.tsv
@@ -53,7 +53,7 @@ lav	Latvian
 lit	Lithuanian		
 ltz	Luxembourgish		
 mkd	Macedonian		
-msa/zlm	Malay 	Malaysia, Brunei, and Singapore	
+msa/zsm	Malay 	Malaysia, Brunei, and Singapore	
 mal	Malayalam		
 mlt	Maltese		
 mri	Maori		

--- a/public/data/other_sources/win11_language_packs.tsv
+++ b/public/data/other_sources/win11_language_packs.tsv
@@ -1,0 +1,92 @@
+### Metadata ###			
+#topic	Windows 11 provides an official language pack to to view menus, dialog boxes, and supported apps and websites	Translation of Windows 11 User Interface	
+#url	https://support.microsoft.com/en-US/Windows/Hardware/Input-Devices/language-packs-for-windows#windowsversion=windows_11		
+#dateAccessed	6/30/26		
+#author	Microsoft		
+#notes			
+			
+Language Code	Language	Locale	Writing System
+afr	Afrikaans		
+sqi	Albanian		
+amh	Amharic		
+ara	Arabic		
+hye	Armenian		
+asm	Assamese		
+aze	Azerbaijani 		Latin
+ben	Bangla 	India	
+eus	Basque		
+bel	Belarusian		
+hbs/bos	Bosnian 		Latin
+bul	Bulgarian		
+cat	Catalan		
+chr	Cherokee 		Cherokee
+zho/cmn	Chinese Simplified		
+zho/cmn	Chinese Traditional		
+hbs/hrv	Croatian		
+ces	Czech		
+dan	Danish		
+nld	Dutch		
+eng	English		
+est	Estonian		
+fil	Filipino		
+fin	Finnish		
+fra	French		
+glg	Galician		
+kat	Georgian		
+deu	German		
+ell	Greek		
+guj	Gujarati		
+heb	Hebrew		
+hin	Hindi		
+hun	Hungarian		
+isl	Icelandic		
+msa/ind	Indonesian		
+gle	Irish		
+ita	Italian		
+jpn	Japanese		
+kan	Kannada		
+kaz	Kazakh		
+khm	Khmer		
+kok	Konkani		
+kor	Korean		
+lav	Latvian		
+lit	Lithuanian		
+ltz	Luxembourgish		
+mkd	Macedonian		
+msa/zlm	Malay 	Malaysia, Brunei, and Singapore	
+mal	Malayalam		
+mlt	Maltese		
+mri	Maori		
+mar	Marathi		
+nep	Nepali		
+nor/nob	Norwegian Bokmål		
+nor/nno	Norwegian Nynorsk		
+ori	Odia		
+fas	Persian		
+pol	Polish		
+por	Portuguese 	Brazil	
+por	Portuguese 	Portugal	
+lah/pan	Punjabi 		Arabic
+que	Quechua		
+ron	Romanian		
+rus	Russian		
+gla	Scottish Gaelic		
+hbs/srp	Serbian	Bosnia and Herzegovina	Cyrillic
+hbs/srp	Serbian	Serbia	Cyrillic
+hbs/srp	Serbian 		Latin
+slk	Slovak		
+slv	Slovenian		
+spa	Spanish		
+swe	Swedish		
+tam	Tamil 	India and Sri Lanka	
+tat	Tatar		
+tel	Telugu		
+tha	Thai		
+tur	Turkish		
+ukr	Ukrainian		
+urd	Urdu		
+uig	Uyghur		
+uzb	Uzbek 		Latin
+cat/vale1252	Valencian		
+vie	Vietnamese		
+cym	Welsh		

--- a/src/entities/language/LanguageTypes.ts
+++ b/src/entities/language/LanguageTypes.ts
@@ -19,6 +19,7 @@ import {
   ObjectBase,
   UniversalDeclarationOfHumanRightsData,
   WikipediaData,
+  Win11LanguagePackData,
 } from '../types/DataTypes';
 
 import { LanguageModality } from './LanguageModality';
@@ -121,6 +122,7 @@ export interface LanguageData extends ObjectBase {
   wikipedias?: WikipediaData[];
   udhr?: UniversalDeclarationOfHumanRightsData[];
   googleTranslate?: GoogleTranslateData[];
+  win11LanguagePacks?: Win11LanguagePackData[];
 
   latitude?: number;
   longitude?: number;

--- a/src/entities/types/DataTypes.tsx
+++ b/src/entities/types/DataTypes.tsx
@@ -67,3 +67,10 @@ export type GoogleTranslateData = {
   locale?: string;
   writingSystem?: string;
 };
+
+export type Win11LanguagePackData = {
+  languageCodePath: string; // e.g. "zho/cmn" when multiple codes are listed
+  name: string;
+  locale?: string;
+  writingSystem?: string;
+};

--- a/src/entities/ui/GoogleTranslateSupportStatus.tsx
+++ b/src/entities/ui/GoogleTranslateSupportStatus.tsx
@@ -15,7 +15,7 @@ const GoogleTranslateSupportStatus: React.FC<{ lang: LanguageData }> = ({ lang }
   const hoverContent = lang.googleTranslate.map((entry) => entry.name).join(', ');
 
   return (
-    <Hoverable hoverContent={hoverContent} style={{ display: 'inline-flex', alignItems: 'center' }}>
+    <Hoverable hoverContent={hoverContent}>
       <CheckCircle2Icon
         style={{ color: 'var(--color-green)', verticalAlign: 'middle' }}
         size={'1em'}

--- a/src/entities/ui/Win11LanguagePackSupportStatus.tsx
+++ b/src/entities/ui/Win11LanguagePackSupportStatus.tsx
@@ -1,0 +1,36 @@
+import { CheckCircle2Icon, XCircleIcon } from 'lucide-react';
+import React from 'react';
+
+import Hoverable from '@features/layers/hovercard/Hoverable';
+
+import { LanguageData } from '@entities/language/LanguageTypes';
+
+const Win11LanguagePackSupportStatus: React.FC<{ lang: LanguageData }> = ({ lang }) => {
+  if (!lang.win11LanguagePacks || lang.win11LanguagePacks.length === 0) {
+    return (
+      <Hoverable hoverContent="No official language pack available.">
+        <XCircleIcon style={{ color: 'var(--color-red)', verticalAlign: 'middle' }} size={'1em'} />
+      </Hoverable>
+    );
+  }
+
+  const hoverContent = lang.win11LanguagePacks
+    .map((entry) => {
+      const parts = [entry.name];
+      if (entry.locale) parts.push(`(${entry.locale})`);
+      if (entry.writingSystem) parts.push(`${entry.writingSystem}`);
+      return parts.join(' ');
+    })
+    .join(', ');
+
+  return (
+    <Hoverable hoverContent={hoverContent}>
+      <CheckCircle2Icon
+        style={{ color: 'var(--color-green)', verticalAlign: 'middle' }}
+        size={'1em'}
+      />
+    </Hoverable>
+  );
+};
+
+export default Win11LanguagePackSupportStatus;

--- a/src/features/data/load/SupplementalData.tsx
+++ b/src/features/data/load/SupplementalData.tsx
@@ -17,6 +17,7 @@ import { loadTerritoryGDPLiteracy } from './supplemental/loadTerritoryGDPLiterac
 import { loadTerritoryNames } from './supplemental/loadTerritoryNames';
 import { loadUDHR } from './supplemental/loadUDHR';
 import { loadVariantAnnotations } from './supplemental/loadVariantAnnotations';
+import { loadWin11LanguagePacks } from './supplemental/loadWin11LanguagePacks';
 import { getLanguageCountsFromCLDR, loadCLDRCoverage } from './supplemental/UnicodeData';
 import { loadAndApplyWikipediaData } from './supplemental/WikipediaData';
 
@@ -44,6 +45,7 @@ export async function loadSupplementalData(dataContext: DataContextType): Promis
     loadGoogleTranslate(dataContext.getLanguage),
     loadUDHR(dataContext.getLanguage),
     loadVariantAnnotations(dataContext.getVariant, dataContext.getLanguage),
+    loadWin11LanguagePacks(dataContext.getLanguage),
   ]);
 
   const censusImports = await loadCensusData();

--- a/src/features/data/load/supplemental/loadWin11LanguagePacks.ts
+++ b/src/features/data/load/supplemental/loadWin11LanguagePacks.ts
@@ -1,0 +1,40 @@
+import { isIgnoredLanguageCode } from '@entities/census/parseCensusLanguageRow';
+import { LanguageData } from '@entities/language/LanguageTypes';
+
+/**
+ * Load Windows 11 language pack availability data.
+ * File format:
+ * Language Code\tLanguage\tLocale\tWriting System
+ */
+export async function loadWin11LanguagePacks(
+  getLanguage: (id: string) => LanguageData | undefined,
+): Promise<void> {
+  await fetch('data/other_sources/win11_language_packs.tsv')
+    .then((res) => res.text())
+    .then((text) => text.split('\n').filter((line) => line.trim() !== '' && !line.startsWith('#')))
+    .then((lines) => {
+      lines.forEach((line) => {
+        const parts = line.split('\t');
+        if (parts.length < 2) return;
+
+        const languageCodePath = (parts[0] ?? '').trim();
+        if (languageCodePath === '' || languageCodePath === 'Language Code') return;
+
+        const name = (parts[1] ?? '').trim();
+        const locale = (parts[2] ?? '').trim() || undefined;
+        const writingSystem = (parts[3] ?? '').trim() || undefined;
+        const languageCodes = languageCodePath.split('/');
+
+        languageCodes.forEach((code) => {
+          if (isIgnoredLanguageCode(code)) return;
+
+          const language = getLanguage(code);
+          if (!language) return;
+
+          if (!language.win11LanguagePacks) language.win11LanguagePacks = [];
+          language.win11LanguagePacks.push({ languageCodePath, name, locale, writingSystem });
+        });
+      });
+    })
+    .catch((err) => console.error('Error loading Windows 11 language packs data:', err));
+}

--- a/src/widgets/tables/columns/LanguageDigitalSupportColumns.tsx
+++ b/src/widgets/tables/columns/LanguageDigitalSupportColumns.tsx
@@ -19,6 +19,7 @@ import {
   WikipediaLink,
   WikipediaStatusDisplay,
 } from '@entities/ui/ObjectWikipediaInfo';
+import Win11LanguagePackSupportStatus from '@entities/ui/Win11LanguagePackSupportStatus';
 
 import ExternalLink from '@shared/ui/ExternalLink';
 
@@ -81,6 +82,23 @@ const columns: TableColumn<LanguageData>[] = [
     exportValue: (lang) => {
       if (!lang.googleTranslate || lang.googleTranslate.length === 0) return 'n/a';
       return lang.googleTranslate.map((entry) => entry.name).join('; ');
+    },
+  },
+  {
+    key: 'Windows 11',
+    description:
+      'Language pack available in Windows 11 for viewing menus, dialog boxes, and supported apps and websites.',
+    render: (lang) => <Win11LanguagePackSupportStatus lang={lang} />,
+    exportValue: (lang) => {
+      if (!lang.win11LanguagePacks || lang.win11LanguagePacks.length === 0) return 'n/a';
+      return lang.win11LanguagePacks
+        .map((entry) => {
+          const parts = [entry.name];
+          if (entry.locale) parts.push(`(${entry.locale})`);
+          if (entry.writingSystem) parts.push(`(${entry.writingSystem})`);
+          return parts.join(' ');
+        })
+        .join('; ');
     },
   },
   {


### PR DESCRIPTION
Part of #538

Summary: Added Windows 11 language-pack support to digital support reporting.

Note 1: Added missing macrolanguage codes for gtranslate and removed a style component, which I both forgot to push in #689

Note 2: This PR adds some sligly redundant code in `DataTypes.tsx`. Before we try to generalise those parts and refactor the digital support codebase, I'd like to just get the data online. Same goes for the view in `LanguageDetailsVitalityAndViability`, which might need to be redone anyway? Will add corresponding issues in the coming days.


### Changes

- User experience
  - Added a new Windows 11 digital-support column that shows support with icons and hover details (including locale/script variants when present).

- Logical changes
  - Extended LanguageTypes and DataTypes
- Data
  - New file `public/data/other_sources/win11_language_packs.tsv` and data loading

Out of scope/Future work: see Note 2 + connections with Locales and Writing Systems

### Test Plan and Screenshots


| Page/View with link | Screenshot After |
|----------------- | ---------------- |
|[Languages Table View](http://localhost:5173/lang-nav/data?view=Table&columns=1-349ut8eip)|<img width="662" height="211" alt="screen4" src="https://github.com/user-attachments/assets/11d67e9f-f005-419e-9289-60339f918c80" />|
|[Languages Table Columns](http://localhost:5173/lang-nav/data?view=Table&columns=1-349ut8eip)|<img width="224" height="307" alt="screen5" src="https://github.com/user-attachments/assets/5c2f2cb4-cd54-4e86-858e-112437d91446" />|


# Checklist
## Summary

- [X] Clear description of what and why
- [X] Scope kept focused; note follow-ups if any
- [X] Set yourself as assignee
- [X] Mention the issue

## Testing

- [X] `npm run lint`
- [X] `npm run build`
- [X] `npm run test`
- [X] `npm run dev` -- tried out the website directly

## Changes

### Visual changes

- [X] Listed screenshots with reproducible links
### Data changes

- [X] TSV in `public/data/`
- [X] Load/connect/compute updates in `src/features/data/` including how we aggregate data or compute derived values

### Internal changes

- [X] Logical changes

## Docs

- [X] Code is self-documenting, or if not, comments are added where needed.
