### PR TITLE
Plural Rules Report: Make a report to compare data better.

### DIFF
--- a/src/entities/language/plurals/LanguagePluralCategories.tsx
+++ b/src/entities/language/plurals/LanguagePluralCategories.tsx
@@ -1,14 +1,11 @@
 import React, { useMemo } from 'react';
 
-import Hoverable from '@features/layers/hovercard/Hoverable';
-
 import Deemphasized from '@shared/ui/Deemphasized';
 
 import { LanguageData } from '../LanguageTypes';
 
-import { findLanguagePluralRules, PluralRuleKey } from './LanguagePluralComputation';
-import PluralRuleExplanation from './PluralRuleExplanation';
-import { getPluralRuleColor, getPluralRuleKeyLabel } from './PluralStrings';
+import LanguagePluralCategory from './LanguagePluralCategory';
+import { findLanguagePluralRules } from './LanguagePluralComputation';
 
 const LanguagePluralCategories: React.FC<{ lang: LanguageData }> = ({ lang }) => {
   // Find the plural rules for this language
@@ -21,23 +18,7 @@ const LanguagePluralCategories: React.FC<{ lang: LanguageData }> = ({ lang }) =>
   return (
     <div style={{ display: 'flex', gap: '0.25em', flexWrap: 'wrap', marginBottom: '0.25em' }}>
       {pluralRules.map(([pluralRuleKey, rule]) => (
-        <Hoverable
-          key={pluralRuleKey}
-          hoverContent={
-            <>
-              <PluralRuleExplanation rule={rule} />
-            </>
-          }
-          style={{
-            backgroundColor: getPluralRuleColor(pluralRuleKey),
-            borderRadius: '0.25em',
-            color: pluralRuleKey === PluralRuleKey.Other ? 'inherit' : 'var(--color-text-on-color)',
-            padding: '0.25em',
-            margin: '0',
-          }}
-        >
-          {getPluralRuleKeyLabel(pluralRuleKey)}
-        </Hoverable>
+        <LanguagePluralCategory key={pluralRuleKey} pluralRuleKey={pluralRuleKey} rule={rule} />
       ))}
     </div>
   );

--- a/src/entities/language/plurals/LanguagePluralCategory.tsx
+++ b/src/entities/language/plurals/LanguagePluralCategory.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import Hoverable from '@features/layers/hovercard/Hoverable';
+
+import { PluralRuleKey } from './LanguagePluralComputation';
+import PluralRuleExplanation from './PluralRuleExplanation';
+import { getPluralRuleKeyLabel } from './PluralStrings';
+
+import './plurals.css';
+
+type Props = {
+  pluralRuleKey: PluralRuleKey;
+  rule?: string;
+};
+
+const LanguagePluralCategory: React.FC<Props> = ({ pluralRuleKey, rule }) => {
+  if (!rule) {
+    return (
+      <span className={'LanguagePluralCategory ' + pluralRuleKey}>
+        {getPluralRuleKeyLabel(pluralRuleKey)}
+      </span>
+    );
+  }
+
+  return (
+    <Hoverable
+      className={'LanguagePluralCategory ' + pluralRuleKey}
+      hoverContent={<PluralRuleExplanation rule={rule} />}
+    >
+      {getPluralRuleKeyLabel(pluralRuleKey)}
+    </Hoverable>
+  );
+};
+
+export default LanguagePluralCategory;

--- a/src/entities/language/plurals/LanguagePluralComputation.ts
+++ b/src/entities/language/plurals/LanguagePluralComputation.ts
@@ -3,6 +3,8 @@
 
 import plurals from 'cldr-core/supplemental/plurals.json';
 
+import { ObjectType } from '@features/params/PageParamTypes';
+
 import { LanguageData } from '../LanguageTypes';
 
 export enum PluralRuleKey {
@@ -30,7 +32,17 @@ export function findLanguagePluralRules(lang: LanguageData): PluralRuleFromCLDR[
 
   // Get plural rules
   const pluralRules = pluralRulesUntyped[lookupID] || pluralRulesUntyped[lookupIDAlt ?? ''];
-  if (!pluralRules) return null;
+  if (!pluralRules) {
+    const dataProvider = lang.CLDR.dataProvider;
+    // Try the CLDR data provider
+    if (
+      dataProvider != null &&
+      dataProvider.ID !== lang.ID &&
+      dataProvider.type === ObjectType.Language
+    )
+      return findLanguagePluralRules(dataProvider);
+    return null;
+  }
 
   // Convert to array with stable key order
   return Object.values(PluralRuleKey)

--- a/src/entities/language/plurals/LanguagePluralExample.tsx
+++ b/src/entities/language/plurals/LanguagePluralExample.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import Hoverable from '@features/layers/hovercard/Hoverable';
+
+import { PluralRuleKey } from './LanguagePluralComputation';
+import PluralRuleExplanation from './PluralRuleExplanation';
+
+import './plurals.css';
+
+type Props = {
+  ruleKey: PluralRuleKey;
+  style?: React.CSSProperties;
+  num: string | number;
+  conditions: string;
+  appearance?: 'td' | 'div';
+  showTooltips?: boolean;
+};
+
+const LanguagePluralExample: React.FC<Props> = ({
+  ruleKey,
+  style,
+  num,
+  conditions,
+  appearance = 'div',
+  showTooltips = true,
+}) => {
+  return (
+    <div
+      className={'LanguagePluralExample ' + ruleKey}
+      style={{ ...style, display: appearance === 'div' ? 'inline-block' : 'table-cell' }}
+    >
+      {showTooltips ? <WithToolTip ruleKey={ruleKey} conditions={conditions} num={num} /> : num}
+    </div>
+  );
+};
+
+type WithToolTipProps = {
+  ruleKey: PluralRuleKey;
+  conditions: string;
+  num: string | number;
+};
+
+function WithToolTip({ ruleKey, conditions, num }: WithToolTipProps) {
+  return (
+    <Hoverable
+      hoverContent={
+        ruleKey !== PluralRuleKey.Other ? (
+          <>
+            Passes <strong>{ruleKey}</strong>
+            <br /> <PluralRuleExplanation rule={conditions} exampleNum={num} />
+          </>
+        ) : (
+          <>
+            Does not pass any plural rule conditions, rather is in group{' '}
+            <strong>{PluralRuleKey.Other}</strong>
+          </>
+        )
+      }
+      style={{ color: ruleKey === PluralRuleKey.Other ? 'inherit' : 'var(--color-background)' }}
+    >
+      {num}
+    </Hoverable>
+  );
+}
+
+export default LanguagePluralExample;

--- a/src/entities/language/plurals/LanguagePluralExample.tsx
+++ b/src/entities/language/plurals/LanguagePluralExample.tsx
@@ -24,10 +24,21 @@ const LanguagePluralExample: React.FC<Props> = ({
   appearance = 'div',
   showTooltips = true,
 }) => {
+  if (appearance === 'td') {
+    return (
+      <td
+        className={'LanguagePluralExample ' + ruleKey}
+        style={{ ...style, borderRight: '1em solid var(--color-background)' }}
+      >
+        {showTooltips ? <WithToolTip ruleKey={ruleKey} conditions={conditions} num={num} /> : num}
+      </td>
+    );
+  }
+
   return (
     <div
       className={'LanguagePluralExample ' + ruleKey}
-      style={{ ...style, display: appearance === 'div' ? 'inline-block' : 'table-cell' }}
+      style={{ ...style, display: 'inline-block' }}
     >
       {showTooltips ? <WithToolTip ruleKey={ruleKey} conditions={conditions} num={num} /> : num}
     </div>

--- a/src/entities/language/plurals/LanguagePluralGrid.tsx
+++ b/src/entities/language/plurals/LanguagePluralGrid.tsx
@@ -1,9 +1,5 @@
 import React, { useMemo } from 'react';
 
-import Hoverable from '@features/layers/hovercard/Hoverable';
-import { View } from '@features/params/PageParamTypes';
-import usePageParams from '@features/params/usePageParams';
-
 import { LanguageData } from '../LanguageTypes';
 
 import {
@@ -11,34 +7,25 @@ import {
   findLanguagePluralRules,
   PluralRuleKey,
 } from './LanguagePluralComputation';
-import PluralRuleExplanation from './PluralRuleExplanation';
-import PluralRuleSymbolExplanation from './PluralRuleSymbolExplanation';
-import { getPluralRuleColor } from './PluralStrings';
+import LanguagePluralExample from './LanguagePluralExample';
+import {
+  COMPACT_NUM_LABELS,
+  COMPACT_NUMS,
+  LARGE_NUMS,
+  SMALL_NUMS,
+  ZERO_TO_99_NUMS,
+} from './PluralNumberSets';
 
-const SMALL_NUMS = ['0.0', 0.1, 0.2, 0.3, 0.5, 0.7, '1.0', 1.5, '2.0', 2.5];
-const LARGE_NUMS = [
-  100, 1000, 10000, 100000, 1000000, 1000001, 1000002, 1000010, 10000000, 100000000,
-];
-const EXPO_NUMS = [
-  '1e2',
-  '1e3',
-  '1e4',
-  '1e5',
-  '1e6',
-  '1.000001e6',
-  '1.000002e6',
-  '1.00001e6',
-  '1e7',
-  '1e8',
-];
+type Props = {
+  lang: LanguageData;
+  showTooltips?: boolean;
+};
 
-const LanguagePluralGrid: React.FC<{ lang: LanguageData }> = ({ lang }) => {
+const LanguagePluralGrid: React.FC<Props> = ({ lang, showTooltips = true }) => {
   // Find the plural rules for this language
   // If we didn't find any, or they are empty, return nothing
   const pluralRules = useMemo(() => findLanguagePluralRules(lang), [lang]);
-  if (!pluralRules || pluralRules.length === 0) {
-    return <></>;
-  }
+  if (!pluralRules || pluralRules.length === 0) return <></>;
 
   // Create function that determines plural rule for a given number
   const getNumPluralRule = convertStringRulesToRuleDeterminer(pluralRules);
@@ -46,101 +33,58 @@ const LanguagePluralGrid: React.FC<{ lang: LanguageData }> = ({ lang }) => {
     pluralRules.find(([key]) => key === ruleKey)?.[1] || '';
 
   // Get examples
-  const zeroTo99 = Array.from({ length: 100 }, (_, i) => getNumPluralRule(i));
+  const zeroTo99 = ZERO_TO_99_NUMS.map((num) => getNumPluralRule(num));
   const smallNumRules = SMALL_NUMS.map((num) => getNumPluralRule(num));
   const largeNumRules = LARGE_NUMS.map((num) => getNumPluralRule(num));
-  const expoNumRules = EXPO_NUMS.map((num) => getNumPluralRule(num));
+  const compactNumRules = COMPACT_NUMS.map((num) => getNumPluralRule(num));
   return (
     <table>
       <tbody>
         {Array.from({ length: 10 }, (_, rowNum) => rowNum).map((rowNum) => (
           <tr key={rowNum}>
-            <ExampleCell
+            <LanguagePluralExample
               key={SMALL_NUMS[rowNum]}
+              appearance="td"
               ruleKey={smallNumRules[rowNum]!}
               conditions={conditionsForRule(smallNumRules[rowNum]!)}
               style={{ borderRight: '1em solid var(--color-background)' }}
               num={SMALL_NUMS[rowNum]}
+              showTooltips={showTooltips}
             />
             {Array.from({ length: 10 }, (_, colNum) => colNum).map((colNum) => {
               const cellNum = colNum * 10 + rowNum;
               return (
-                <ExampleCell
+                <LanguagePluralExample
                   key={cellNum}
+                  appearance="td"
                   ruleKey={zeroTo99[cellNum]!}
                   num={cellNum}
                   conditions={conditionsForRule(zeroTo99[cellNum]!)}
+                  showTooltips={showTooltips}
                 />
               );
             })}
-            <ExampleCell
+            <LanguagePluralExample
               key={LARGE_NUMS[rowNum]}
+              appearance="td"
               ruleKey={largeNumRules[rowNum]!}
               style={{ borderLeft: '1em solid var(--color-background)' }}
               num={LARGE_NUMS[rowNum]}
               conditions={conditionsForRule(largeNumRules[rowNum]!)}
+              showTooltips={showTooltips}
             />
-            <ExampleCell
-              key={EXPO_NUMS[rowNum]}
-              ruleKey={expoNumRules[rowNum]!}
-              num={EXPO_NUMS[rowNum]}
-              conditions={conditionsForRule(expoNumRules[rowNum]!)}
+            <LanguagePluralExample
+              key={COMPACT_NUMS[rowNum]}
+              appearance="td"
+              ruleKey={compactNumRules[rowNum]!}
+              num={COMPACT_NUM_LABELS[rowNum]}
+              conditions={conditionsForRule(compactNumRules[rowNum]!)}
+              showTooltips={showTooltips}
             />
           </tr>
         ))}
       </tbody>
     </table>
-  );
-};
-
-const ExampleCell: React.FC<{
-  ruleKey: PluralRuleKey;
-  style?: React.CSSProperties;
-  num: string | number;
-  conditions: string;
-}> = ({ ruleKey, style, num, conditions }) => {
-  const { view } = usePageParams();
-
-  return (
-    <td
-      style={{
-        ...style,
-        color: ruleKey === PluralRuleKey.Other ? 'inherit' : 'var(--color-text-on-color)',
-        backgroundColor: getPluralRuleColor(ruleKey),
-        minWidth: '1em',
-        textAlign: 'right',
-        padding: '0 0.25em',
-      }}
-    >
-      {view !== View.Table ? ( // Too many hoverables in the table view, will tank page performance
-        <Hoverable
-          hoverContent={
-            ruleKey !== PluralRuleKey.Other ? (
-              <>
-                Passes <strong>{ruleKey}</strong>
-                <br /> <PluralRuleExplanation rule={conditions} exampleNum={num} />
-              </>
-            ) : (
-              <>
-                Does not pass any plural rule conditions, rather is in group{' '}
-                <strong>{PluralRuleKey.Other}</strong>
-                {['n', 'i', 'v', 'w', 'f', 't', 'c', 'e'].map((symbol) => (
-                  <div key={symbol} style={{ marginTop: '0.25em' }}>
-                    <strong>{symbol}:</strong>{' '}
-                    <PluralRuleSymbolExplanation symbol={symbol} exampleNum={num} />
-                  </div>
-                ))}
-              </>
-            )
-          }
-          style={{ color: ruleKey === PluralRuleKey.Other ? 'inherit' : 'var(--color-background)' }}
-        >
-          {num}
-        </Hoverable>
-      ) : (
-        num
-      )}
-    </td>
   );
 };
 

--- a/src/entities/language/plurals/LanguagePluralGridToggle.tsx
+++ b/src/entities/language/plurals/LanguagePluralGridToggle.tsx
@@ -8,7 +8,12 @@ import { LanguageData } from '../LanguageTypes';
 import { findLanguagePluralRules } from './LanguagePluralComputation';
 import LanguagePluralGrid from './LanguagePluralGrid';
 
-const LanguagePluralGridButton: React.FC<{ lang: LanguageData }> = ({ lang }) => {
+type Props = {
+  lang: LanguageData;
+  showTooltips?: boolean;
+};
+
+const LanguagePluralGridButton: React.FC<Props> = ({ lang, showTooltips }) => {
   const [isGridVisible, setIsGridVisible] = useState(false);
 
   if (!lang) return null;
@@ -28,7 +33,7 @@ const LanguagePluralGridButton: React.FC<{ lang: LanguageData }> = ({ lang }) =>
         hoverContent={
           <>
             click to persist
-            <LanguagePluralGrid lang={lang} />
+            <LanguagePluralGrid lang={lang} showTooltips={showTooltips} />
           </>
         }
         style={{ padding: '0.25em 0.5em', marginLeft: '0.5em' }}
@@ -37,7 +42,7 @@ const LanguagePluralGridButton: React.FC<{ lang: LanguageData }> = ({ lang }) =>
         <GridIcon size="1em" style={{ marginRight: '0.25em', verticalAlign: 'middle' }} />
         examples
       </HoverableButton>
-      {isGridVisible && <LanguagePluralGrid lang={lang} />}
+      {isGridVisible && <LanguagePluralGrid lang={lang} showTooltips={showTooltips} />}
     </>
   );
 };

--- a/src/entities/language/plurals/LanguagePluralsColumns.tsx
+++ b/src/entities/language/plurals/LanguagePluralsColumns.tsx
@@ -1,0 +1,166 @@
+import { TriangleAlertIcon } from 'lucide-react';
+
+import Hoverable from '@features/layers/hovercard/Hoverable';
+import { CodeColumn, NameColumn } from '@features/table/CommonColumns';
+import TableColumn from '@features/table/TableColumn';
+import Field from '@features/transforms/fields/Field';
+
+import { LanguageData } from '@entities/language/LanguageTypes';
+import LanguagePluralCategories from '@entities/language/plurals/LanguagePluralCategories';
+import LanguagePluralCategory from '@entities/language/plurals/LanguagePluralCategory';
+import {
+  convertStringRulesToRuleDeterminer,
+  findLanguagePluralRules,
+  PluralRuleKey,
+} from '@entities/language/plurals/LanguagePluralComputation';
+import LanguagePluralExample from '@entities/language/plurals/LanguagePluralExample';
+import LanguagePluralGrid from '@entities/language/plurals/LanguagePluralGrid';
+import LanguagePluralGridButton from '@entities/language/plurals/LanguagePluralGridToggle';
+import {
+  COMPACT_NUM_LABELS,
+  COMPACT_NUMS,
+  LARGE_NUMS,
+  PROTOTYPICAL_NUMS,
+  SMALL_NUMS,
+} from '@entities/language/plurals/PluralNumberSets';
+import PluralRuleEquation from '@entities/language/plurals/PluralRuleEquation';
+import PluralRuleExampleSet from '@entities/language/plurals/PluralRuleExampleSet';
+import { getPluralRuleKeyLabel } from '@entities/language/plurals/PluralStrings';
+
+import { getLanguageScopeLabel } from '@strings/LanguageScopeStrings';
+
+function getLanguagePluralsColumns(): TableColumn<LanguageData>[] {
+  function getRuleColumn(
+    ruleKey: PluralRuleKey,
+    type: 'existence' | 'equation' | 'integer examples' | 'decimal examples',
+  ): TableColumn<LanguageData> {
+    const label =
+      type === 'existence'
+        ? 'Has ' + getPluralRuleKeyLabel(ruleKey) + ' case'
+        : getPluralRuleKeyLabel(ruleKey) + ' ' + type;
+    return {
+      key: label,
+      label: type === 'existence' ? <div style={{ width: 'min-content' }}>{label}</div> : label,
+      labelInColumnGroup: label,
+      render: (lang) => {
+        const pluralRules = findLanguagePluralRules(lang);
+        if (!pluralRules || pluralRules.length === 0) return null;
+        const ruleConditions = pluralRules.find(([key]) => key === ruleKey)?.[1];
+        if (!ruleConditions) return null;
+        if (type === 'equation') return <PluralRuleEquation rule={ruleConditions} />;
+        if (type === 'integer examples')
+          return <PluralRuleExampleSet rule={ruleConditions} exampleSet="integer" />;
+        if (type === 'decimal examples')
+          return <PluralRuleExampleSet rule={ruleConditions} exampleSet="decimal" />;
+        return <LanguagePluralCategory pluralRuleKey={ruleKey} rule={ruleConditions} />;
+      },
+      isInitiallyVisible: type === 'existence',
+      columnGroup: 'Plural rules ' + type,
+    };
+  }
+
+  function getExampleColumn(
+    num: number | string,
+    group: string,
+    label?: string,
+  ): TableColumn<LanguageData> {
+    return {
+      key: group + num.toString(), // needs to be unique
+      label: label || num.toString(),
+      render: (lang) => {
+        const pluralRules = findLanguagePluralRules(lang);
+        if (!pluralRules || pluralRules.length === 0) return null;
+        const rule = convertStringRulesToRuleDeterminer(pluralRules)(num);
+        if (rule == null) return null;
+        const ruleConditions = pluralRules.find(([key]) => key === rule)?.[1] || '';
+        return (
+          <LanguagePluralExample
+            key={num}
+            ruleKey={rule}
+            conditions={ruleConditions}
+            num={label ?? num}
+          />
+        );
+      },
+      isInitiallyVisible: PROTOTYPICAL_NUMS.includes(num),
+      columnGroup: group,
+    };
+  }
+
+  const smallNumCols = SMALL_NUMS.map((num) => getExampleColumn(num, 'Decimals'));
+  const zeroToNineNumCols = Array.from({ length: 10 }, (_, i) => getExampleColumn(i, '0 to 9'));
+  const teensNumCols = Array.from({ length: 10 }, (_, i) => getExampleColumn(i + 10, 'Teens'));
+  const tensNumCols = Array.from({ length: 8 }, (_, i) => getExampleColumn((i + 2) * 10, 'Tens'));
+  const largeNumCols = LARGE_NUMS.map((num) => getExampleColumn(num, 'Large Numbers'));
+  const compactNumCols = COMPACT_NUMS.map((num, i) =>
+    getExampleColumn(num, 'Compact Numbers', COMPACT_NUM_LABELS[i]),
+  );
+
+  return [
+    { ...CodeColumn, columnGroup: 'ID' },
+    {
+      ...NameColumn,
+      render: (lang) => {
+        const rules = findLanguagePluralRules(lang);
+        return (
+          <Hoverable
+            hoverContent={rules == null ? 'No plural rules available from CLDR' : undefined}
+            style={{ display: 'flex', alignItems: 'center', gap: '0.25em' }}
+          >
+            {lang.nameDisplay}{' '}
+            {rules == null && (
+              <TriangleAlertIcon
+                display="block"
+                size="1em"
+                style={{ color: 'var(--color-yellow)' }}
+              />
+            )}
+          </Hoverable>
+        );
+      },
+      columnGroup: 'ID',
+    },
+    {
+      key: 'Scope',
+      render: (lang) => getLanguageScopeLabel(lang.scope),
+      isInitiallyVisible: false,
+      field: Field.LanguageScope,
+      columnGroup: 'ID',
+    },
+    {
+      key: 'Applicable plural rules',
+      render: (lang) => <LanguagePluralCategories lang={lang} />,
+      isInitiallyVisible: false,
+      columnGroup: 'Plural rules',
+    },
+    ...Object.values(PluralRuleKey).map((ruleKey) => getRuleColumn(ruleKey, 'existence')),
+    ...Object.values(PluralRuleKey).map((ruleKey) => getRuleColumn(ruleKey, 'equation')),
+    ...Object.values(PluralRuleKey).map((ruleKey) => getRuleColumn(ruleKey, 'integer examples')),
+    ...Object.values(PluralRuleKey).map((ruleKey) => getRuleColumn(ruleKey, 'decimal examples')),
+    ...smallNumCols,
+    ...zeroToNineNumCols,
+    ...teensNumCols,
+    ...tensNumCols,
+    ...largeNumCols,
+    ...compactNumCols,
+    {
+      key: 'Full example grid (hover)',
+      render: (lang) => <LanguagePluralGridButton lang={lang} showTooltips={false} />,
+      isInitiallyVisible: true,
+      columnGroup: 'Example grid',
+    },
+    {
+      key: 'Full example grid',
+      render: (lang) => (
+        <LanguagePluralGrid
+          lang={lang}
+          showTooltips={false /* too many items to render for table view */}
+        />
+      ),
+      isInitiallyVisible: false,
+      columnGroup: 'Example grid',
+    },
+  ];
+}
+
+export default getLanguagePluralsColumns;

--- a/src/entities/language/plurals/PluralNumberSets.ts
+++ b/src/entities/language/plurals/PluralNumberSets.ts
@@ -1,0 +1,50 @@
+export const PROTOTYPICAL_NUMS = [0, 1, 2, 3, 5, 10, 11, 20, 1000000, '1c6'];
+
+// Most of these sets have 10 items each to fit in a grid
+export const SMALL_NUMS = ['0.0', 0.1, 0.2, 0.3, 0.5, 0.7, '1.0', 1.5, '2.0', 2.5];
+export const ZERO_TO_NINE_NUMS = Array.from({ length: 10 }, (_, i) => i);
+export const TEENS_NUMS = Array.from({ length: 10 }, (_, i) => i + 10);
+export const TWENTY_TO_NINETY_NUMS = Array.from({ length: 8 }, (_, i) => (i + 2) * 10);
+export const ZERO_TO_99_NUMS = Array.from({ length: 100 }, (_, i) => i);
+export const LARGE_NUMS = [
+  100, 1000, 10000, 100000, 1000000, 1000001, 1000002, 1000010, 10000000, 100000000,
+];
+
+export const SCIENTIFIC_NUMS = [
+  '1e2',
+  '1e3',
+  '1e4',
+  '1e5',
+  '1e6',
+  '1.000001e6',
+  '1.000002e6',
+  '1.00001e6',
+  '1e7',
+  '1e8',
+];
+
+// Similar to scientific notation, this represents values in a mixed word-number compact form like "1 million"
+export const COMPACT_NUMS = [
+  '1c2',
+  '1c3',
+  '1c4',
+  '1c5',
+  '1c6',
+  '1.000001c6',
+  '1.000002c6',
+  '1.00001c6',
+  '1c7',
+  '1c8',
+];
+export const COMPACT_NUM_LABELS = [
+  '1 hundred',
+  '1 thousand',
+  '10 thousand',
+  '100 thousand',
+  '1 million',
+  '1 million (+1)',
+  '1 million (+2)',
+  '1 million (+10)',
+  '10 million',
+  '100 million',
+];

--- a/src/entities/language/plurals/PluralRuleEquation.tsx
+++ b/src/entities/language/plurals/PluralRuleEquation.tsx
@@ -1,0 +1,115 @@
+import { CopyIcon } from 'lucide-react';
+import React, { Fragment, ReactNode } from 'react';
+
+import Hoverable from '@features/layers/hovercard/Hoverable';
+import HoverableButton from '@features/layers/hovercard/HoverableButton';
+
+import useCopyToClipboard from '@shared/hooks/useCopyToClipboard';
+
+import { getConditionFunction } from './LanguagePluralComputation';
+import { parsePluralRuleEquation } from './pluralRuleParsing';
+import { SymbolToLabel } from './PluralRuleSymbolExplanation';
+
+type Props = {
+  rule: string;
+  exampleNum?: string | number;
+  includeCopyButton?: boolean;
+};
+
+const PluralRuleEquation: React.FC<Props> = ({ rule, exampleNum, includeCopyButton = false }) => {
+  const { copy } = useCopyToClipboard();
+
+  const { conditions } = parsePluralRuleEquation(rule);
+
+  return (
+    <>
+      {includeCopyButton && (
+        <>
+          <HoverableButton
+            onClick={() => copy(conditions)}
+            aria-label="Copy conditions"
+            style={{ marginLeft: '0.5em', padding: '0.25em' }}
+          >
+            <CopyIcon size="1em" style={{ display: 'block' }} />
+          </HoverableButton>{' '}
+        </>
+      )}
+      <FormattedConditions conditions={conditions} exampleNum={exampleNum} />
+    </>
+  );
+};
+
+const FormattedConditions: React.FC<{ conditions: string; exampleNum?: string | number }> = ({
+  conditions,
+  exampleNum,
+}) => {
+  // eg. "i = 0 and v = 0"
+  const andConditions = conditions.split(' and ');
+  if (andConditions.length <= 1) {
+    return <FormattedCondition condition={conditions} exampleNum={exampleNum} />;
+  }
+  return (
+    <div style={{ display: 'inline-flex', flexWrap: 'wrap', alignItems: 'center', gap: '0.25em' }}>
+      {andConditions.map((cond, index) => (
+        <Fragment key={index}>
+          {index > 0 && (
+            <span style={{ color: 'var(--color-text-secondary)', padding: '0 0.25em' }}>and</span>
+          )}
+          <div style={{ textWrap: 'nowrap' }}>
+            (<FormattedCondition key={index} condition={cond} exampleNum={exampleNum} />)
+          </div>
+        </Fragment>
+      ))}
+    </div>
+  );
+};
+
+const FormattedCondition: React.FC<{ condition: string; exampleNum?: string | number }> = ({
+  condition,
+  exampleNum,
+}) => {
+  const symbols = condition.split(' ');
+  const passes = exampleNum != null ? getConditionFunction(condition)(exampleNum) : undefined;
+  return (
+    <>
+      {symbols.map((symbol, i) => (
+        <span style={{ padding: '0 0.25em' }} key={i} className={passes ? 'highlighted' : ''}>
+          <SymbolToFormat symbol={symbol} />
+        </span>
+      ))}
+    </>
+  );
+};
+
+function SymbolToFormat({ symbol }: { symbol: string }): ReactNode {
+  // If it's a number or range, return as is
+  if (symbol.match('^[0-9]')) {
+    if (symbol.includes('..')) {
+      return <>{symbol.replace('..', '…')}</>;
+    }
+    return symbol;
+  }
+
+  // Otherwise try to parse the symbol
+  switch (symbol) {
+    case '=':
+      return '=';
+    case '!=':
+      return '≠';
+    case '%':
+      return '%';
+    case 'n': // the absolute value of N
+    case 'i': // the integer digits of N
+    case 'v': // the number of visible fraction digits in N, with trailing zeros
+    case 'w': // the number of visible fraction digits in N, without trailing zeros
+    case 'f': // the visible fraction digits in N, with trailing zeros, expressed as an integer
+    case 't': // the visible fraction digits in N, without trailing zeros, expressed as an integer
+    case 'c': // compact decimal exponent value: exponent of the power of 10 used in compact decimal formatting.
+    case 'e': // scientific notation exponent value
+      return <Hoverable hoverContent={<SymbolToLabel symbol={symbol} />}>{symbol}</Hoverable>;
+    default:
+      return <div style={{ display: 'inline-block', color: 'var(--color-red)' }}>{symbol}</div>;
+  }
+}
+
+export default PluralRuleEquation;

--- a/src/entities/language/plurals/PluralRuleEquation.tsx
+++ b/src/entities/language/plurals/PluralRuleEquation.tsx
@@ -44,6 +44,42 @@ const FormattedConditions: React.FC<{ conditions: string; exampleNum?: string | 
   exampleNum,
 }) => {
   // eg. "i = 0 and v = 0"
+  // eg. "n % 10 = 1 and n % 100 != 11,71,91"
+  const orConditions = conditions.split(' or ');
+  if (orConditions.length <= 1) {
+    return <FormattedAndConditions conditions={conditions} exampleNum={exampleNum} />;
+  }
+  return (
+    <div style={{ display: 'flex', gap: '0.5em', flexWrap: 'wrap', flexDirection: 'column' }}>
+      {orConditions.map((conditions, index) => (
+        <div key={index} style={{ display: 'inline-flex', alignItems: 'center', gap: '0.25em' }}>
+          <div
+            style={{
+              border: '1px solid var(--color-text)',
+              height: '100%',
+              borderRadius: '0.25em',
+              borderTop: 0,
+              borderBottom: 0,
+              padding: '0 0.5em',
+            }}
+          >
+            <FormattedAndConditions conditions={conditions} exampleNum={exampleNum} />
+          </div>
+
+          {index < orConditions.length - 1 && (
+            <div style={{ color: 'var(--color-text-secondary)' }}>or</div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const FormattedAndConditions: React.FC<{ conditions: string; exampleNum?: string | number }> = ({
+  conditions,
+  exampleNum,
+}) => {
+  // eg. "i = 0 and v = 0"
   const andConditions = conditions.split(' and ');
   if (andConditions.length <= 1) {
     return <FormattedCondition condition={conditions} exampleNum={exampleNum} />;

--- a/src/entities/language/plurals/PluralRuleExampleSet.tsx
+++ b/src/entities/language/plurals/PluralRuleExampleSet.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import { parsePluralRuleEquation } from './pluralRuleParsing';
+
+type Props = {
+  rule: string;
+  exampleSet: 'integer' | 'decimal';
+};
+
+const PluralRuleExampleSet: React.FC<Props> = ({ rule, exampleSet }) => {
+  const { integerExamples, decimalExamples } = parsePluralRuleEquation(rule);
+
+  if (exampleSet === 'decimal' && decimalExamples) {
+    return replaceCompactNotationInExamples(decimalExamples);
+  }
+  return integerExamples ? replaceCompactNotationInExamples(integerExamples) : '';
+};
+
+function replaceCompactNotationInExamples(numSequenceString: string): string {
+  return numSequenceString.trim().split(', ').map(replaceCompactNotation).join(', ');
+}
+
+function replaceCompactNotation(num: string): string {
+  if (num.includes('~')) {
+    const parts = num.split('~');
+    return replaceCompactNotation(parts[0]) + ' to ' + replaceCompactNotation(parts[1]);
+  }
+
+  // Compact notation, eg. "1c4" = "10 thousand"
+  if (num.includes('c')) {
+    const parts = num.split('c');
+    const exponent = parseInt(parts[1], 10);
+    let base = parts[0];
+
+    if (exponent == 2) return base + ' hundred';
+
+    // Adjust the base, so the "1" in "1e4" becomes "10" to result with "10 thousand".
+    if (exponent % 3 === 1) {
+      base = (parseFloat(base) * 10).toString();
+    } else if (exponent % 3 === 2) {
+      base = (parseFloat(base) * 100).toString();
+    }
+    // For now only supporting English compact numbers for examples
+    if (exponent >= 3 && exponent < 6) {
+      return base + ' thousand';
+    } else if (exponent >= 6 && exponent < 9) {
+      return base + ' million';
+    } else if (exponent >= 9 && exponent < 12) {
+      return base + ' billion';
+    } else if (exponent >= 12 && exponent < 15) {
+      return base + ' trillion';
+    }
+    return num; // not supported
+  }
+  return num;
+}
+
+export default PluralRuleExampleSet;

--- a/src/entities/language/plurals/PluralRuleExplanation.tsx
+++ b/src/entities/language/plurals/PluralRuleExplanation.tsx
@@ -1,52 +1,37 @@
-import { CopyIcon } from 'lucide-react';
-import React, { Fragment, ReactNode } from 'react';
+import React from 'react';
 
-import Hoverable from '@features/layers/hovercard/Hoverable';
-import HoverableButton from '@features/layers/hovercard/HoverableButton';
-
-import useCopyToClipboard from '@shared/hooks/useCopyToClipboard';
 import LinkButton from '@shared/ui/LinkButton';
 
-import { getConditionFunction } from './LanguagePluralComputation';
-import PluralRuleSymbolExplanation, { SymbolToLabel } from './PluralRuleSymbolExplanation';
+import PluralRuleEquation from './PluralRuleEquation';
+import PluralRuleExampleSet from './PluralRuleExampleSet';
+import { parsePluralRuleEquation } from './pluralRuleParsing';
+import PluralRuleSymbolExplanation from './PluralRuleSymbolExplanation';
 
 const PluralRuleExplanation: React.FC<{ rule: string; exampleNum?: string | number }> = ({
   rule,
   exampleNum,
 }) => {
-  const { copy } = useCopyToClipboard();
-
-  // 3 main parts "conditions" "@integer examples" "@decimal examples"
-  const [conditions, integerExamples, decimalExamples] = rule
-    .match(/([^@]*)(?:@integer ([^@]*))?(?:@decimal ([^@]*))?/)!
-    .slice(1);
+  const { conditions, integerExamples, decimalExamples } = parsePluralRuleEquation(rule);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '1em' }}>
-      {conditions.trim() && (
+      {conditions && (
         <div>
           <strong>Equation:</strong>
-          <HoverableButton
-            onClick={() => copy(conditions)}
-            aria-label="Copy conditions"
-            style={{ marginLeft: '0.5em', padding: '0.25em' }}
-          >
-            <CopyIcon size="1em" style={{ display: 'block' }} />
-          </HoverableButton>{' '}
-          <FormattedConditions conditions={conditions} exampleNum={exampleNum} />
+          <PluralRuleEquation rule={rule} includeCopyButton={true} />
         </div>
       )}
       {integerExamples && exampleNum == null && (
         <div>
           <strong>Integer examples:</strong>{' '}
-          {integerExamples.replace(/~/g, '…').replace(/c/g, 'e').trim()}
+          <PluralRuleExampleSet rule={rule} exampleSet="integer" />
           <br />
         </div>
       )}
       {decimalExamples && exampleNum == null && (
         <div>
           <strong>Decimal examples:</strong>{' '}
-          {decimalExamples.replace(/~/g, '…').replace(/c/g, 'e').trim()}
+          <PluralRuleExampleSet rule={rule} exampleSet="decimal" />
         </div>
       )}
       <SymbolsExplanation conditions={conditions} exampleNum={exampleNum} />
@@ -63,116 +48,6 @@ const PluralRuleExplanation: React.FC<{ rule: string; exampleNum?: string | numb
     </div>
   );
 };
-
-const FormattedConditions: React.FC<{ conditions: string; exampleNum?: string | number }> = ({
-  conditions,
-  exampleNum,
-}) => {
-  // eg. "i = 0 and v = 0"
-  // eg. "n % 10 = 1 and n % 100 != 11,71,91"
-  const orConditions = conditions.split(' or ');
-  if (orConditions.length <= 1) {
-    return <FormattedAndConditions conditions={conditions} exampleNum={exampleNum} />;
-  }
-  return (
-    <div style={{ display: 'flex', gap: '0.5em', flexWrap: 'wrap', flexDirection: 'column' }}>
-      {orConditions.map((conditions, index) => (
-        <div key={index} style={{ display: 'inline-flex', alignItems: 'center', gap: '0.25em' }}>
-          <div
-            style={{
-              border: '1px solid var(--color-text)',
-              height: '100%',
-              borderRadius: '0.25em',
-              borderTop: 0,
-              borderBottom: 0,
-              padding: '0 0.5em',
-            }}
-          >
-            <FormattedAndConditions conditions={conditions} exampleNum={exampleNum} />
-          </div>
-
-          {index < orConditions.length - 1 && (
-            <div style={{ color: 'var(--color-text-secondary)' }}>or</div>
-          )}
-        </div>
-      ))}
-    </div>
-  );
-};
-
-const FormattedAndConditions: React.FC<{ conditions: string; exampleNum?: string | number }> = ({
-  conditions,
-  exampleNum,
-}) => {
-  // eg. "i = 0 and v = 0"
-  const andConditions = conditions.split(' and ');
-  if (andConditions.length <= 1) {
-    return <FormattedCondition condition={conditions} exampleNum={exampleNum} />;
-  }
-  return (
-    <div style={{ display: 'inline-flex', flexWrap: 'wrap', alignItems: 'center', gap: '0.25em' }}>
-      {andConditions.map((cond, index) => (
-        <Fragment key={index}>
-          {index > 0 && (
-            <span style={{ color: 'var(--color-text-secondary)', padding: '0 0.25em' }}>and</span>
-          )}
-          <div style={{ textWrap: 'nowrap' }}>
-            (<FormattedCondition key={index} condition={cond} exampleNum={exampleNum} />)
-          </div>
-        </Fragment>
-      ))}
-    </div>
-  );
-};
-
-const FormattedCondition: React.FC<{ condition: string; exampleNum?: string | number }> = ({
-  condition,
-  exampleNum,
-}) => {
-  const symbols = condition.split(' ');
-  const passes = exampleNum != null ? getConditionFunction(condition)(exampleNum) : undefined;
-  return (
-    <>
-      {symbols.map((symbol, i) => (
-        <span style={{ padding: '0 0.25em' }} key={i} className={passes ? 'highlighted' : ''}>
-          <SymbolToFormat symbol={symbol} />
-        </span>
-      ))}
-    </>
-  );
-};
-
-function SymbolToFormat({ symbol }: { symbol: string }): ReactNode {
-  // If it's a number or range, return as is
-  if (symbol.match('^[0-9]')) {
-    if (symbol.includes('..')) {
-      return <>{symbol.replace('..', '…')}</>;
-    }
-    return symbol;
-  }
-
-  // Otherwise try to parse the symbol
-  switch (symbol) {
-    case '=':
-      return '=';
-    case '!=':
-      return '≠';
-    case '%':
-      return '%';
-    case 'n': // the absolute value of N
-    case 'i': // the integer digits of N
-    case 'v': // the number of visible fraction digits in N, with trailing zeros
-    case 'w': // the number of visible fraction digits in N, without trailing zeros
-    case 'f': // the visible fraction digits in N, with trailing zeros, expressed as an integer
-    case 't': // the visible fraction digits in N, without trailing zeros, expressed as an integer
-      return <Hoverable hoverContent={<SymbolToLabel symbol={symbol} />}>{symbol}</Hoverable>;
-    case 'c': // compact decimal exponent value: exponent of the power of 10 used in compact decimal formatting.
-    case 'e': // a deprecated synonym for ‘c’. Note: it may be redefined in the future.
-      return <Hoverable hoverContent={<SymbolToLabel symbol="e" />}>e</Hoverable>;
-    default:
-      return <div style={{ display: 'inline-block', color: 'var(--color-red)' }}>{symbol}</div>;
-  }
-}
 
 const SymbolsExplanation: React.FC<{ conditions: string; exampleNum?: string | number }> = ({
   conditions,

--- a/src/entities/language/plurals/PluralRuleExplanation.tsx
+++ b/src/entities/language/plurals/PluralRuleExplanation.tsx
@@ -18,14 +18,13 @@ const PluralRuleExplanation: React.FC<{ rule: string; exampleNum?: string | numb
       {conditions && (
         <div>
           <strong>Equation:</strong>
-          <PluralRuleEquation rule={rule} includeCopyButton={true} />
+          <PluralRuleEquation rule={rule} includeCopyButton={true} exampleNum={exampleNum} />
         </div>
       )}
       {integerExamples && exampleNum == null && (
         <div>
           <strong>Integer examples:</strong>{' '}
           <PluralRuleExampleSet rule={rule} exampleSet="integer" />
-          <br />
         </div>
       )}
       {decimalExamples && exampleNum == null && (

--- a/src/entities/language/plurals/PluralRuleSymbolExplanation.tsx
+++ b/src/entities/language/plurals/PluralRuleSymbolExplanation.tsx
@@ -57,6 +57,8 @@ export const SymbolToLabel: React.FC<{ symbol: string }> = ({ symbol }) => {
     case 'c':
     case 'e':
       return 'compact decimal exponent value: exponent of the power of 10 used in compact decimal formatting';
+    // e may be interpreted as scientific notation too
+    // return 'scientific decimal exponent value: exponent of the power of 10 used in scientific number formatting';
     default:
       return <>{symbol}</>;
   }

--- a/src/entities/language/plurals/PluralRulesLanguageExamplesTable.tsx
+++ b/src/entities/language/plurals/PluralRulesLanguageExamplesTable.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+
+import Hoverable from '@features/layers/hovercard/Hoverable';
+
+import { PluralRuleKey } from './LanguagePluralComputation';
+
+function PluralRulesLanguageExamplesTable() {
+  return (
+    <table style={{ width: 'fit-content' }}>
+      <thead>
+        <tr>
+          <th>English</th>
+          <th>French</th>
+          <th>Croatian</th>
+          <th colSpan={2}>
+            <Hoverable
+              hoverContent={
+                <>
+                  Modern Standard Arabic. Generally, there are only 3 plural forms (1/2/3+). The
+                  11-100 range and superplural ranges are not used by all speakers. Additionally,
+                  the zero case is usually not separated out, but you can think of the equivalent in
+                  English since instead of &quot;0 cats&quot;, it would be more comfortable to write
+                  &quot;no cats&quot;. Translations in Arabic and Latin writing are provided and
+                  most values have explanations on hover.
+                </>
+              }
+            >
+              Arabic
+            </Hoverable>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <Cell>0 cats</Cell>
+          <Cell ruleKey={PluralRuleKey.One}>0 chats</Cell>
+          <Cell>0 mačaka</Cell>
+          <Cell ruleKey={PluralRuleKey.Zero} rtl={true}>
+            لا قطة
+          </Cell>
+          <Cell
+            ruleKey={PluralRuleKey.Zero}
+            explanation={
+              <>
+                Literally &quot;no cat&quot;. A literal translation is &quot;ṣifru qiṭaṭin&quot;
+                (صِفْرُ قِطَطٍ) but that is an awkward form.
+              </>
+            }
+          >
+            lā qiṭṭa
+          </Cell>
+        </tr>
+        <tr>
+          <Cell ruleKey={PluralRuleKey.One}>1 cat</Cell>
+          <Cell ruleKey={PluralRuleKey.One}>1 chat</Cell>
+          <Cell ruleKey={PluralRuleKey.One}>1 mačak</Cell>
+          <Cell ruleKey={PluralRuleKey.One} rtl={true}>
+            قِطٌّ وَاحِدٌ
+          </Cell>
+          <Cell
+            ruleKey={PluralRuleKey.One}
+            explanation={<>Some people pronounce this &quot;qitt&quot;.</>}
+          >
+            qiṭṭun 1
+          </Cell>
+        </tr>
+        <tr>
+          <Cell>2 cats</Cell>
+          <Cell>2 chats</Cell>
+          <Cell ruleKey={PluralRuleKey.Few}>2 mačka</Cell>
+          <Cell ruleKey={PluralRuleKey.Two} rtl={true}>
+            قِطَّانِ
+          </Cell>
+          <Cell ruleKey={PluralRuleKey.Two}>qiṭṭāni</Cell>
+        </tr>
+        <tr>
+          <Cell>3 cats</Cell>
+          <Cell>3 chats</Cell>
+          <Cell ruleKey={PluralRuleKey.Few}>3 mačka</Cell>
+          <Cell ruleKey={PluralRuleKey.Few} rtl={true}>
+            ثَلَاثَةُ قِطَطٍ
+          </Cell>
+          <Cell
+            ruleKey={PluralRuleKey.Few}
+            explanation={
+              <>
+                While in CLDR this is specifically for 3-10, in practice this used for most 3+
+                cases. Some people pronounce this &quot;qitat&quot;.
+              </>
+            }
+          >
+            3 qiṭaṭin
+          </Cell>
+        </tr>
+        <tr>
+          <Cell>20 cats</Cell>
+          <Cell>20 chats</Cell>
+          <Cell>20 mačaka</Cell>
+          <Cell ruleKey={PluralRuleKey.Many} rtl={true}>
+            عِشْرُونَ قِطًّا
+          </Cell>
+          <Cell
+            ruleKey={PluralRuleKey.Many}
+            explanation={
+              <>
+                According to grammar rules, the noun is changed from nominative to accusative when
+                there are many of them (11-100). Some people just use the 3+ form (qiṭaṭin/qitat).
+              </>
+            }
+          >
+            20 qiṭṭan
+          </Cell>
+        </tr>
+        <tr>
+          <Cell>1 million cats</Cell>
+          <Cell ruleKey={PluralRuleKey.Many}>un million de chats</Cell>
+          <Cell>1 milijun mačaka</Cell>
+          <Cell rtl={true}>مَلْيُونُ قِطٍّ</Cell>
+          <Cell
+            explanation={
+              <>
+                According to grammar rules, the noun is changed from nominative to genitive when
+                there are very many of them. Some people just use the 3+ form (qiṭaṭin/qitat).
+              </>
+            }
+          >
+            malyūnu qiṭṭin
+          </Cell>
+        </tr>
+      </tbody>
+    </table>
+  );
+}
+
+type CellProps = {
+  children: React.ReactNode;
+  explanation?: React.ReactNode;
+  rtl?: boolean;
+  ruleKey?: PluralRuleKey;
+};
+
+const Cell: React.FC<CellProps> = ({ children, ruleKey, rtl, explanation }) => {
+  let contents = children;
+  if (explanation) {
+    contents = (
+      <Hoverable
+        hoverContent={explanation}
+        style={{
+          color:
+            ruleKey && ruleKey !== PluralRuleKey.Other ? 'var(--color-text-on-color)' : undefined,
+        }}
+      >
+        {children}
+      </Hoverable>
+    );
+  }
+
+  return (
+    <td
+      className={ruleKey}
+      style={{ direction: rtl ? 'rtl' : 'ltr', borderRadius: '0.25em', padding: '0 0.25em' }}
+    >
+      {contents}
+    </td>
+  );
+};
+
+export default PluralRulesLanguageExamplesTable;

--- a/src/entities/language/plurals/PluralRulesLanguageExamplesTable.tsx
+++ b/src/entities/language/plurals/PluralRulesLanguageExamplesTable.tsx
@@ -42,8 +42,8 @@ function PluralRulesLanguageExamplesTable() {
             ruleKey={PluralRuleKey.Zero}
             explanation={
               <>
-                Literally &quot;no cat&quot;. A literal translation is &quot;ṣifru qiṭaṭin&quot;
-                (صِفْرُ قِطَطٍ) but that is an awkward form.
+                Literally &quot;no cat&quot;. A literal translation of &quot;0 cats&quot; is
+                &quot;ṣifru qiṭaṭin&quot; (صِفْرُ قِطَطٍ) but that less natural.
               </>
             }
           >

--- a/src/entities/language/plurals/PluralRulesSummaryTable.tsx
+++ b/src/entities/language/plurals/PluralRulesSummaryTable.tsx
@@ -1,0 +1,72 @@
+import Deemphasized from '@shared/ui/Deemphasized';
+
+import LanguagePluralCategory from './LanguagePluralCategory';
+import { PluralRuleKey } from './LanguagePluralComputation';
+
+function PluralRulesSummaryTable() {
+  return (
+    <table style={{ width: 'fit-content' }}>
+      <thead>
+        <tr>
+          <th>Rule Key</th>
+          <th>Formal Name</th>
+          <th>Example Ranges</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <LanguagePluralCategory pluralRuleKey={PluralRuleKey.Zero} />
+          </td>
+          <td>Privative</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <td>
+            <LanguagePluralCategory pluralRuleKey={PluralRuleKey.One} />
+          </td>
+          <td>Singular</td>
+          <td>1, 0-1</td>
+        </tr>
+        <tr>
+          <td>
+            <LanguagePluralCategory pluralRuleKey={PluralRuleKey.Two} />
+          </td>
+          <td>Dual</td>
+          <td>
+            2 <Deemphasized>& 12? ...</Deemphasized>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <LanguagePluralCategory pluralRuleKey={PluralRuleKey.Few} />
+          </td>
+          <td>Trial or Paucal</td>
+          <td>
+            3, 2-3, 2-4 <Deemphasized>& 12-14? ...</Deemphasized>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <LanguagePluralCategory pluralRuleKey={PluralRuleKey.Many} />
+          </td>
+          <td>Greater plural or Fractional</td>
+          <td>
+            11+, 101+, 1 million <Deemphasized>or</Deemphasized> 0.0, 0.5, 1.0, ...
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <LanguagePluralCategory pluralRuleKey={PluralRuleKey.Other} />
+          </td>
+          <td>Everything else</td>
+          <td>
+            2+, 3+, 10+ <Deemphasized>with or without 0</Deemphasized>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}
+
+export default PluralRulesSummaryTable;

--- a/src/entities/language/plurals/PluralStrings.ts
+++ b/src/entities/language/plurals/PluralStrings.ts
@@ -16,20 +16,3 @@ export function getPluralRuleKeyLabel(key: PluralRuleKey): string {
       return 'Other';
   }
 }
-
-export function getPluralRuleColor(key: PluralRuleKey): string {
-  switch (key) {
-    case PluralRuleKey.Zero:
-      return 'var(--color-blue)';
-    case PluralRuleKey.One:
-      return 'var(--color-green)';
-    case PluralRuleKey.Two:
-      return 'var(--color-yellow)';
-    case PluralRuleKey.Few:
-      return 'var(--color-orange)';
-    case PluralRuleKey.Many:
-      return 'var(--color-red)';
-    case PluralRuleKey.Other:
-      return 'var(--color-button-secondary)';
-  }
-}

--- a/src/entities/language/plurals/pluralRuleParsing.ts
+++ b/src/entities/language/plurals/pluralRuleParsing.ts
@@ -1,0 +1,15 @@
+// 3 main parts "conditions" "@integer examples" "@decimal examples"
+export function parsePluralRuleEquation(rule: string): {
+  conditions: string;
+  integerExamples?: string;
+  decimalExamples?: string;
+} {
+  const [conditions, integerExamples, decimalExamples] = rule
+    .match(/([^@]*)(?:@integer ([^@]*))?(?:@decimal ([^@]*))?/)!
+    .slice(1);
+  return {
+    conditions: conditions.trim(),
+    integerExamples,
+    decimalExamples,
+  };
+}

--- a/src/entities/language/plurals/plurals.css
+++ b/src/entities/language/plurals/plurals.css
@@ -1,0 +1,48 @@
+/* Colors */
+.pluralRule-count-zero {
+  color: var(--color-text-on-color) !important;
+  background-color: var(--color-blue);
+}
+
+.pluralRule-count-one {
+  color: var(--color-text-on-color) !important;
+  background-color: var(--color-green);
+}
+
+.pluralRule-count-two {
+  color: var(--color-text-on-color) !important;
+  background-color: var(--color-yellow);
+}
+
+.pluralRule-count-few {
+  color: var(--color-text-on-color) !important;
+  background-color: var(--color-orange);
+}
+
+.pluralRule-count-many {
+  color: var(--color-text-on-color) !important;
+  background-color: var(--color-red);
+}
+
+.pluralRule-count-other {
+  color: var(--color-text) !important;
+  background-color: var(--color-button-secondary);
+}
+
+/* Components */
+.LanguagePluralExample {
+  border-radius: 0.25em;
+  min-width: 1em;
+  text-align: right;
+  padding: 0 0.25em;
+}
+
+.LanguagePluralCategory {
+  border-radius: 0.25em;
+  padding: 0 0.25em;
+}
+
+.LanguagePluralCategory.hoverableText {
+  /* avoiding negative margins on regular hoverable text */
+  margin: 0;
+}

--- a/src/features/layers/hovercard/Hoverable.tsx
+++ b/src/features/layers/hovercard/Hoverable.tsx
@@ -6,10 +6,17 @@ type HoverableProps = {
   children: React.ReactNode;
   hoverContent?: React.ReactNode;
   onClick?: () => void;
+  className?: string;
   style?: React.CSSProperties;
 };
 
-const Hoverable: React.FC<HoverableProps> = ({ children, hoverContent, onClick, style }) => {
+const Hoverable: React.FC<HoverableProps> = ({
+  children,
+  hoverContent,
+  onClick,
+  style,
+  className,
+}) => {
   const { showHoverCard, hideHoverCard, onMouseLeaveTriggeringElement } = useHoverCard();
 
   if (hoverContent == null) {
@@ -24,7 +31,7 @@ const Hoverable: React.FC<HoverableProps> = ({ children, hoverContent, onClick, 
     <span
       data-testid="hoverable"
       aria-label={typeof hoverContent === 'string' ? hoverContent : undefined} // For screen readers
-      className="hoverableText"
+      className={`hoverableText${className ? ` ${className}` : ''}`}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={onMouseLeaveTriggeringElement}
       onClick={(e) => {

--- a/src/features/table/TableID.tsx
+++ b/src/features/table/TableID.tsx
@@ -19,6 +19,7 @@ enum TableID {
   LocaleIndigeneity,
   VariantAnnotation,
   LanguageScopeIssues,
+  LanguagePlurals,
 }
 
 export default TableID;

--- a/src/widgets/reports/Report.tsx
+++ b/src/widgets/reports/Report.tsx
@@ -13,6 +13,7 @@ const ReportCensusInputTool = React.lazy(() => import('./ReportCensusInputTool')
 const ReportEntitiesMissingFields = React.lazy(() => import('./ReportEntitiesMissingFields'));
 const ReportLanguageDescendants = React.lazy(() => import('./ReportLanguageDescendants'));
 const ReportLanguagePaths = React.lazy(() => import('./ReportLanguagePaths'));
+const ReportLanguagePlurals = React.lazy(() => import('./ReportLanguagePlurals'));
 const ReportLanguageScopeIssues = React.lazy(() => import('./ReportLanguageScopeIssues'));
 const ReportLanguagesDubious = React.lazy(() => import('./ReportLanguagesDubious'));
 const ReportLanguagesWithAmbiguousNames = React.lazy(
@@ -45,6 +46,8 @@ const SpecificReport: React.FC<{ reportID: ReportID }> = ({ reportID }) => {
       return <ReportEntitiesMissingFields />;
     case ReportID.LanguagePaths:
       return <ReportLanguagePaths />;
+    case ReportID.LanguagePlurals:
+      return <ReportLanguagePlurals />;
     case ReportID.LanguageScopeIssues:
       return <ReportLanguageScopeIssues />;
     case ReportID.LanguageDescendants:

--- a/src/widgets/reports/ReportID.ts
+++ b/src/widgets/reports/ReportID.ts
@@ -1,6 +1,7 @@
-// ID should be entity type (usually plural) followed by specific information, even if it is ungrammatical
+// ID should be entity type (usually plural) followed by specific information, even if it is ungrammatical.
+// Names can change but the order should not, since the numeric values are used in the URL params and should not change.
 enum ReportID {
-  EntitiesMissingFields, // fixed at 0 since it is always there. All others should be alphabetic
+  EntitiesMissingFields, // Useful for all entities
   CensusCountries,
   CensusInputTool,
   LanguagesWithAmbiguousNames,
@@ -13,6 +14,7 @@ enum ReportID {
   LocalesPotential,
   VariantsAnnotationTool,
   WritingSystemsLanguagesWithout,
+  LanguagePlurals,
 }
 
 export default ReportID;

--- a/src/widgets/reports/ReportLabels.tsx
+++ b/src/widgets/reports/ReportLabels.tsx
@@ -6,6 +6,7 @@ const ReportLabels: Record<ReportID, string> = {
   [ReportID.EntitiesMissingFields]: 'Missing Fields',
   [ReportID.LanguageDescendants]: 'Descendants',
   [ReportID.LanguagePaths]: 'Paths',
+  [ReportID.LanguagePlurals]: 'Plurals',
   [ReportID.LanguageScopeIssues]: 'Scope Issues',
   [ReportID.LanguagesDubious]: 'Dubious Languages',
   [ReportID.LanguagesWithAmbiguousNames]: 'Ambiguous Names',

--- a/src/widgets/reports/ReportLanguagePlurals.tsx
+++ b/src/widgets/reports/ReportLanguagePlurals.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import LanguagePluralsTable from '@widgets/tables/LanguagePluralsTable';
+
+import LanguagePluralCategory from '@entities/language/plurals/LanguagePluralCategory';
+import { PluralRuleKey } from '@entities/language/plurals/LanguagePluralComputation';
+import PluralRulesLanguageExamplesTable from '@entities/language/plurals/PluralRulesLanguageExamplesTable';
+import PluralRulesSummaryTable from '@entities/language/plurals/PluralRulesSummaryTable';
+
+import ExternalLink from '@shared/ui/ExternalLink';
+
+const ReportLanguagePlurals: React.FC = () => {
+  return (
+    <>
+      <div>
+        When counting objects, languages may change the form of the noun based on how many objects
+        are being counted. In English we think of this as singular (1 cat,{' '}
+        <LanguagePluralCategory pluralRuleKey={PluralRuleKey.One} />) and plural (2 cats,{' '}
+        <LanguagePluralCategory pluralRuleKey={PluralRuleKey.Other} />
+        ). Some languages have more than 2 forms. For example, Croatian has a special form for 2-4
+        objects (
+        <LanguagePluralCategory pluralRuleKey={PluralRuleKey.Few} />
+        ). Additionally, the boundaries of singular and plural may be different in other languages.
+        For example, in French &quot;0 cats&quot; is translated to &quot;0 chat&quot; (
+        <LanguagePluralCategory pluralRuleKey={PluralRuleKey.One} /> form).
+      </div>
+      <div>
+        Outside of the particular noun, there may also be changes to words around the noun, such as
+        a third case in French when using counting groups (&quot;dozens&quot;,
+        &quot;thousands&quot;,...) -- notice the &quot;<strong>de</strong>&quot; added in &quot;un
+        million <strong>de</strong> chats&quot; as opposed to &quot;1,000,000 chats&quot;. While
+        there are only 2 noun cases, the CLDR system takes this as a 3rd counting case since it
+        affects plural constructions: the pattern &quot;# chats&quot; needs to become &quot;# de
+        chats&quot;. See the summary tables below for examples on different plural constructions and
+        the full table below for all languages.
+      </div>
+      <div style={{ display: 'flex', gap: '2em', justifyContent: 'space-evenly', width: '100%' }}>
+        <PluralRulesSummaryTable />
+        <PluralRulesLanguageExamplesTable />
+      </div>
+      <div>
+        See the following table for information for all languages. Columns with just a number as the
+        title show the case something with that number would belong to. For example, if &quot;0
+        cats&quot; is handled with its own case (
+        <LanguagePluralCategory pluralRuleKey={PluralRuleKey.Zero} />
+        ), as the singular case(
+        <LanguagePluralCategory pluralRuleKey={PluralRuleKey.One} />) or with the other plural case(
+        <LanguagePluralCategory pluralRuleKey={PluralRuleKey.Other} />
+        ). Use the table&apos;s column selector to see other number examples to compare. This data
+        comes from CLDR and an empty row (without even an{' '}
+        <LanguagePluralCategory pluralRuleKey={PluralRuleKey.Other} /> case) is not covered by CLDR.
+        Please consult the{' '}
+        <ExternalLink href="https://unicode.org/reports/tr35/tr35-numbers.html?#Language_Plural_Rules">
+          Unicode Specification
+        </ExternalLink>{' '}
+        and{' '}
+        <ExternalLink href="https://unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html">
+          CLDR charts
+        </ExternalLink>{' '}
+        for more information.
+      </div>
+      <LanguagePluralsTable />
+    </>
+  );
+};
+
+export default ReportLanguagePlurals;

--- a/src/widgets/reports/getReportIDsForEntityType.ts
+++ b/src/widgets/reports/getReportIDsForEntityType.ts
@@ -14,6 +14,7 @@ function getReportIDsForEntityType(entityType: ObjectType): ReportID[] {
         ReportID.LanguagePaths,
         ReportID.LanguageDescendants,
         ReportID.LanguageScopeIssues,
+        ReportID.LanguagePlurals,
       ];
     case ObjectType.Locale:
       return [

--- a/src/widgets/tables/LanguagePluralsTable.tsx
+++ b/src/widgets/tables/LanguagePluralsTable.tsx
@@ -1,0 +1,23 @@
+import React, { useMemo } from 'react';
+
+import { useDataContext } from '@features/data/context/useDataContext';
+import InteractiveEntityTable from '@features/table/InteractiveEntityTable';
+import TableID from '@features/table/TableID';
+
+import { LanguageData } from '@entities/language/LanguageTypes';
+import getLanguagePluralsColumns from '@entities/language/plurals/LanguagePluralsColumns';
+
+const LanguagePluralsTable: React.FC = () => {
+  const { languagesInSelectedSource } = useDataContext();
+  const columns = useMemo(() => getLanguagePluralsColumns(), []);
+
+  return (
+    <InteractiveEntityTable<LanguageData>
+      tableID={TableID.LanguagePlurals}
+      entities={languagesInSelectedSource}
+      columns={columns}
+    />
+  );
+};
+
+export default LanguagePluralsTable;

--- a/src/widgets/tables/columns/LanguageColumns.tsx
+++ b/src/widgets/tables/columns/LanguageColumns.tsx
@@ -205,7 +205,12 @@ function getLanguageColumns(): TableColumn<LanguageData>[] {
     },
     {
       key: 'Plural rule examples',
-      render: (lang) => <LanguagePluralRuleExamplesGrid lang={lang} />,
+      render: (lang) => (
+        <LanguagePluralRuleExamplesGrid
+          lang={lang}
+          showTooltips={false /* too many items to render for table view */}
+        />
+      ),
       isInitiallyVisible: false,
       columnGroup: 'Grammar',
     },


### PR DESCRIPTION
Fixes #725 

Summary: In my discussions with CLDR there remain many problems with plural cases. I figured it would be good to make a tool to dive into them!

### Changes

- User experience
  - Added a new report for plurals
  - Decreased some of the padding
- Logical changes
  - When finding plural rules it now checks the CLDR data provider
- Data
  - n/a the data still comes from CLDR
- Refactors
  - Split some of the existing plural component into their components

Out of scope/Future work: Add screenshot tests for reports, Ordinal plurals

### Test Plan and Screenshots

How to test the changes in this PR: Go to the language reports -> plurals

<img width="982" height="758" alt="Screenshot 2026-07-23 at 16 37 46" src="https://github.com/user-attachments/assets/517c7585-5b7d-4490-9749-5448965f715f" />

