### PR TITLE
feat: replace Digital Support bars with circular score indicators

### DIFF
--- a/src/entities/language/digitalsupport/LanguageDetailsDigitalSupport.tsx
+++ b/src/entities/language/digitalsupport/LanguageDetailsDigitalSupport.tsx
@@ -13,6 +13,7 @@ import enforceExhaustiveSwitch from '@shared/lib/enforceExhaustiveness';
 import CommaSeparated from '@shared/ui/CommaSeparated';
 import Deemphasized from '@shared/ui/Deemphasized';
 import LinkButton from '@shared/ui/LinkButton';
+import ScoreRing from '@shared/ui/ScoreRing';
 
 import { getDigitalSupportDimensionLabel } from '@strings/DigitalSupportStrings';
 
@@ -20,7 +21,6 @@ import { ObjectCLDRCoverageLevel, ObjectCLDRLocaleCount } from '../../ui/CLDRCov
 import ObjectWikipediaInfo from '../../ui/ObjectWikipediaInfo';
 import { LanguageData } from '../LanguageTypes';
 
-import LanguageDigitalSupportMeter from './DigitalSupportMeter';
 import { DigitalSupportDimension } from './DigitalSupportTypes';
 import LanguageUDHRInfo, { LanguageUDHRDescription } from './LanguageUDHRInfo';
 
@@ -37,12 +37,21 @@ const LanguageDetailsDigitalSupport: React.FC<Props> = ({ lang }) => {
             key={dimension}
             style={{
               gridColumn: dimension === DigitalSupportDimension.Overall ? '1 / -1' : 'span 1',
+              display: 'flex',
+              // The Overall row has no breakdown, so its title reads better beside the ring
+              alignItems: dimension === DigitalSupportDimension.Overall ? 'center' : 'flex-start',
+              gap: '0.6em',
             }}
           >
-            <strong>{getDigitalSupportDimensionLabel(dimension)}:</strong>{' '}
-            {Math.floor(digitalSupportScore[dimension])}/10
-            <LanguageDigitalSupportMeter lang={lang} dim={dimension} />
-            <DigitalSupportDimensionBreakdown key={dimension} lang={lang} dimension={dimension} />
+            <ScoreRing
+              value={Math.floor(digitalSupportScore[dimension])}
+              max={10}
+              label={`${getDigitalSupportDimensionLabel(dimension)} score`}
+            />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontWeight: 600 }}>{getDigitalSupportDimensionLabel(dimension)}</div>
+              <DigitalSupportDimensionBreakdown lang={lang} dimension={dimension} />
+            </div>
           </div>
         ))}
       </ResponsiveGrid>

--- a/src/shared/ui/ScoreRing.tsx
+++ b/src/shared/ui/ScoreRing.tsx
@@ -1,0 +1,110 @@
+import React, { useId } from 'react';
+
+interface Props {
+  value: number | null | undefined;
+  max: number;
+  size?: number; // diameter in px
+  label?: string; // accessible name, eg. "Keyboards score"
+}
+
+// Mirrors the HTML <meter> thresholds used elsewhere for these scores:
+// below 3/10 is red, up to 7/10 is yellow, above that is green.
+function getScoreColor(ratio: number | null): string {
+  if (ratio == null) return 'var(--color-text-secondary)';
+  if (ratio >= 0.7) return 'var(--color-green)';
+  if (ratio >= 0.3) return 'var(--color-yellow)';
+  return 'var(--color-red)';
+}
+
+const ScoreRing: React.FC<Props> = ({ value, max, size = 44, label }) => {
+  const gradientId = useId();
+  const glowId = useId();
+  const stroke = size * 0.120;
+  const radius = (size - stroke) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const ratio = value != null ? Math.min(Math.max(value / max, 0), 1) : null;
+  const color = getScoreColor(ratio);
+
+  return (
+    <div
+      role="progressbar"
+      aria-label={label}
+      aria-valuenow={value ?? undefined}
+      aria-valuemin={0}
+      aria-valuemax={max}
+      title={value != null ? `${value} out of ${max}` : undefined}
+      style={{
+        position: 'relative',
+        width: size,
+        height: size,
+        flexShrink: 0,
+      }}
+    >
+      <svg width={size} height={size}>
+        <defs>
+          {/* Diagonal light-to-base sweep reads as a sheen across the arc */}
+          <linearGradient
+            id={gradientId}
+            gradientUnits="userSpaceOnUse"
+            x1={0}
+            y1={0}
+            x2={size}
+            y2={size}
+          >
+            <stop offset="0%" stopColor={`color-mix(in srgb, ${color} 72%, white)`} />
+            <stop offset="60%" stopColor={color} />
+            <stop offset="100%" stopColor={`color-mix(in srgb, ${color} 92%, black)`} />
+          </linearGradient>
+          <filter id={glowId} x="-50%" y="-50%" width="200%" height="200%">
+            <feDropShadow
+              dx="0"
+              dy={size * 0.015}
+              stdDeviation={size * 0.02}
+              floodColor={color}
+              floodOpacity="0.2"
+            />
+          </filter>
+        </defs>
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="var(--color-border)"
+          strokeWidth={stroke}
+        />
+        {ratio != null && ratio > 0 && (
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            fill="none"
+            stroke={`url(#${gradientId})`}
+            strokeWidth={stroke}
+            strokeLinecap="round"
+            strokeDasharray={circumference}
+            strokeDashoffset={circumference * (1 - ratio)}
+            filter={`url(#${glowId})`}
+            transform={`rotate(-90 ${size / 2} ${size / 2})`}
+          />
+        )}
+      </svg>
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: size * 0.32,
+          fontWeight: 600,
+          lineHeight: 1,
+        }}
+      >
+        {value != null ? value : <span style={{ color: 'var(--color-text-secondary)' }}>—</span>}
+      </div>
+    </div>
+  );
+};
+
+export default ScoreRing;

--- a/src/shared/ui/ScoreRing.tsx
+++ b/src/shared/ui/ScoreRing.tsx
@@ -19,7 +19,7 @@ function getScoreColor(ratio: number | null): string {
 const ScoreRing: React.FC<Props> = ({ value, max, size = 44, label }) => {
   const gradientId = useId();
   const glowId = useId();
-  const stroke = size * 0.120;
+  const stroke = size * 0.12;
   const radius = (size - stroke) / 2;
   const circumference = 2 * Math.PI * radius;
   const ratio = value != null ? Math.min(Math.max(value / max, 0), 1) : null;

--- a/src/widgets/details/ui/DetailsField.tsx
+++ b/src/widgets/details/ui/DetailsField.tsx
@@ -23,10 +23,14 @@ const DetailsField: React.FC<Props> = ({
         display: 'flex',
         justifyContent: 'space-between',
         alignItems: 'center',
+        // End content drops to its own line rather than spilling out of a narrow container
+        flexWrap: 'wrap',
         marginLeft: indent * 2 + 'em',
+        minWidth: 0,
       }}
     >
-      <div style={{ minWidth: '200px' }}>
+      {/* Prefers 200px so titles line up, but yields in containers too narrow for it */}
+      <div style={{ minWidth: 'min(200px, 100%)' }}>
         <div style={{ fontWeight: 600, marginRight: '0.25em', display: 'inline-flex' }}>
           {title}
           {description && (


### PR DESCRIPTION
Fixes #750 

Summary: Redesigns the Digital Support scoring UI by replacing the existing horizontal progress bars with compact circular score indicators. The updated layout improves visual hierarchy, reduces unnecessary visual weight, and makes individual support scores easier to scan while preserving the existing Digital Support information.

### Changes

- User experience
  - Replaced horizontal Digital Support score bars with circular progress indicators.
  - Displays the score directly inside each indicator.
  - Places each score indicator to the left of its category title and supporting information.
  - Improved spacing and alignment across the Digital Support grid.
  - Preserved visual differentiation between full, partial, and unavailable scores.

- Logical changes
  - Added a reusable `ScoreRing` component for rendering circular score progress.
  - Updated the Digital Support section to use the new score component.


- Refactors
  - Updated `DetailsField` sizing so content can fit correctly within responsive grid columns.
  - Kept the existing horizontal `DigitalSupportMeter` unchanged where it is still used outside this section.


### Screenshots

<img width="1172" height="429" alt="image" src="https://github.com/user-attachments/assets/143bd120-e13b-438b-b148-fe33f290d687" />

