### PR TITLE
Cloudflare: production deploys and root-based serving

### DIFF
--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -133,8 +133,8 @@ jobs:
             const body = [
               '### Cloudflare Pages preview',
               '',
-              `- Deploy URL: ${url}/lang-nav/`,
-              alias ? `- Branch alias: ${alias}/lang-nav/` : null,
+              `- Deploy URL: ${url}`,
+              alias ? `- Branch alias: ${alias}` : null,
               '',
               `Commit: \`${context.sha.slice(0, 7)}\``,
             ].filter(Boolean).join('\n');

--- a/.github/workflows/cloudflare-production.yml
+++ b/.github/workflows/cloudflare-production.yml
@@ -1,0 +1,43 @@
+name: Cloudflare Pages Production
+
+on:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: cf-production
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CF_PROJECT: lang-nav
+
+jobs:
+  deploy-production:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build for Cloudflare Pages
+        run: npm run build:cf
+        env:
+          VITE_AMPLITUDE_API_KEY: ${{ secrets.VITE_AMPLITUDE_API_KEY }}
+
+      - name: Deploy to Cloudflare Pages (production)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=${{ env.CF_PROJECT }} --branch=master

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ CLAUDE.md
 # Screenshot update artifacts (local review only)
 public/current/
 public/diff/
+
+# Wrangler local cache (wrangler pages dev)
+.wrangler/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   },
 
   use: {
-    baseURL: 'http://localhost:4173/lang-nav/',
+    baseURL: 'http://localhost:4173/',
     trace: 'on-first-retry',
   },
 
@@ -33,8 +33,8 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npm run build && npm run preview',
-    url: 'http://localhost:4173/lang-nav/',
+    command: 'VITE_BASE_PATH=/ npm run build && VITE_BASE_PATH=/ npm run preview',
+    url: 'http://localhost:4173/',
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/public/404.html
+++ b/public/404.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <title>Redirecting…</title>
-    <meta http-equiv="refresh" content="0; url=/lang-nav/" />
+    <meta http-equiv="refresh" content="0; url=/" />
     <script type="text/javascript">
       (function () {
-        var pathSegmentsToKeep = 1; // keep /lang-nav
+        var pathSegmentsToKeep = 0;
         var l = window.location;
         var origin = l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '');
         var basePath = l.pathname

--- a/scripts/build-cf.mjs
+++ b/scripts/build-cf.mjs
@@ -4,19 +4,25 @@ import { resolve } from 'node:path';
 
 const root = resolve(import.meta.dirname, '..');
 const dist = resolve(root, 'dist');
-const subdir = resolve(dist, 'lang-nav');
 
 rmSync(dist, { recursive: true, force: true });
 
 execSync('tsc -b', { cwd: root, stdio: 'inherit' });
-execSync(`vite build --outDir ${subdir} --emptyOutDir`, { cwd: root, stdio: 'inherit' });
+execSync('vite build', {
+  cwd: root,
+  stdio: 'inherit',
+  env: { ...process.env, VITE_BASE_PATH: '/' },
+});
+
+// Pages only enables its native SPA fallback (index.html on unknown paths)
+// when no top-level 404.html exists; 404.html is the GitHub Pages hack anyway.
+rmSync(resolve(dist, '404.html'), { force: true });
 
 const redirects = [
-  '/               /lang-nav/             301',
-  '/lang-nav       /lang-nav/             301',
-  '/lang-nav/*     /lang-nav/index.html   200',
+  '/lang-nav       /            301',
+  '/lang-nav/*     /:splat      301',
   '',
 ].join('\n');
 
 writeFileSync(resolve(dist, '_redirects'), redirects);
-console.log('\nBuilt for Cloudflare Pages at dist/lang-nav/ with _redirects at dist/_redirects');
+console.log('\nBuilt for Cloudflare Pages at dist/ (base /) with _redirects');

--- a/scripts/build-cf.mjs
+++ b/scripts/build-cf.mjs
@@ -18,6 +18,7 @@ execSync('vite build', {
 // when no top-level 404.html exists; 404.html is the GitHub Pages hack anyway.
 rmSync(resolve(dist, '404.html'), { force: true });
 
+// prettier-ignore
 const redirects = [
   '/lang-nav       /            301',
   '/lang-nav/*     /:splat      301',

--- a/scripts/preview-screenshots.config.ts
+++ b/scripts/preview-screenshots.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   reporter: 'list',
 
   use: {
-    baseURL: 'http://localhost:4173/lang-nav/',
+    baseURL: 'http://localhost:4173/',
     trace: 'on-first-retry',
   },
 
@@ -28,8 +28,8 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npm run build && npm run preview',
-    url: 'http://localhost:4173/lang-nav/',
+    command: 'VITE_BASE_PATH=/ npm run build && VITE_BASE_PATH=/ npm run preview',
+    url: 'http://localhost:4173/',
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/src/app/main.tsx
+++ b/src/app/main.tsx
@@ -11,7 +11,7 @@ import './component_styles.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter basename="/lang-nav">
+    <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, '')}>
       <App />
     </BrowserRouter>
   </StrictMode>,

--- a/src/pages/LuckySearchPageBody.tsx
+++ b/src/pages/LuckySearchPageBody.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import { useDataContext } from '@features/data/context/useDataContext';
 import usePageParams from '@features/params/usePageParams';
@@ -75,9 +75,9 @@ const LuckySearchPageBody: React.FC = () => {
       <div style={{ marginBottom: '1em' }}>Try searching again:</div>
       <SearchBar />
       <div style={{ marginTop: '1em' }}>
-        <a href="/intro">
+        <Link to="/intro">
           <button style={{ padding: '0.5em 1em' }}>Back to Home</button>
-        </a>
+        </Link>
       </div>
     </SearchContainer>
   );

--- a/src/widgets/PageNavBar.tsx
+++ b/src/widgets/PageNavBar.tsx
@@ -17,7 +17,7 @@ const PageNavBar: React.FC = () => {
     <NavBarContainer>
       <NavBarTitle>
         <img
-          src={`/lang-nav/logo/LangNavLogoNavBar${pageBrightness === 'dark' ? 'Dark' : ''}.svg`}
+          src={`${import.meta.env.BASE_URL}logo/LangNavLogoNavBar${pageBrightness === 'dark' ? 'Dark' : ''}.svg`}
           width="60px"
           alt="LangNav Logo"
         />

--- a/src/widgets/controls/selectors/ViewSelector.tsx
+++ b/src/widgets/controls/selectors/ViewSelector.tsx
@@ -42,17 +42,18 @@ function getViewLabel(view: View): React.ReactNode {
 }
 
 function getImageSrc(view: View): string {
+  const base = import.meta.env.BASE_URL;
   switch (view) {
     case View.CardList:
-      return '/lang-nav/cardlist.png';
+      return `${base}cardlist.png`;
     case View.Hierarchy:
-      return '/lang-nav/hierarchy.png';
+      return `${base}hierarchy.png`;
     case View.Map:
-      return '/lang-nav/map.png';
+      return `${base}map.png`;
     case View.Table:
-      return '/lang-nav/table.png';
+      return `${base}table.png`;
     case View.Reports:
-      return '/lang-nav/reports.png';
+      return `${base}reports.png`;
   }
 }
 

--- a/src/widgets/docs/LargeLangNavLogo.tsx
+++ b/src/widgets/docs/LargeLangNavLogo.tsx
@@ -5,7 +5,7 @@ function LargeLangNavLogo({ width = 120 }: { width?: number }) {
 
   return (
     <img
-      src={`/lang-nav/logo/LangNavLogo${pageBrightness === 'dark' ? 'Dark' : ''}.svg`}
+      src={`${import.meta.env.BASE_URL}logo/LangNavLogo${pageBrightness === 'dark' ? 'Dark' : ''}.svg`}
       width={`${width}px`}
       height={`${width / 2}px`}
       alt="LangNav Logo"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from 'vite';
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/lang-nav/',
+  base: process.env.VITE_BASE_PATH ?? '/lang-nav/',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
Fixes #723

Summary: This PR is the first step in moving the site to langnav.org, hosted on Cloudflare Pages. Every push to master now deploys the site to the production environment of the lang-nav Pages project. The site is served from the root, so once the domain is pointed over, pages live at langnav.org/intro, langnav.org/data, and langnav.org/about with no /lang-nav prefix. Old /lang-nav links on Cloudflare redirect to the new paths. GitHub Pages keeps working during the transition so nothing breaks while we switch.

### Changes

- User experience
  - The production site runs on Cloudflare Pages at root paths, for example `lang-nav.pages.dev/data`. Old `/lang-nav/*` links redirect to the new paths and keep their query strings.
  - PR previews are also served from the root now, and the preview comment links no longer add `/lang-nav/`.
- Logical changes
  - New workflow `.github/workflows/cloudflare-production.yml`. On every push to master it builds with `npm run build:cf` and deploys with `--branch=master`. That name matches the project's production branch setting, which is what makes Cloudflare treat it as a production deploy instead of a preview.
  - The base path in `vite.config.ts` now comes from the `VITE_BASE_PATH` env var and defaults to `/lang-nav/`. GitHub Pages and local dev do not change, and the Cloudflare build sets it to `/`.
  - The router basename and the hardcoded logo and view image URLs now come from `import.meta.env.BASE_URL` instead of a hardcoded `/lang-nav`.
- Refactors
  - `scripts/build-cf.mjs` now builds straight into `dist/` with the root base instead of nesting everything under `dist/lang-nav/`. It also deletes `404.html` from the build. Cloudflare only serves `index.html` for unknown paths when there is no top-level `404.html`, and it ignores a `/* /index.html 200` redirect rule, so the file had to go.
  - The Playwright and preview screenshot configs now build and test against the root layout.
  - The "Back to Home" button on the lucky search page now uses a router `Link` instead of a plain anchor, so it works on GitHub Pages too.

Out of scope/Future work: Pointing langnav.org at this deploy. The domain currently sits on the unused lang-nav-prod project and has to be moved to the lang-nav project in the dashboard. Once langnav.org serves the Cloudflare deploy and it has run for a while without problems, we retire the GitHub Pages deploy in a follow-up PR.

### Test Plan and Screenshots

How to test the changes in this PR:

1. Locally, run `npm run build:cf && npx wrangler pages dev dist`. Check that `/intro` and `/data?view=Table` load, that a made-up path shows the app's "Page not found" view, and that `/lang-nav/data?view=Table` redirects to `/data?view=Table`.
2. Open this PR's Cloudflare preview URL and check the same things.
3. After merge, check the production site at `lang-nav.pages.dev`.

No screenshots. This is an infra change with no visual differences.

# Checklist

## Summary

- [x] Clear description of what and why
- [x] Scope kept focused; follow-ups noted above
- [x] Set yourself as assignee
- [x] Mention the issue

## Testing

- [x] `npm run lint`
- [x] `npm run build` (GitHub Pages output still uses `/lang-nav/`)
- [x] `npm run test` (419 passing)
- [x] Checked locally with `wrangler pages dev` (fallback and redirects work)

## Changes

- [x] Internal changes only; no visual or data changes
