### PR TITLE
Maps: Add a popup card button to choose map appearance #680

### DIFF
--- a/src/features/map/MapSidebar.tsx
+++ b/src/features/map/MapSidebar.tsx
@@ -33,8 +33,12 @@ const MapSidebar: React.FC<Props> = ({ drawableEntities, objectType, hoveredId, 
 
   const [showItems, setShowItems] = React.useState(true);
 
+  if (pinnedEntities.length === 0) {
+    return null;
+  }
+
   return (
-    <div className="MapSidebar" style={{ width: pinnedEntities.length > 0 ? '300px' : '0' }}>
+    <div className="MapSidebar" style={{ width: '300px' }}>
       {/* <div> */}
       <HoverableButton
         className="MapSidebarTitle"

--- a/src/features/map/ZoomControls.tsx
+++ b/src/features/map/ZoomControls.tsx
@@ -1,8 +1,12 @@
-import { Maximize2Icon, ZoomInIcon, ZoomOutIcon } from 'lucide-react';
+import { Maximize2Icon, ZoomInIcon, ZoomOutIcon, Settings2 } from 'lucide-react';
 import React from 'react';
 
 import HoverableIcon from '@features/layers/hovercard/HoverableIcon';
+import PopupCard from '@features/layers/popupcard/PopupCard';
 import ZIndex from '@features/layers/ZIndex';
+import ColorBySelector from '@features/transforms/coloring/ColorBySelector';
+import ColorGradientSelector from '@features/transforms/coloring/ColorGradientSelector';
+import ScaleBySelector from '@features/transforms/scales/ScaleBySelector';
 
 type Props = {
   zoomIn: () => void;
@@ -23,6 +27,20 @@ const ZoomControls: React.FC<Props> = ({
       <HoverableIcon onClick={zoomIn} description="Zoom in" Icon={ZoomInIcon} />
       <HoverableIcon onClick={zoomOut} description="Zoom out" Icon={ZoomOutIcon} />
       <HoverableIcon onClick={resetTransform} description="Reset" Icon={Maximize2Icon} />
+      <PopupCard
+        buttonLabel={<Settings2 style={{ display: 'block' }} />}
+        buttonStyle={{ padding: '0.5em' }}
+        description="Map Display Options"
+        body={
+          <div
+            style={{ display: 'flex', flexDirection: 'column', gap: '0.5em', width: 'max-content' }}
+          >
+            <ColorBySelector />
+            <ColorGradientSelector />
+            <ScaleBySelector />
+          </div>
+        }
+      />
     </div>
   );
 };

--- a/src/features/map/map.css
+++ b/src/features/map/map.css
@@ -67,19 +67,23 @@
 @keyframes growThenShow {
   0% {
     max-height: 0;
-    display: none;
+    padding: 0;
+    opacity: 0;
+    visibility: hidden;
   }
 
   1% {
     max-height: 1%;
-    /* Keep it displayed right until the absolute last millisecond */
-    display: flex;
+    padding: 1em 0.5em 0.5em 0.5em;
+    opacity: 0;
+    visibility: visible;
   }
 
   100% {
-    /* Instantly yank the element out of the layout flow completely */
-    max-height: 100%;
-    display: flex;
+    max-height: 100vh;
+    padding: 1em 0.5em 0.5em 0.5em;
+    opacity: 1;
+    visibility: visible;
   }
 }
 
@@ -89,20 +93,24 @@
 
 @keyframes shrinkThenHide {
   0% {
-    max-height: 100%;
-    display: flex;
+    max-height: 100vh;
+    padding: 1em 0.5em 0.5em 0.5em;
+    opacity: 1;
+    visibility: visible;
   }
 
   99% {
     max-height: 0;
-    /* Keep it displayed right until the absolute last millisecond */
-    display: flex;
+    padding: 0;
+    opacity: 0;
+    visibility: visible;
   }
 
   100% {
-    /* Instantly yank the element out of the layout flow completely */
-    display: none;
     max-height: 0;
+    padding: 0;
+    opacity: 0;
+    visibility: hidden;
   }
 }
 

--- a/src/features/transforms/coloring/ColorGradientSelector.tsx
+++ b/src/features/transforms/coloring/ColorGradientSelector.tsx
@@ -24,7 +24,7 @@ const ColorGradientSelector: React.FC = () => {
 
   return (
     <Selector<ColorGradient>
-      selectorLabel={display === SelectorDisplay.Dropdown ? 'Color gradient' : undefined}
+      selectorLabel={display === SelectorDisplay.Dropdown ? 'Color Gradient' : undefined}
       selectorDescription="Choose the range of colors used to represent values."
       options={Object.values(ColorGradient).filter((cg) => typeof cg === 'number')}
       onChange={(colorGradient) => updatePageParams({ colorGradient })}

--- a/src/widgets/controls/Settings.tsx
+++ b/src/widgets/controls/Settings.tsx
@@ -7,7 +7,6 @@ import LimitInput from '@features/pagination/LimitInput';
 import ColorBySelector from '@features/transforms/coloring/ColorBySelector';
 import ColorGradientSelector from '@features/transforms/coloring/ColorGradientSelector';
 import FieldFocusSelector from '@features/transforms/fields/FieldFocusSelector';
-import ScaleBySelector from '@features/transforms/scales/ScaleBySelector';
 import SearchBySelector from '@features/transforms/search/SearchBySelector';
 
 import ClearAllPinsButton from './selectors/ClearAllPinsButton';
@@ -27,7 +26,6 @@ const Settings = (): React.ReactNode => {
           <LimitInput />
           <ColorBySelector />
           <ColorGradientSelector />
-          <ScaleBySelector />
           <FieldFocusSelector />
           <PopulationFocusSelector />
           <LocaleSeparatorSelector />


### PR DESCRIPTION
Fixes #680 

Summary: Moved the map color/scale controls from global settings to a dedicated on map popup button to make them more discoverable. Also fixed two edge case visual bugs related to sidebar visibility and animations.

### Changes

- User experience
  - Added a popup button in the map zoom controls cluster.
  - Moved ColorBy, ColorGradient, and ScaleBy map settings from the global settings panel into this new map control popup.
  - Sidebar now cleanly disappears when 0 languages are pinned.
  - Fixed an empty gray padding artifact that was left behind when manually collapsing the selected languages list.
- Logical changes
  - ZoomControls: Integrated ColorBySelector, ColorGradientSelector, and ScaleBySelector into the map controls by wrapping them in a PopupCard component.
  - Settings: Removed ScaleBySelector from the global settings panel, since scaling map points is exclusively a map-specific feature. (ColorBy and ColorGradient were kept here as they also apply to cards).
  - MapSidebar: Added  (if (pinnedEntities.length === 0) return null;) to prevent the sidebar container from rendering at all when the selection is empty.
- Refactors
  - map.css: Overhauled the growThenShow and shrinkThenHide keyframes. Transitioned away from trying to animate display (which caused the visual artifacts), and instead animated padding, opacity, and visibility to ensure the sidebar hides completely cleanly.)

### Screenshots
#### Before - Shows the gray artifact left behind when there are no pinned entities.
<img width="1602" height="1065" alt="image" src="https://github.com/user-attachments/assets/b50d517b-c377-4e90-8720-b8837f5a900c" />

#### After Image - Added PopUp Map Options Button; Also the gray artifact is fixed.
<img width="1602" height="1065" alt="image" src="https://github.com/user-attachments/assets/d1afcbee-c624-4f8a-9290-4463834bd0da" />

#### Before - Showing the padding bug
<img width="1602" height="1065" alt="image" src="https://github.com/user-attachments/assets/53fd03ca-a8c9-4d3a-8a37-c9f38ba5cfbd" />

#### After Image - Fixed padding bug.
<img width="1602" height="1065" alt="image" src="https://github.com/user-attachments/assets/fd42e72e-5ee6-4e6d-9291-011dd3b203da" />