### PR TITLE
Refactor: PageParamsOptional -> Partial

### DIFF
--- a/src/features/layers/hovercard/HoverableInternalLinkButton.tsx
+++ b/src/features/layers/hovercard/HoverableInternalLinkButton.tsx
@@ -4,7 +4,7 @@ import { Link, useSearchParams } from 'react-router';
 import { LangNavPageName } from '@app/PageRoutes';
 
 import { getNewURLSearchParams } from '@features/params/getNewURLSearchParams';
-import { PageParamsOptional } from '@features/params/PageParamTypes';
+import { PageParams } from '@features/params/PageParamTypes';
 
 import useHoverCard from './useHoverCard';
 
@@ -17,7 +17,7 @@ type HoverableProps = {
   onClick?: () => void;
   onMouseDown?: () => void;
   page?: LangNavPageName;
-  params?: PageParamsOptional;
+  params?: Partial<PageParams>;
   role?: string;
   style?: React.CSSProperties;
 };

--- a/src/features/layers/hovercard/HoverableObject.tsx
+++ b/src/features/layers/hovercard/HoverableObject.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 
 import Hoverable from '@features/layers/hovercard/Hoverable';
-import { PageParamsOptional } from '@features/params/PageParamTypes';
+import { PageParams } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 
 import { ObjectData } from '@entities/types/DataTypes';
@@ -20,7 +20,7 @@ const HoverableObject: React.FC<Props> = ({ object, children, style }) => {
   }
 
   const onClick = useCallback(() => {
-    const params: PageParamsOptional = { objectID: object.ID };
+    const params: Partial<PageParams> = { objectID: object.ID };
     updatePageParams(params);
   }, [object, updatePageParams, view]);
 

--- a/src/features/params/InternalLink.tsx
+++ b/src/features/params/InternalLink.tsx
@@ -4,11 +4,11 @@ import { Link, useSearchParams } from 'react-router-dom';
 import { LangNavPageName } from '@app/PageRoutes';
 
 import { getNewURLSearchParams } from './getNewURLSearchParams';
-import { PageParamsOptional } from './PageParamTypes';
+import { PageParams } from './PageParamTypes';
 
 type Props = {
   page?: LangNavPageName;
-  params?: PageParamsOptional;
+  params?: Partial<PageParams>;
   children: React.ReactNode;
   style?: React.CSSProperties;
   keepOldParams?: boolean;

--- a/src/features/params/LocalParamsProvider.tsx
+++ b/src/features/params/LocalParamsProvider.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import HoverCardProvider from '@features/layers/hovercard/HoverCardProvider';
 
 import { PageParamsContext, PageParamsContextState } from './PageParamsContext';
-import { PageParamsOptional } from './PageParamTypes';
+import { PageParams } from './PageParamTypes';
 import usePageParams from './usePageParams';
 
 /**
@@ -11,19 +11,19 @@ import usePageParams from './usePageParams';
  */
 const LocalParamsProvider: React.FC<{
   children: React.ReactNode;
-  overrides?: PageParamsOptional;
+  overrides?: Partial<PageParams>;
 }> = ({ children, overrides }) => {
   const globalParams = usePageParams();
-  const [localParams, setLocalParams] = useState<PageParamsOptional>({});
+  const [localParams, setLocalParams] = useState<Partial<PageParams>>({});
 
   // Instead of mutating the global page's parameters, have mutations in this context just override a local layer
   const updateLocalParams = useCallback(
-    (newParams: PageParamsOptional) => {
+    (newParams: Partial<PageParams>) => {
       setLocalParams((prev) => {
         const nextParams = { ...prev, ...newParams };
         Object.entries(nextParams).forEach(([key, value]) => {
           if (value === undefined) {
-            delete nextParams[key as keyof PageParamsOptional];
+            delete nextParams[key as keyof PageParams];
           }
         });
         return nextParams;

--- a/src/features/params/PageParamTypes.tsx
+++ b/src/features/params/PageParamTypes.tsx
@@ -123,38 +123,3 @@ export type PageParams = {
   vitalityEthCoarse: VitalityEthnologueCoarse[];
   writingSystemFilter: string;
 };
-
-export type PageParamsOptional = {
-  colorBy?: Field;
-  colorGradient?: ColorGradient;
-  columns?: TableIDToBinarizedColumnVisibility;
-  isoStatus?: LanguageISOStatus[];
-  fieldFocus?: Field;
-  languageFilter?: string;
-  languageFamilyFilter?: string;
-  languageScopes?: LanguageScope[];
-  languageSource?: LanguageSource;
-  limit?: number;
-  localeSeparator?: LocaleSeparator;
-  modalityFilter?: LanguageModality[];
-  objectID?: string;
-  objectType?: ObjectType;
-  page?: number;
-  pinned?: string[];
-  populationMax?: number;
-  populationMin?: number;
-  profile?: ProfileType;
-  reportID?: ReportID;
-  scaleBy?: Field;
-  searchBy?: SearchableField;
-  searchString?: string;
-  secondarySortBy?: Field;
-  sortBehavior?: SortBehavior;
-  sortBy?: Field;
-  territoryFilter?: string;
-  territoryScopes?: TerritoryScope[];
-  view?: View;
-  vitalityEthCoarse?: VitalityEthnologueCoarse[];
-  vitalityEthFine?: VitalityEthnologueFine[];
-  writingSystemFilter?: string;
-};

--- a/src/features/params/PageParamsContext.tsx
+++ b/src/features/params/PageParamsContext.tsx
@@ -2,11 +2,11 @@ import { createContext } from 'react';
 
 import { PageBrightnessParams } from '@shared/hooks/usePageBrightness';
 
-import { PageParams, PageParamsOptional } from './PageParamTypes';
+import { PageParams } from './PageParamTypes';
 
 export type PageParamsContextState = PageParams & {
   brightness: PageBrightnessParams;
-  updatePageParams: (newParams: PageParamsOptional) => void;
+  updatePageParams: (newParams: Partial<PageParams>) => void;
 };
 
 export const PageParamsContext = createContext<PageParamsContextState | undefined>(undefined);

--- a/src/features/params/PageParamsProvider.tsx
+++ b/src/features/params/PageParamsProvider.tsx
@@ -6,7 +6,7 @@ import { usePageBrightness } from '@shared/hooks/usePageBrightness';
 import { getNewURLSearchParams } from './getNewURLSearchParams';
 import { getParamsFromURL } from './getParamsFromURL';
 import { PageParamsContext, PageParamsContextState } from './PageParamsContext';
-import { PageParamsOptional } from './PageParamTypes';
+import type { PageParams } from './PageParamTypes';
 import { getDefaultParams } from './Profiles';
 
 const PageParamsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -14,7 +14,7 @@ const PageParamsProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   const pageBrightness = usePageBrightness();
 
   const updatePageParams = useCallback(
-    (newParams: PageParamsOptional) => {
+    (newParams: Partial<PageParams>) => {
       setURLPageParams((prev) => getNewURLSearchParams(newParams, prev));
     },
     [setURLPageParams],
@@ -31,7 +31,7 @@ const PageParamsProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     );
 
     Object.keys(instantiatedParams).forEach((key) => {
-      const typedKey = key as keyof PageParamsOptional;
+      const typedKey = key as keyof PageParams;
       if (instantiatedParams[typedKey] == null) delete instantiatedParams[typedKey];
     });
     return {

--- a/src/features/params/Profiles.tsx
+++ b/src/features/params/Profiles.tsx
@@ -22,9 +22,8 @@ import {
   LocaleSeparator,
   ObjectType,
   PageParams,
-  PageParamsOptional,
   SearchableField,
-  View,
+  View
 } from './PageParamTypes';
 
 export enum ProfileType {
@@ -72,7 +71,7 @@ const GLOBAL_DEFAULTS: PageParams = {
   writingSystemFilter: '',
 };
 
-export const DEFAULTS_BY_PROFILE: Record<ProfileType, PageParamsOptional> = {
+export const DEFAULTS_BY_PROFILE: Record<ProfileType, Partial<PageParams>> = {
   [ProfileType.LanguageEthusiast]: {
     // Nothing, default profile is based on this
   },

--- a/src/features/params/Profiles.tsx
+++ b/src/features/params/Profiles.tsx
@@ -18,13 +18,7 @@ import { SortBehavior } from '@features/transforms/sorting/SortTypes';
 import { LanguageScope, LanguageSource } from '@entities/language/LanguageTypes';
 import { TerritoryScope } from '@entities/territory/TerritoryTypes';
 
-import {
-  LocaleSeparator,
-  ObjectType,
-  PageParams,
-  SearchableField,
-  View
-} from './PageParamTypes';
+import { LocaleSeparator, ObjectType, PageParams, SearchableField, View } from './PageParamTypes';
 
 export enum ProfileType {
   LanguageEthusiast = 'Language Enthusiast', // Default

--- a/src/features/params/getNewURL.ts
+++ b/src/features/params/getNewURL.ts
@@ -1,10 +1,10 @@
 import { getNewURLSearchParams } from './getNewURLSearchParams';
-import { PageParamsOptional } from './PageParamTypes';
+import type { PageParams } from './PageParamTypes';
 
 /**
  * Gets a fresh URL -- good for anchor links where you want to clear out existing parameters
  * and to enable people to use extra interactions (like open in new window, copy link URL, etc).
  */
-export function getNewURL(params: PageParamsOptional): string {
+export function getNewURL(params: Partial<PageParams>): string {
   return `?${getNewURLSearchParams(params).toString()}`;
 }

--- a/src/features/params/getNewURLSearchParams.ts
+++ b/src/features/params/getNewURLSearchParams.ts
@@ -1,7 +1,7 @@
 import { stringifyColumnVisibilityBinaries } from '@features/table/useColumnVisibility';
 import Field from '@features/transforms/fields/Field';
 
-import { ObjectType, PageParamKey, PageParamsOptional, View } from './PageParamTypes';
+import { ObjectType, PageParamKey, PageParams, View } from './PageParamTypes';
 import { getDefaultParams, ProfileType } from './Profiles';
 
 /**
@@ -9,7 +9,7 @@ import { getDefaultParams, ProfileType } from './Profiles';
  */
 
 function buildNextURLSearchParams(
-  newParams: PageParamsOptional,
+  newParams: Partial<PageParams>,
   next: URLSearchParams,
 ): URLSearchParams {
   // Convert newParams to array for iterate
@@ -103,7 +103,7 @@ function clearDefaultParams(next: URLSearchParams): URLSearchParams {
 }
 
 function clearContextDependentParams(
-  newParams: PageParamsOptional,
+  newParams: Partial<PageParams>,
   next: URLSearchParams,
   prev?: URLSearchParams,
 ): URLSearchParams {
@@ -153,7 +153,7 @@ function clearContextDependentParams(
 }
 
 export function getNewURLSearchParams(
-  newParams: PageParamsOptional,
+  newParams: Partial<PageParams>,
   prev?: URLSearchParams,
 ): URLSearchParams {
   let next = new URLSearchParams(prev);

--- a/src/features/params/getParamsFromURL.ts
+++ b/src/features/params/getParamsFromURL.ts
@@ -22,7 +22,7 @@ import {
   LocaleSeparator,
   ObjectType,
   PageParamKey,
-  PageParamsOptional,
+  PageParams,
   SearchableField,
   View,
 } from './PageParamTypes';
@@ -45,8 +45,8 @@ function parseNumericEnumArray<T extends number>(
 /**
  * This function is important for parsing the URL parameters
  */
-export function getParamsFromURL(urlParams: URLSearchParams): PageParamsOptional {
-  const params: PageParamsOptional = {};
+export function getParamsFromURL(urlParams: URLSearchParams): Partial<PageParams> {
+  const params: Partial<PageParams> = {};
   urlParams.forEach((value, keyUntyped) => {
     const key = keyUntyped as PageParamKey;
     switch (key) {

--- a/src/features/params/useAmplitudeParamEvents.ts
+++ b/src/features/params/useAmplitudeParamEvents.ts
@@ -18,7 +18,7 @@ import {
 } from '@shared/lib/amplitudeFormat';
 
 import { getParamsFromURL } from './getParamsFromURL';
-import { PageParamsOptional } from './PageParamTypes';
+import { PageParams } from './PageParamTypes';
 import { getDefaultParams } from './Profiles';
 
 /**
@@ -32,7 +32,7 @@ export default function useAmplitudeParamEvents() {
   const location = useLocation();
   const [urlParams] = useSearchParams();
 
-  const prevParamsRef = useRef<PageParamsOptional | null>(null);
+  const prevParamsRef = useRef<Partial<PageParams> | null>(null);
   const prevPathnameRef = useRef<string>(location.pathname);
 
   useEffect(() => {
@@ -84,8 +84,8 @@ export default function useAmplitudeParamEvents() {
     }
 
     for (const key of FILTER_PARAM_KEYS) {
-      const prevVal = previous[key as keyof PageParamsOptional];
-      const nextVal = current[key as keyof PageParamsOptional];
+      const prevVal = previous[key as keyof PageParams];
+      const nextVal = current[key as keyof PageParams];
       if (areFilterValuesEqual(prevVal, nextVal)) continue;
       trackFilterChanged({
         ...base,

--- a/src/features/table/__tests__/TableColumnHovercard.test.tsx
+++ b/src/features/table/__tests__/TableColumnHovercard.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
-import { PageParamsOptional } from '@features/params/PageParamTypes';
+import { PageParams } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 import Field from '@features/transforms/fields/Field';
 import { SortBehavior } from '@features/transforms/sorting/SortTypes';
@@ -27,10 +27,10 @@ vi.mock('../getValueType', () => ({
 }));
 
 describe('TableColumnHovercard', () => {
-  let updatePageParams: (params: PageParamsOptional) => void;
+  let updatePageParams: (params: Partial<PageParams>) => void;
 
   // Helper function to eliminate mock setup duplication
-  const setupMockParams = (overrides: PageParamsOptional = {}) => {
+  const setupMockParams = (overrides: Partial<PageParams> = {}) => {
     const mockUsePageParams = createMockUsePageParams(overrides);
     (usePageParams as Mock).mockReturnValue(mockUsePageParams);
     updatePageParams = mockUsePageParams.updatePageParams;

--- a/src/features/transforms/filtering/__tests__/FilterBreakdown.test.tsx
+++ b/src/features/transforms/filtering/__tests__/FilterBreakdown.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
-import { PageParamsOptional } from '@features/params/PageParamTypes';
+import { PageParams } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 
 import { VitalityEthnologueFine } from '@entities/language/vitality/VitalityTypes';
@@ -18,10 +18,10 @@ vi.mock('@features/layers/hovercard/useHoverCard', () => ({
 }));
 
 describe('FilterBreakdown', () => {
-  let updatePageParams: (params: PageParamsOptional) => void;
+  let updatePageParams: (params: Partial<PageParams>) => void;
 
   // Helper function to eliminate mock setup duplication
-  const setupMockParams = (overrides: PageParamsOptional = {}) => {
+  const setupMockParams = (overrides: Partial<PageParams> = {}) => {
     const mockUsePageParams = createMockUsePageParams(overrides);
     (usePageParams as Mock).mockReturnValue(mockUsePageParams);
     updatePageParams = mockUsePageParams.updatePageParams;

--- a/src/features/transforms/filtering/__tests__/FilterPath.test.tsx
+++ b/src/features/transforms/filtering/__tests__/FilterPath.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
-import { PageParamsOptional, SearchableField } from '@features/params/PageParamTypes';
+import { PageParams, SearchableField } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 
 import {
@@ -37,10 +37,10 @@ vi.mock('@features/layers/hovercard/HoverableButton', () => ({
 }));
 
 describe('FilterPath', () => {
-  let updatePageParams: (params: PageParamsOptional) => void;
+  let updatePageParams: (params: Partial<PageParams>) => void;
 
   // Helper function to eliminate mock setup duplication
-  const setupMockParams = (overrides: PageParamsOptional = {}) => {
+  const setupMockParams = (overrides: Partial<PageParams> = {}) => {
     const mockUsePageParams = createMockUsePageParams(overrides);
     (usePageParams as Mock).mockReturnValue(mockUsePageParams);
     updatePageParams = mockUsePageParams.updatePageParams;

--- a/src/features/transforms/filtering/__tests__/filter.test.tsx
+++ b/src/features/transforms/filtering/__tests__/filter.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, Mock, vi } from 'vitest';
 
-import { ObjectType, PageParamsOptional } from '@features/params/PageParamTypes';
+import { ObjectType, PageParams } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 
 import { getBaseLanguageData } from '@entities/language/LanguageTypes';
@@ -40,7 +40,7 @@ describe('getFilterByVitality', () => {
     populationFromUN: 1000,
   };
 
-  function mockParams(params: PageParamsOptional) {
+  function mockParams(params: Partial<PageParams>) {
     (usePageParams as Mock).mockReturnValue(createMockUsePageParams(params));
   }
 

--- a/src/features/transforms/filtering/__tests__/useFilteredEntities.test.tsx
+++ b/src/features/transforms/filtering/__tests__/useFilteredEntities.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
-import { PageParamsOptional } from '@features/params/PageParamTypes';
+import { PageParams } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 import Field from '@features/transforms/fields/Field';
 import { SortBehavior } from '@features/transforms/sorting/SortTypes';
@@ -37,7 +37,7 @@ function getHookResult(
 }
 
 describe('useFilteredEntities', () => {
-  const setupMockParams = (overrides: PageParamsOptional = {}) => {
+  const setupMockParams = (overrides: Partial<PageParams> = {}) => {
     const mockUsePageParams = createMockUsePageParams(overrides);
     (usePageParams as Mock).mockReturnValue(mockUsePageParams);
   };

--- a/src/features/transforms/filtering/selectors/__tests__/LanguageFilterSelector.test.tsx
+++ b/src/features/transforms/filtering/selectors/__tests__/LanguageFilterSelector.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
-import { PageParamsOptional } from '@features/params/PageParamTypes';
+import { PageParams } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 
 import { LanguageScope } from '@entities/language/LanguageTypes';
@@ -29,10 +29,10 @@ vi.mock('@features/data/context/useDataContext', () => ({
 
 // Import component under test after mocks are defined
 describe('LanguageFilterSelector', () => {
-  let updatePageParams: (params: PageParamsOptional) => void;
+  let updatePageParams: (params: Partial<PageParams>) => void;
 
   // Helper function to eliminate mock setup duplication
-  const setupMockParams = (overrides: PageParamsOptional = {}) => {
+  const setupMockParams = (overrides: Partial<PageParams> = {}) => {
     const mockUsePageParams = createMockUsePageParams(overrides);
     (usePageParams as Mock).mockReturnValue(mockUsePageParams);
     updatePageParams = mockUsePageParams.updatePageParams;

--- a/src/features/transforms/filtering/selectors/__tests__/VitalitySelector.test.tsx
+++ b/src/features/transforms/filtering/selectors/__tests__/VitalitySelector.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
-import { PageParamsOptional } from '@features/params/PageParamTypes';
+import { PageParams } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 
 import { getLanguageISOStatusLabel } from '@entities/language/vitality/VitalityStrings';
@@ -27,10 +27,10 @@ vi.mock('@features/layers/hovercard/useHoverCard', () => ({
 }));
 
 describe('VitalitySelector', () => {
-  let updatePageParams: (params: PageParamsOptional) => void;
+  let updatePageParams: (params: Partial<PageParams>) => void;
 
   // Helper function to eliminate mock setup duplication
-  const setupMockParams = (overrides: PageParamsOptional = {}) => {
+  const setupMockParams = (overrides: Partial<PageParams> = {}) => {
     const mockUsePageParams = createMockUsePageParams(overrides);
     (usePageParams as Mock).mockReturnValue(mockUsePageParams);
     updatePageParams = mockUsePageParams.updatePageParams;

--- a/src/tests/MockPageParams.test.tsx
+++ b/src/tests/MockPageParams.test.tsx
@@ -1,14 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { PageParamsContextState } from '@features/params/PageParamsContext';
-import { ObjectType, PageParamsOptional, View } from '@features/params/PageParamTypes';
+import { ObjectType, PageParams, View } from '@features/params/PageParamTypes';
 import { getDefaultParams } from '@features/params/Profiles';
 import Field from '@features/transforms/fields/Field';
 
 const mockUpdatePageParams = vi.fn();
 
 export const createMockUsePageParams = (
-  overrides: PageParamsOptional = {},
+  overrides: Partial<PageParams> = {},
 ): PageParamsContextState => {
   return {
     ...getDefaultParams(),
@@ -28,7 +28,7 @@ describe('createMockUsePageParams', () => {
   });
 
   it('overrides default values when provided', () => {
-    const overrides: PageParamsOptional = {
+    const overrides: Partial<PageParams> = {
       sortBy: Field.Name,
       objectType: ObjectType.Locale,
       limit: 25,

--- a/src/widgets/CommonObjectives.tsx
+++ b/src/widgets/CommonObjectives.tsx
@@ -3,12 +3,7 @@ import React, { useState } from 'react';
 import { LangNavPageName } from '@app/PageRoutes';
 
 import { getNewURL } from '@features/params/getNewURL';
-import {
-  ObjectType,
-  PageParamKey,
-  PageParamsOptional,
-  View,
-} from '@features/params/PageParamTypes';
+import { ObjectType, PageParamKey, PageParams, View } from '@features/params/PageParamTypes';
 import Field from '@features/transforms/fields/Field';
 
 const CommonObjectives: React.FC = () => {
@@ -47,8 +42,8 @@ export const ObjectiveList: React.FC = () => {
 type ObjectiveProps = {
   label: string;
   inputPlaceholder?: string;
-  inputParam?: keyof PageParamsOptional;
-  urlParams?: PageParamsOptional;
+  inputParam?: keyof PageParams;
+  urlParams?: Partial<PageParams>;
   urlPath?: LangNavPageName;
 };
 
@@ -60,7 +55,7 @@ const Objective: React.FC<ObjectiveProps> = ({
   urlPath = LangNavPageName.Data,
 }) => {
   const [inputText, setInputText] = useState('');
-  let params: PageParamsOptional = { ...urlParams };
+  let params: Partial<PageParams> = { ...urlParams };
   if (inputParam) params = { [inputParam]: inputText, ...urlParams };
 
   return (
@@ -87,7 +82,7 @@ const Objective: React.FC<ObjectiveProps> = ({
   );
 };
 
-const GoButton: React.FC<{ params: PageParamsOptional; urlPath: LangNavPageName }> = ({
+const GoButton: React.FC<{ params: Partial<PageParams>; urlPath: LangNavPageName }> = ({
   params,
   urlPath,
 }) => {

--- a/src/widgets/cardlists/__tests__/CardList.test.tsx
+++ b/src/widgets/cardlists/__tests__/CardList.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
 import { getFullyInstantiatedMockedObjects } from '@features/__tests__/MockObjects';
-import { ObjectType, PageParamsOptional } from '@features/params/PageParamTypes';
+import { ObjectType, PageParams } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 import useFilteredEntities from '@features/transforms/filtering/useFilteredEntities';
 import { sortByPopulation } from '@features/transforms/sorting/sort';
@@ -29,7 +29,7 @@ describe('CardList', () => {
     .sort(sortByPopulation);
 
   // Helper function to eliminate mock setup duplication
-  function setupMockParams(overrides: PageParamsOptional = {}) {
+  function setupMockParams(overrides: Partial<PageParams> = {}) {
     (usePageParams as Mock).mockReturnValue(createMockUsePageParams(overrides));
   }
 

--- a/src/widgets/controls/NavTabs.tsx
+++ b/src/widgets/controls/NavTabs.tsx
@@ -1,13 +1,13 @@
 import React, { ReactNode, useCallback } from 'react';
 
 import HoverableInternalLinkButton from '@features/layers/hovercard/HoverableInternalLinkButton';
-import { PageParamsOptional } from '@features/params/PageParamTypes';
+import { PageParams } from '@features/params/PageParamTypes';
 import usePageParams from '@features/params/usePageParams';
 
 export type TabOption = {
   description?: ReactNode;
   label: string;
-  urlParams: PageParamsOptional;
+  urlParams: Partial<PageParams>;
 };
 
 type Props = {
@@ -20,7 +20,7 @@ const NavTabs: React.FC<Props> = ({ label, options }) => {
   const getIsActive = useCallback(
     (option: TabOption) =>
       Object.entries(option.urlParams).every(
-        ([key, value]) => params[key as keyof PageParamsOptional] === value,
+        ([key, value]) => params[key as keyof PageParams] === value,
       ),
     [params],
   );

--- a/src/widgets/details/sections/LanguageLocation.tsx
+++ b/src/widgets/details/sections/LanguageLocation.tsx
@@ -4,7 +4,7 @@ import React, { useMemo } from 'react';
 import HoverableButton from '@features/layers/hovercard/HoverableButton';
 import EntityMap from '@features/map/EntityMap';
 import LocalParamsProvider from '@features/params/LocalParamsProvider';
-import { ObjectType, PageParamsOptional, View } from '@features/params/PageParamTypes';
+import { ObjectType, PageParams, View } from '@features/params/PageParamTypes';
 import { SelectorDisplay } from '@features/params/ui/SelectorDisplayContext';
 import usePageParams from '@features/params/usePageParams';
 import Field from '@features/transforms/fields/Field';
@@ -75,7 +75,7 @@ const LanguageLocation: React.FC<{ lang: LanguageData }> = ({ lang }) => {
 type MapsProps = {
   lang: LanguageData;
   // Updating the global page params, not the local params
-  updatePageParams: (newParams: PageParamsOptional) => void;
+  updatePageParams: (newParams: Partial<PageParams>) => void;
 };
 function Maps({ lang, updatePageParams }: MapsProps) {
   const [showConstituents, setShowConstituents] = React.useState(true);


### PR DESCRIPTION
Summary: I was working on another code base and I realized we could use `Partial<>` instead of having 2 duplicate object declarations.

### Changes

- User experience
  - n/a
- Logical changes
  - n/a
- Data
  - n/a
- Refactors
  - All usages of PageParamsOptional replaced with Partial<PageParams>

### Test Plan and Screenshots

How to test the changes in this PR: Ran the tests